### PR TITLE
Fix mTLS: remove TCP health check + dedicated IPv4

### DIFF
--- a/fly.toml
+++ b/fly.toml
@@ -28,10 +28,9 @@ primary_region = 'iad'
   [[services.ports]]
     port = 8443
 
-  [[services.tcp_checks]]
-    interval = '15s'
-    timeout = '5s'
-    grace_period = '10s'
+  # No health checks on the mTLS port. Fly's TCP health check opens a raw
+  # socket (no TLS ClientHello), which the TLS listener rejects as EOF.
+  # Machine health is determined by the HTTP /healthz check on the client port.
 
 # Client WebSocket — standard HTTPS with Fly's automatic TLS.
 # Browser clients connect here for real-time telemetry.


### PR DESCRIPTION
## Summary

Closes #104

Fixes the Tesla mTLS WebSocket connection that has been broken for days. Vehicle telemetry fields (BatteryLevel, VehicleSpeed, Location, etc.) were not flowing because the vehicle couldn't establish a direct mTLS connection.

### Changes

1. **Remove TCP health check from mTLS port** — Fly's TCP health check opens a raw socket every 15s, which the TLS listener rejects as EOF. This generated 59+ error logs per session and masked real vehicle connection failures. Machine health is already determined by `/healthz` on the client port.

2. **Allocate dedicated IPv4** ($2/mo) — The shared IPv4 uses SNI-based routing which adds a proxy layer that can interfere with raw TCP/TLS passthrough. Dedicated IPv4 routes traffic directly to the app. New IP: `109.105.217.163`

### Post-merge steps (done manually)

- [x] Dedicated IPv4 allocated (`fly ips allocate-v4`)
- [ ] Deploy (auto on merge)
- [ ] Update DNS: `telemetry.myrobotaxi.app` A record → `109.105.217.163`
- [ ] Re-push fleet config to vehicle (ensures CA cert is current)
- [ ] Monitor logs for `"vehicle connected"` and telemetry field data

## Test plan

- [x] `go vet`, `go test`, `go build` — all pass
- [ ] Verify 15s EOF errors stop after deploy
- [ ] Verify vehicle connects and streams telemetry fields

🤖 Generated with [Claude Code](https://claude.com/claude-code)