### PR TITLE
#55 Round integer fields in WebSocket broadcast

### DIFF
--- a/internal/ws/broadcaster_test.go
+++ b/internal/ws/broadcaster_test.go
@@ -740,7 +740,8 @@ func TestDeriveVehicleStatus(t *testing.T) {
 		{"gear D speed 0", map[string]any{"gearPosition": "D", "speed": 0.0}, "driving"},
 		{"gear R speed 0", map[string]any{"gearPosition": "R", "speed": 0.0}, "driving"},
 		{"gear P speed 0", map[string]any{"gearPosition": "P", "speed": 0.0}, "parked"},
-		{"no gear speed 65", map[string]any{"speed": 65.0}, "driving"},
+		{"no gear speed 65 float", map[string]any{"speed": 65.0}, "driving"},
+		{"no gear speed 65 int", map[string]any{"speed": 65}, "driving"},
 		{"gear N speed 0", map[string]any{"gearPosition": "N", "speed": 0.0}, "parked"},
 		{"empty fields", map[string]any{}, "parked"},
 	}

--- a/internal/ws/field_mapping.go
+++ b/internal/ws/field_mapping.go
@@ -84,7 +84,14 @@ func translateFieldName(internal string) string {
 // The frontend reads vehicle.status to decide which UI to render.
 func deriveVehicleStatus(fields map[string]any) string {
 	gear, _ := fields["gearPosition"].(string)
-	speed, _ := fields["speed"].(float64)
+
+	var speed float64
+	switch v := fields["speed"].(type) {
+	case float64:
+		speed = v
+	case int:
+		speed = float64(v)
+	}
 
 	switch {
 	case gear == "D" || gear == "R" || speed > 0:


### PR DESCRIPTION
Speed, ETA, temperatures etc. were sent as floats (67.11 mph, 28.87 min). The frontend Vehicle model types these as integers.

Adds `roundIfInteger` step in `mapFieldsForClient` that rounds float64 values for known integer-semantic fields before JSON serialization.

Closes #55