### PR TITLE
Auto-deploy to Fly.io on merge to main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -189,14 +189,15 @@ jobs:
   deploy:
     name: Deploy
     runs-on: ubuntu-latest
+    environment: production
     timeout-minutes: 15
-    needs: [build]
+    needs: [build, security]
     # Only deploy on push to main (not PRs).
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     steps:
       - uses: actions/checkout@v6
 
-      - uses: superfly/flyctl-action/setup-flyctl@master
+      - uses: superfly/flyctl-action/setup-flyctl@v2
 
       - name: Deploy to Fly.io
         run: flyctl deploy --remote-only


### PR DESCRIPTION
## Summary

Closes #96 — Every merge to main now auto-deploys to Fly.io. No more manual `flyctl deploy`.

### How it works
- New `deploy` job in CI, runs after `build` passes
- Only triggers on push to main (skipped on PRs)
- Uses `superfly/flyctl-action` with `FLY_API_TOKEN` secret (already set)
- `--remote-only` builds on Fly's remote builders

### Flow
```
PR merged → CI: lint + test + security + build → deploy to Fly.io
```

## Test plan
- [ ] Merge this PR → verify deploy job runs and succeeds
- [ ] Verify app is healthy after auto-deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)