### PR TITLE
Fix exp field: Tesla requires 31-360 days

### DIFF
--- a/internal/telemetry/fleet_config_handler.go
+++ b/internal/telemetry/fleet_config_handler.go
@@ -128,7 +128,8 @@ func (h *FleetConfigHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		ca = &h.endpoint.CA
 	}
 
-	expTime := time.Now().Add(365 * 24 * time.Hour).Unix()
+	// Tesla requires exp between ~31 and ~360 days from now.
+	expTime := time.Now().Add(350 * 24 * time.Hour).Unix()
 
 	req := FleetConfigRequest{
 		VINs: []string{vin},


### PR DESCRIPTION
Hotfix — Tesla Fleet API rejects exp >360 days. Changed from 365 to 350 days.

🤖 Generated with [Claude Code](https://claude.com/claude-code)