### PR TITLE
Remove /readyz health check from fly.toml

### DIFF
--- a/fly.toml
+++ b/fly.toml
@@ -55,12 +55,8 @@ primary_region = 'iad'
     method = 'GET'
     path = '/healthz'
 
-  [[http_service.checks]]
-    interval = '10s'
-    timeout = '5s'
-    grace_period = '15s'
-    method = 'GET'
-    path = '/readyz'
+  # /readyz is served on the metrics port (9090), not the client port (8080).
+  # Fly health checks only reach internal_port, so /healthz is sufficient here.
 
 # VM sizing — 512MB to handle mTLS + WebSocket + PostgreSQL connections.
 [[vm]]


### PR DESCRIPTION
## Summary

The `/readyz` endpoint is registered on the **metrics server** (port 9090), not the client server (port 8080). Fly's health check targets `internal_port` 8080 and gets a 404, causing a critical check failure that prevents the machine from being marked healthy.

**Fix:** Remove the `/readyz` check. `/healthz` on port 8080 is sufficient for Fly's liveness/routing.

## Test plan
- [ ] Deploy — machine shows 2/2 checks passing (healthz + TCP)
- [ ] `curl https://my-robo-taxi-telemetry.fly.dev/healthz` returns 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)