### PR TITLE
#52 Stream route coordinates in vehicle_update for live polyline

### DIFF
--- a/internal/ws/broadcaster.go
+++ b/internal/ws/broadcaster.go
@@ -2,7 +2,6 @@ package ws
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"log/slog"
 	"time"
@@ -19,6 +18,7 @@ type Broadcaster struct {
 	resolver VINResolver
 	logger   *slog.Logger
 	subs     []events.Subscription
+	routes   *routeTracker
 }
 
 // NewBroadcaster creates a Broadcaster ready to start. Call Start to begin
@@ -29,6 +29,7 @@ func NewBroadcaster(hub *Hub, bus events.Bus, resolver VINResolver, logger *slog
 		bus:      bus,
 		resolver: resolver,
 		logger:   logger,
+		routes:   newRouteTracker(),
 	}
 }
 
@@ -118,7 +119,12 @@ func (b *Broadcaster) handleTelemetry(ctx context.Context, event events.Event) {
 
 	// Derive vehicle status from gear and speed. This is a synthetic field
 	// (not from Tesla telemetry) — it drives the frontend's driving/parked UI.
-	fields["status"] = deriveVehicleStatus(fields)
+	status := deriveVehicleStatus(fields)
+	fields["status"] = status
+
+	// Accumulate route coordinates while driving so the frontend can render
+	// a live polyline. When the vehicle parks, clear the accumulated route.
+	b.applyRouteState(vehicleID, status, fields)
 
 	msg, err := marshalWSMessage(msgTypeVehicleUpdate, vehicleUpdatePayload{
 		VehicleID: vehicleID,
@@ -196,6 +202,8 @@ func (b *Broadcaster) handleDriveEnded(ctx context.Context, event events.Event) 
 		return
 	}
 
+	b.routes.clear(vehicleID)
+
 	msg, err := marshalWSMessage(msgTypeDriveEnded, driveEndedPayload{
 		VehicleID: vehicleID,
 		DriveID:   payload.DriveID,
@@ -236,6 +244,10 @@ func (b *Broadcaster) handleConnectivity(ctx context.Context, event events.Event
 		return
 	}
 
+	if payload.Status == events.StatusDisconnected {
+		b.routes.clear(vehicleID)
+	}
+
 	msg, err := marshalWSMessage(msgTypeConnectivity, connectivityPayload{
 		VehicleID: vehicleID,
 		Online:    payload.Status == events.StatusConnected,
@@ -252,6 +264,23 @@ func (b *Broadcaster) handleConnectivity(ctx context.Context, event events.Event
 	b.hub.Broadcast(vehicleID, msg)
 }
 
+// applyRouteState appends the current position to the route tracker when the
+// vehicle is driving and injects the accumulated coordinates into fields. When
+// the vehicle is parked (drive ended), the route is cleared.
+func (b *Broadcaster) applyRouteState(vehicleID, status string, fields map[string]any) {
+	if status == "driving" {
+		lng, lngOK := fields["longitude"].(float64)
+		lat, latOK := fields["latitude"].(float64)
+		if lngOK && latOK {
+			fields["routeCoordinates"] = b.routes.append(vehicleID, lng, lat)
+		}
+		return
+	}
+
+	// Vehicle is not driving — clear any accumulated route.
+	b.routes.clear(vehicleID)
+}
+
 // unsubscribeAll removes all active subscriptions from the bus.
 func (b *Broadcaster) unsubscribeAll() {
 	for _, sub := range b.subs {
@@ -263,21 +292,4 @@ func (b *Broadcaster) unsubscribeAll() {
 		}
 	}
 	b.subs = nil
-}
-
-// marshalWSMessage creates a JSON-encoded WebSocket message envelope.
-func marshalWSMessage(msgType string, payload any) ([]byte, error) {
-	payloadBytes, err := json.Marshal(payload)
-	if err != nil {
-		return nil, fmt.Errorf("marshalWSMessage(%s): marshal payload: %w", msgType, err)
-	}
-
-	msg, err := json.Marshal(wsMessage{
-		Type:    msgType,
-		Payload: payloadBytes,
-	})
-	if err != nil {
-		return nil, fmt.Errorf("marshalWSMessage(%s): marshal envelope: %w", msgType, err)
-	}
-	return msg, nil
 }

--- a/internal/ws/broadcaster_test.go
+++ b/internal/ws/broadcaster_test.go
@@ -832,6 +832,241 @@ func assertInt(t *testing.T, m map[string]any, key string, want int) {
 	}
 }
 
+func TestApplyRouteState_DrivingWithLocation(t *testing.T) {
+	b := NewBroadcaster(nil, nil, nil, slog.Default())
+
+	fields := map[string]any{
+		"longitude": -122.4194,
+		"latitude":  37.7749,
+	}
+	b.applyRouteState("v-1", "driving", fields)
+
+	coords, ok := fields["routeCoordinates"].([][]float64)
+	if !ok {
+		t.Fatalf("expected routeCoordinates to be [][]float64, got %T", fields["routeCoordinates"])
+	}
+	if len(coords) != 1 {
+		t.Fatalf("expected 1 coordinate, got %d", len(coords))
+	}
+	if coords[0][0] != -122.4194 || coords[0][1] != 37.7749 {
+		t.Fatalf("expected [-122.4194, 37.7749], got %v", coords[0])
+	}
+}
+
+func TestApplyRouteState_DrivingWithoutLocation(t *testing.T) {
+	b := NewBroadcaster(nil, nil, nil, slog.Default())
+
+	fields := map[string]any{
+		"speed": 65,
+	}
+	b.applyRouteState("v-1", "driving", fields)
+
+	if _, ok := fields["routeCoordinates"]; ok {
+		t.Fatal("routeCoordinates should not be set when lat/lng are missing")
+	}
+}
+
+func TestApplyRouteState_DrivingAccumulatesRoute(t *testing.T) {
+	b := NewBroadcaster(nil, nil, nil, slog.Default())
+
+	points := [][2]float64{
+		{-122.4194, 37.7749},
+		{-122.4180, 37.7760},
+		{-122.4170, 37.7770},
+	}
+
+	for i, pt := range points {
+		fields := map[string]any{
+			"longitude": pt[0],
+			"latitude":  pt[1],
+		}
+		b.applyRouteState("v-1", "driving", fields)
+
+		coords, ok := fields["routeCoordinates"].([][]float64)
+		if !ok {
+			t.Fatalf("iteration %d: expected [][]float64, got %T", i, fields["routeCoordinates"])
+		}
+		if len(coords) != i+1 {
+			t.Fatalf("iteration %d: expected %d coordinates, got %d", i, i+1, len(coords))
+		}
+	}
+}
+
+func TestApplyRouteState_ParkedClearsRoute(t *testing.T) {
+	b := NewBroadcaster(nil, nil, nil, slog.Default())
+
+	// Build up a route.
+	fields := map[string]any{"longitude": -122.4194, "latitude": 37.7749}
+	b.applyRouteState("v-1", "driving", fields)
+	fields = map[string]any{"longitude": -122.4180, "latitude": 37.7760}
+	b.applyRouteState("v-1", "driving", fields)
+
+	// Vehicle parks.
+	parkedFields := map[string]any{"speed": 0}
+	b.applyRouteState("v-1", "parked", parkedFields)
+
+	if _, ok := parkedFields["routeCoordinates"]; ok {
+		t.Fatal("routeCoordinates should not be in parked fields")
+	}
+
+	// Verify route state was cleared.
+	if coords := b.routes.get("v-1"); coords != nil {
+		t.Fatalf("route should be cleared after parking, got %d coordinates", len(coords))
+	}
+}
+
+func TestApplyRouteState_IsolatesVehicles(t *testing.T) {
+	b := NewBroadcaster(nil, nil, nil, slog.Default())
+
+	f1 := map[string]any{"longitude": -122.4194, "latitude": 37.7749}
+	b.applyRouteState("v-1", "driving", f1)
+
+	f2 := map[string]any{"longitude": -73.9857, "latitude": 40.7484}
+	b.applyRouteState("v-2", "driving", f2)
+
+	coords1, _ := f1["routeCoordinates"].([][]float64)
+	coords2, _ := f2["routeCoordinates"].([][]float64)
+
+	if len(coords1) != 1 || len(coords2) != 1 {
+		t.Fatalf("expected 1 coordinate each, got v-1=%d v-2=%d", len(coords1), len(coords2))
+	}
+	if coords1[0][0] != -122.4194 {
+		t.Fatalf("v-1 lng: expected -122.4194, got %v", coords1[0][0])
+	}
+	if coords2[0][0] != -73.9857 {
+		t.Fatalf("v-2 lng: expected -73.9857, got %v", coords2[0][0])
+	}
+}
+
+func TestBroadcaster_DriveEndedClearsRoute(t *testing.T) {
+	bus := events.NewChannelBus(events.DefaultBusConfig(), events.NoopBusMetrics{}, slog.Default())
+	t.Cleanup(func() { _ = bus.Close(context.Background()) })
+
+	resolver := newStubVINResolver(map[string]string{
+		"5YJ3E1EA1NF000001": "vehicle-id-1",
+	})
+
+	hub := NewHub(slog.Default(), NoopHubMetrics{})
+	t.Cleanup(hub.Stop)
+
+	b := NewBroadcaster(hub, bus, resolver, slog.Default())
+	ctx := context.Background()
+	if err := b.Start(ctx); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	t.Cleanup(func() { _ = b.Stop() })
+
+	// Pre-populate route state as if the vehicle was driving.
+	b.routes.append("vehicle-id-1", -122.4194, 37.7749)
+	b.routes.append("vehicle-id-1", -122.4180, 37.7760)
+
+	// Publish drive_ended event.
+	now := time.Date(2026, 3, 18, 12, 30, 0, 0, time.UTC)
+	event := events.NewEvent(events.DriveEndedEvent{
+		VIN:     "5YJ3E1EA1NF000001",
+		DriveID: "drive-abc",
+		Stats: events.DriveStats{
+			Distance: 15.3,
+			Duration: 25 * time.Minute,
+			AvgSpeed: 36.7,
+			MaxSpeed: 65.0,
+		},
+		EndedAt: now,
+	})
+
+	if err := bus.Publish(ctx, event); err != nil {
+		t.Fatalf("Publish: %v", err)
+	}
+
+	waitForCondition(t, func() bool {
+		return b.routes.get("vehicle-id-1") == nil
+	})
+}
+
+func TestBroadcaster_DisconnectClearsRoute(t *testing.T) {
+	bus := events.NewChannelBus(events.DefaultBusConfig(), events.NoopBusMetrics{}, slog.Default())
+	t.Cleanup(func() { _ = bus.Close(context.Background()) })
+
+	resolver := newStubVINResolver(map[string]string{
+		"5YJ3E1EA1NF000001": "vehicle-id-1",
+	})
+
+	hub := NewHub(slog.Default(), NoopHubMetrics{})
+	t.Cleanup(hub.Stop)
+
+	b := NewBroadcaster(hub, bus, resolver, slog.Default())
+	ctx := context.Background()
+	if err := b.Start(ctx); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	t.Cleanup(func() { _ = b.Stop() })
+
+	// Pre-populate route state.
+	b.routes.append("vehicle-id-1", -122.4194, 37.7749)
+
+	// Publish disconnect event.
+	now := time.Date(2026, 3, 18, 12, 0, 0, 0, time.UTC)
+	event := events.NewEvent(events.ConnectivityEvent{
+		VIN:       "5YJ3E1EA1NF000001",
+		Status:    events.StatusDisconnected,
+		Timestamp: now,
+	})
+
+	if err := bus.Publish(ctx, event); err != nil {
+		t.Fatalf("Publish: %v", err)
+	}
+
+	waitForCondition(t, func() bool {
+		return b.routes.get("vehicle-id-1") == nil
+	})
+}
+
+func TestBroadcaster_ConnectDoesNotClearRoute(t *testing.T) {
+	bus := events.NewChannelBus(events.DefaultBusConfig(), events.NoopBusMetrics{}, slog.Default())
+	t.Cleanup(func() { _ = bus.Close(context.Background()) })
+
+	resolver := newStubVINResolver(map[string]string{
+		"5YJ3E1EA1NF000001": "vehicle-id-1",
+	})
+
+	hub := NewHub(slog.Default(), NoopHubMetrics{})
+	t.Cleanup(hub.Stop)
+
+	b := NewBroadcaster(hub, bus, resolver, slog.Default())
+	ctx := context.Background()
+	if err := b.Start(ctx); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	t.Cleanup(func() { _ = b.Stop() })
+
+	// Pre-populate route state.
+	b.routes.append("vehicle-id-1", -122.4194, 37.7749)
+
+	// Publish connect event (not disconnect).
+	now := time.Date(2026, 3, 18, 12, 0, 0, 0, time.UTC)
+	event := events.NewEvent(events.ConnectivityEvent{
+		VIN:       "5YJ3E1EA1NF000001",
+		Status:    events.StatusConnected,
+		Timestamp: now,
+	})
+
+	if err := bus.Publish(ctx, event); err != nil {
+		t.Fatalf("Publish: %v", err)
+	}
+
+	// Wait for the event to be processed.
+	waitForCondition(t, func() bool {
+		resolver.mu.RLock()
+		defer resolver.mu.RUnlock()
+		return len(resolver.callLog) > 0
+	})
+
+	// Route should still be present.
+	if coords := b.routes.get("vehicle-id-1"); len(coords) != 1 {
+		t.Fatalf("expected route to be preserved on connect, got %d coordinates", len(coords))
+	}
+}
+
 // waitForCondition polls until fn returns true or times out.
 func waitForCondition(t *testing.T, fn func() bool) {
 	t.Helper()

--- a/internal/ws/messages.go
+++ b/internal/ws/messages.go
@@ -3,7 +3,10 @@
 // telemetry updates to authorized users.
 package ws
 
-import "encoding/json"
+import (
+	"encoding/json"
+	"fmt"
+)
 
 // Message type constants matching the frontend protocol.
 const (
@@ -82,3 +85,20 @@ const (
 	errCodeAuthFailed  = "auth_failed"
 	errCodeAuthTimeout = "auth_timeout"
 )
+
+// marshalWSMessage creates a JSON-encoded WebSocket message envelope.
+func marshalWSMessage(msgType string, payload any) ([]byte, error) {
+	payloadBytes, err := json.Marshal(payload)
+	if err != nil {
+		return nil, fmt.Errorf("marshalWSMessage(%s): marshal payload: %w", msgType, err)
+	}
+
+	msg, err := json.Marshal(wsMessage{
+		Type:    msgType,
+		Payload: payloadBytes,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("marshalWSMessage(%s): marshal envelope: %w", msgType, err)
+	}
+	return msg, nil
+}

--- a/internal/ws/route_tracker.go
+++ b/internal/ws/route_tracker.go
@@ -1,0 +1,61 @@
+package ws
+
+import "sync"
+
+// routeTracker accumulates route coordinates for vehicles that are currently
+// driving. Each coordinate is a [longitude, latitude] pair following the
+// Mapbox/GeoJSON convention. The tracker is safe for concurrent use.
+type routeTracker struct {
+	mu     sync.Mutex
+	routes map[string][][2]float64
+}
+
+func newRouteTracker() *routeTracker {
+	return &routeTracker{
+		routes: make(map[string][][2]float64),
+	}
+}
+
+// append adds a coordinate to the vehicle's route and returns the full
+// accumulated route. The caller must ensure lng and lat are valid before
+// calling append.
+func (rt *routeTracker) append(vehicleID string, lng, lat float64) [][]float64 {
+	rt.mu.Lock()
+	defer rt.mu.Unlock()
+
+	rt.routes[vehicleID] = append(rt.routes[vehicleID], [2]float64{lng, lat})
+	return rt.snapshot(vehicleID)
+}
+
+// clear removes all accumulated route data for a vehicle. This should be
+// called when a drive ends or a vehicle disconnects.
+func (rt *routeTracker) clear(vehicleID string) {
+	rt.mu.Lock()
+	defer rt.mu.Unlock()
+
+	delete(rt.routes, vehicleID)
+}
+
+// get returns a copy of the current route for a vehicle, or nil if no
+// route data exists.
+func (rt *routeTracker) get(vehicleID string) [][]float64 {
+	rt.mu.Lock()
+	defer rt.mu.Unlock()
+
+	return rt.snapshot(vehicleID)
+}
+
+// snapshot returns a deep copy of the route for serialization. Must be
+// called with rt.mu held.
+func (rt *routeTracker) snapshot(vehicleID string) [][]float64 {
+	coords := rt.routes[vehicleID]
+	if len(coords) == 0 {
+		return nil
+	}
+
+	out := make([][]float64, len(coords))
+	for i, c := range coords {
+		out[i] = []float64{c[0], c[1]}
+	}
+	return out
+}

--- a/internal/ws/route_tracker_test.go
+++ b/internal/ws/route_tracker_test.go
@@ -1,0 +1,146 @@
+package ws
+
+import (
+	"sync"
+	"testing"
+)
+
+func TestRouteTracker_Append(t *testing.T) {
+	rt := newRouteTracker()
+
+	coords := rt.append("v-1", -122.4194, 37.7749)
+
+	if len(coords) != 1 {
+		t.Fatalf("expected 1 coordinate, got %d", len(coords))
+	}
+	if coords[0][0] != -122.4194 || coords[0][1] != 37.7749 {
+		t.Fatalf("expected [-122.4194, 37.7749], got %v", coords[0])
+	}
+}
+
+func TestRouteTracker_Append_AccumulatesPoints(t *testing.T) {
+	rt := newRouteTracker()
+
+	rt.append("v-1", -122.4194, 37.7749)
+	rt.append("v-1", -122.4180, 37.7760)
+	coords := rt.append("v-1", -122.4170, 37.7770)
+
+	if len(coords) != 3 {
+		t.Fatalf("expected 3 coordinates, got %d", len(coords))
+	}
+	// Verify order is preserved.
+	if coords[0][0] != -122.4194 {
+		t.Fatalf("first point lng: expected -122.4194, got %v", coords[0][0])
+	}
+	if coords[2][0] != -122.4170 {
+		t.Fatalf("third point lng: expected -122.4170, got %v", coords[2][0])
+	}
+}
+
+func TestRouteTracker_Append_IsolatesVehicles(t *testing.T) {
+	rt := newRouteTracker()
+
+	rt.append("v-1", -122.4194, 37.7749)
+	rt.append("v-1", -122.4180, 37.7760)
+	rt.append("v-2", -73.9857, 40.7484)
+
+	v1 := rt.get("v-1")
+	v2 := rt.get("v-2")
+
+	if len(v1) != 2 {
+		t.Fatalf("v-1: expected 2 coordinates, got %d", len(v1))
+	}
+	if len(v2) != 1 {
+		t.Fatalf("v-2: expected 1 coordinate, got %d", len(v2))
+	}
+}
+
+func TestRouteTracker_Clear(t *testing.T) {
+	rt := newRouteTracker()
+
+	rt.append("v-1", -122.4194, 37.7749)
+	rt.append("v-1", -122.4180, 37.7760)
+	rt.clear("v-1")
+
+	coords := rt.get("v-1")
+	if coords != nil {
+		t.Fatalf("expected nil after clear, got %v", coords)
+	}
+}
+
+func TestRouteTracker_Clear_DoesNotAffectOtherVehicles(t *testing.T) {
+	rt := newRouteTracker()
+
+	rt.append("v-1", -122.4194, 37.7749)
+	rt.append("v-2", -73.9857, 40.7484)
+	rt.clear("v-1")
+
+	if coords := rt.get("v-2"); len(coords) != 1 {
+		t.Fatalf("v-2 should be unaffected, got %d coordinates", len(coords))
+	}
+}
+
+func TestRouteTracker_Clear_NonexistentVehicle(t *testing.T) {
+	rt := newRouteTracker()
+	// Should not panic.
+	rt.clear("nonexistent")
+}
+
+func TestRouteTracker_Get_Empty(t *testing.T) {
+	rt := newRouteTracker()
+
+	coords := rt.get("v-1")
+	if coords != nil {
+		t.Fatalf("expected nil for unknown vehicle, got %v", coords)
+	}
+}
+
+func TestRouteTracker_Snapshot_IsDeepCopy(t *testing.T) {
+	rt := newRouteTracker()
+
+	rt.append("v-1", -122.4194, 37.7749)
+	coords := rt.get("v-1")
+
+	// Mutate the returned slice — should not affect the tracker.
+	coords[0][0] = 999.0
+
+	fresh := rt.get("v-1")
+	if fresh[0][0] != -122.4194 {
+		t.Fatalf("snapshot was not a deep copy: got lng=%v", fresh[0][0])
+	}
+}
+
+func TestRouteTracker_ConcurrentAccess(t *testing.T) {
+	rt := newRouteTracker()
+	var wg sync.WaitGroup
+
+	// Concurrent appends from multiple goroutines.
+	for i := range 100 {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			rt.append("v-1", float64(i), float64(i))
+		}(i)
+	}
+
+	// Concurrent clears.
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for range 10 {
+			rt.clear("v-1")
+		}
+	}()
+
+	// Concurrent reads.
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for range 100 {
+			rt.get("v-1")
+		}
+	}()
+
+	wg.Wait()
+	// If we get here without a race detector complaint, the test passes.
+}


### PR DESCRIPTION
The WebSocket broadcaster now accumulates route coordinates per vehicle during active drives and includes them in every `vehicle_update` message as `routeCoordinates: [[lng, lat], ...]`.

## How it works
- When status is "driving" and lat/lng are present: append `[lng, lat]` to the route tracker, inject `routeCoordinates` into the fields map
- When status is "parked", drive ends, or vehicle disconnects: clear the route state
- Coordinates use Mapbox convention `[longitude, latitude]`
- Full accumulated route sent each tick (~28 KB for a 30-min drive at 1 tick/sec)

## Files
| File | Lines | Purpose |
|------|-------|---------|
| `route_tracker.go` | 55 | Thread-safe per-vehicle route accumulator |
| `broadcaster.go` | 295 | Added `applyRouteState`, route clearing on drive end/disconnect |
| `route_tracker_test.go` | 9 tests | Append, accumulate, clear, deep-copy, concurrency |
| `broadcaster_test.go` | 8 new tests | applyRouteState, drive_ended clearing, disconnect clearing |

## Frontend usage
The frontend `VehicleMap` already accepts `routeCoordinates` as `Array<[number, number]>`. The `useVehicleStream` hook merges fields into Vehicle state. The frontend just needs to read `vehicle.routeCoordinates` from the live state and pass it to `VehicleMap`.

Closes #52