### PR TITLE
Disable prepared statement cache for Supabase transaction pooler

### DIFF
--- a/configs/fly.json
+++ b/configs/fly.json
@@ -12,7 +12,8 @@
   },
   "database": {
     "max_conns": 10,
-    "min_conns": 2
+    "min_conns": 2,
+    "disable_prepared_statements": true
   },
   "telemetry": {
     "max_vehicles": 100,

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -37,9 +37,10 @@ type TLSConfig struct {
 
 // DatabaseConfig holds connection pool parameters and the connection URL.
 type DatabaseConfig struct {
-	URL      string
-	MaxConns int
-	MinConns int
+	URL                       string
+	MaxConns                  int
+	MinConns                  int
+	DisablePreparedStatements bool // Set true for PgBouncer transaction pooling (Supabase port 6543)
 }
 
 // TelemetryConfig holds tuning parameters for the telemetry receiver.

--- a/internal/config/load.go
+++ b/internal/config/load.go
@@ -39,8 +39,9 @@ type fileTLSConfig struct {
 }
 
 type fileDatabaseConfig struct {
-	MaxConns int `json:"max_conns"`
-	MinConns int `json:"min_conns"`
+	MaxConns                  int  `json:"max_conns"`
+	MinConns                  int  `json:"min_conns"`
+	DisablePreparedStatements bool `json:"disable_prepared_statements"`
 }
 
 type fileTelemetryConfig struct {
@@ -121,6 +122,11 @@ func applyEnvOverrides(fc *fileConfig) error {
 	fc.teslaPublicKey = os.Getenv("TESLA_PUBLIC_KEY")   // optional
 	fc.fleetTelemetryCA = os.Getenv("FLEET_TELEMETRY_CA") // optional: PEM CA cert
 
+	// Database env var overrides.
+	if v := os.Getenv("DATABASE_DISABLE_PREPARED_STATEMENTS"); v == "true" || v == "1" {
+		fc.Database.DisablePreparedStatements = true
+	}
+
 	// Proxy env var overrides.
 	if v := os.Getenv("TESLA_PROXY_URL"); v != "" {
 		fc.Proxy.URL = v
@@ -157,9 +163,10 @@ func buildConfig(fc *fileConfig) *Config {
 			CAFile:   fc.TLS.CAFile,
 		},
 		database: DatabaseConfig{
-			URL:      fc.databaseURL,
-			MaxConns: fc.Database.MaxConns,
-			MinConns: fc.Database.MinConns,
+			URL:                       fc.databaseURL,
+			MaxConns:                  fc.Database.MaxConns,
+			MinConns:                  fc.Database.MinConns,
+			DisablePreparedStatements: fc.Database.DisablePreparedStatements,
 		},
 		telemetry: TelemetryConfig{
 			MaxVehicles:        fc.Telemetry.MaxVehicles,

--- a/internal/store/db.go
+++ b/internal/store/db.go
@@ -9,6 +9,7 @@ import (
 	"log/slog"
 	"math"
 
+	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
 
 	"github.com/tnando/my-robo-taxi-telemetry/internal/config"
@@ -36,6 +37,13 @@ func NewDB(ctx context.Context, cfg config.DatabaseConfig, logger *slog.Logger, 
 		poolCfg.MinConns = int32(cfg.MinConns) // #nosec G115 -- bounds checked above
 	}
 
+	// Disable prepared statement caching for PgBouncer transaction pooling
+	// (Supabase port 6543). Prepared statements are per-connection state that
+	// PgBouncer does not track when rotating connections between queries.
+	if cfg.DisablePreparedStatements {
+		poolCfg.ConnConfig.DefaultQueryExecMode = pgx.QueryExecModeSimpleProtocol
+	}
+
 	pool, err := pgxpool.NewWithConfig(ctx, poolCfg)
 	if err != nil {
 		return nil, fmt.Errorf("store.NewDB: create pool: %w", err)
@@ -49,6 +57,7 @@ func NewDB(ctx context.Context, cfg config.DatabaseConfig, logger *slog.Logger, 
 	logger.Info("database connection established",
 		slog.Int("max_conns", int(poolCfg.MaxConns)),
 		slog.Int("min_conns", int(poolCfg.MinConns)),
+		slog.Bool("simple_protocol", cfg.DisablePreparedStatements),
 	)
 
 	return &DB{


### PR DESCRIPTION
## Summary

Closes #94 — pgx's prepared statement cache breaks with Supabase's transaction pooler (PgBouncer). Prepared statements are per-connection state, but PgBouncer rotates connections between queries in transaction mode.

**Fix:** Use `QueryExecModeSimpleProtocol` when `DisablePreparedStatements` is true. This is the standard fix recommended by both pgx and Supabase documentation.

### Changes
- `DatabaseConfig.DisablePreparedStatements` — new configurable flag
- `db.go` — applies `QueryExecModeSimpleProtocol` when flag is set
- `fly.json` — enabled by default for production
- Env var override: `DATABASE_DISABLE_PREPARED_STATEMENTS=true`
- Log line includes `simple_protocol` field for operator visibility

### No query changes needed
Existing `::type` casts work with simple protocol. All parameter types (string, float64, int, time.Time, json.RawMessage) have well-defined text representations.

## Test plan
- [x] All tests pass
- [ ] Deploy → broadcaster resolves VIN successfully (no prepared statement errors)
- [ ] Telemetry events flow through to WebSocket clients

🤖 Generated with [Claude Code](https://claude.com/claude-code)