### PR TITLE
Fix deploy: internal port 8443 for non-root process

### DIFF
--- a/configs/fly.json
+++ b/configs/fly.json
@@ -1,7 +1,7 @@
 {
   "_comment": "Fly.io deployment config. TLS paths match start.sh decode locations (/tmp/certs/). These are also overridden at runtime by env vars TLS_CERT_FILE, TLS_KEY_FILE, TLS_CA_FILE that start.sh exports after decoding base64 secrets.",
   "server": {
-    "tesla_port": 443,
+    "tesla_port": 8443,
     "client_port": 8080,
     "metrics_port": 9090
   },

--- a/fly.toml
+++ b/fly.toml
@@ -21,8 +21,10 @@ primary_region = 'iad'
 # The app terminates TLS and extracts the VIN from the client cert.
 # NO handlers — Fly passes raw TCP bytes so mTLS works end-to-end.
 # NO health checks — TCP probes cause TLS EOF errors on the mTLS listener.
+# internal_port 8443 because the app runs as non-root (can't bind <1024).
+# Fly routes external 443 → internal 8443 transparently.
 [[services]]
-  internal_port = 443
+  internal_port = 8443
   protocol = 'tcp'
 
   [[services.ports]]


### PR DESCRIPTION
Hotfix for #106 — deploy timed out because the app tried to bind port 443 as non-root.

**Fix**: Keep `internal_port = 8443` (what the app binds to), let Fly.io route external port 443 → internal 8443. The `fleet_telemetry_port` in config stays at 443 (what Tesla vehicles connect to externally).

🤖 Generated with [Claude Code](https://claude.com/claude-code)