### PR TITLE
Add climate fields + convert temperatures to Fahrenheit

### DIFF
--- a/internal/telemetry/converters.go
+++ b/internal/telemetry/converters.go
@@ -26,6 +26,15 @@ func convertValue(field tpb.Field, v *tpb.Value) (events.TelemetryValue, error) 
 		return convertSentryMode(v)
 	case tpb.Field_Locked:
 		return convertBool(v)
+	case tpb.Field_DefrostMode:
+		return convertDefrostMode(v)
+	case tpb.Field_ClimateKeeperMode:
+		return convertClimateKeeperMode(v)
+	case tpb.Field_HvacPower:
+		return convertHvacPower(v)
+	case tpb.Field_InsideTemp, tpb.Field_OutsideTemp,
+		tpb.Field_HvacLeftTemperatureRequest, tpb.Field_HvacRightTemperatureRequest:
+		return convertTemperature(v)
 	default:
 		return convertNumericOrString(v)
 	}
@@ -170,6 +179,78 @@ func convertNumericOrString(v *tpb.Value) (events.TelemetryValue, error) {
 			"%w: expected numeric or string, got %T", ErrUnexpectedValueType, v.Value,
 		)
 	}
+}
+
+// convertDefrostMode extracts a DefrostModeState enum and returns it as a string.
+func convertDefrostMode(v *tpb.Value) (events.TelemetryValue, error) {
+	switch val := v.Value.(type) {
+	case *tpb.Value_DefrostModeValue:
+		s := defrostModeString(val.DefrostModeValue)
+		return events.TelemetryValue{StringVal: &s}, nil
+	case *tpb.Value_StringValue:
+		s := val.StringValue
+		return events.TelemetryValue{StringVal: &s}, nil
+	default:
+		return events.TelemetryValue{}, fmt.Errorf(
+			"%w: expected defrostMode or string, got %T", ErrUnexpectedValueType, v.Value,
+		)
+	}
+}
+
+// convertClimateKeeperMode extracts a ClimateKeeperModeState enum and returns
+// it as a string.
+func convertClimateKeeperMode(v *tpb.Value) (events.TelemetryValue, error) {
+	switch val := v.Value.(type) {
+	case *tpb.Value_ClimateKeeperModeValue:
+		s := climateKeeperModeString(val.ClimateKeeperModeValue)
+		return events.TelemetryValue{StringVal: &s}, nil
+	case *tpb.Value_StringValue:
+		s := val.StringValue
+		return events.TelemetryValue{StringVal: &s}, nil
+	default:
+		return events.TelemetryValue{}, fmt.Errorf(
+			"%w: expected climateKeeperMode or string, got %T", ErrUnexpectedValueType, v.Value,
+		)
+	}
+}
+
+// convertHvacPower extracts an HvacPowerState enum and returns it as a string.
+func convertHvacPower(v *tpb.Value) (events.TelemetryValue, error) {
+	switch val := v.Value.(type) {
+	case *tpb.Value_HvacPowerValue:
+		s := hvacPowerString(val.HvacPowerValue)
+		return events.TelemetryValue{StringVal: &s}, nil
+	case *tpb.Value_StringValue:
+		s := val.StringValue
+		return events.TelemetryValue{StringVal: &s}, nil
+	default:
+		return events.TelemetryValue{}, fmt.Errorf(
+			"%w: expected hvacPower or string, got %T", ErrUnexpectedValueType, v.Value,
+		)
+	}
+}
+
+// convertTemperature extracts a numeric Celsius value and converts it to
+// Fahrenheit. Tesla sends temperatures in Celsius; the frontend expects
+// Fahrenheit for US users, so we convert at the telemetry pipeline boundary
+// so all downstream consumers (WebSocket, database) receive Fahrenheit.
+func convertTemperature(v *tpb.Value) (events.TelemetryValue, error) {
+	tv, err := convertNumericOrString(v)
+	if err != nil {
+		return tv, err
+	}
+
+	if tv.FloatVal != nil {
+		f := celsiusToFahrenheit(*tv.FloatVal)
+		return events.TelemetryValue{FloatVal: &f}, nil
+	}
+
+	return tv, nil
+}
+
+// celsiusToFahrenheit converts a Celsius temperature to Fahrenheit.
+func celsiusToFahrenheit(c float64) float64 {
+	return c*9.0/5.0 + 32.0
 }
 
 // parseStringValue attempts to parse a string into a numeric TelemetryValue.

--- a/internal/telemetry/decoder_test.go
+++ b/internal/telemetry/decoder_test.go
@@ -676,8 +676,8 @@ func TestDecoder_DecodePayload_UntrackedFieldsSkipped(t *testing.T) {
 	dec := NewDecoder()
 
 	payload := makePayload([]*tpb.Datum{
-		// SeatHeaterLeft is not in our fieldMap — should be silently skipped.
-		makeDatum(tpb.Field_SeatHeaterLeft, stringVal("3")),
+		// SeatHeaterRearLeft is not in our fieldMap — should be silently skipped.
+		makeDatum(tpb.Field_SeatHeaterRearLeft, stringVal("3")),
 		makeDatum(tpb.Field_VehicleSpeed, stringVal("70")),
 	})
 
@@ -734,6 +734,11 @@ func TestDecoder_DecodePayload_FullPayload(t *testing.T) {
 	assertFloat(t, evt.Fields, "odometer", 12345.6)
 	assertString(t, evt.Fields, "gear", "D")
 	assertLocation(t, evt.Fields, "location", 33.0903, -96.8237)
+
+	// Temperatures are converted from Celsius to Fahrenheit.
+	// 22.1C -> 71.78F, 28.4C -> 83.12F
+	assertFloatApprox(t, evt.Fields, "insideTemp", 71.78)
+	assertFloatApprox(t, evt.Fields, "outsideTemp", 83.12)
 }
 
 func TestDecoder_DecodePayload_EmptyString(t *testing.T) {
@@ -826,7 +831,8 @@ func TestIsTrackedField(t *testing.T) {
 		{tpb.Field_VehicleSpeed, true},
 		{tpb.Field_Location, true},
 		{tpb.Field_Gear, true},
-		{tpb.Field_SeatHeaterLeft, false},
+		{tpb.Field_SeatHeaterLeft, true},
+		{tpb.Field_SeatHeaterRearLeft, false},
 		{tpb.Field_Unknown, false},
 	}
 
@@ -906,4 +912,268 @@ func assertLocation(t *testing.T, fields map[string]events.TelemetryValue, name 
 	if v.LocationVal.Longitude != wantLng {
 		t.Errorf("field %q lng = %f, want %f", name, v.LocationVal.Longitude, wantLng)
 	}
+}
+
+// assertFloatApprox checks that a float field is within 0.01 of the
+// expected value. Used for converted values where floating-point rounding
+// may produce slight differences.
+func assertFloatApprox(t *testing.T, fields map[string]events.TelemetryValue, name string, want float64) {
+	t.Helper()
+	const epsilon = 0.01
+	v, ok := fields[name]
+	if !ok {
+		t.Errorf("missing field %q", name)
+		return
+	}
+	if v.FloatVal == nil {
+		t.Errorf("field %q: FloatVal is nil", name)
+		return
+	}
+	diff := *v.FloatVal - want
+	if diff < 0 {
+		diff = -diff
+	}
+	if diff > epsilon {
+		t.Errorf("field %q = %f, want %f (within %f)", name, *v.FloatVal, want, epsilon)
+	}
+}
+
+func TestDecoder_DecodePayload_TemperatureConversion(t *testing.T) {
+	t.Parallel()
+	dec := NewDecoder()
+
+	tests := []struct {
+		name      string
+		field     tpb.Field
+		fieldName string
+		celsius   string
+		wantF     float64
+	}{
+		{
+			name:      "inside temp string",
+			field:     tpb.Field_InsideTemp,
+			fieldName: "insideTemp",
+			celsius:   "20.0",
+			wantF:     68.0,
+		},
+		{
+			name:      "outside temp string",
+			field:     tpb.Field_OutsideTemp,
+			fieldName: "outsideTemp",
+			celsius:   "0",
+			wantF:     32.0,
+		},
+		{
+			name:      "driver temp setting",
+			field:     tpb.Field_HvacLeftTemperatureRequest,
+			fieldName: "driverTempSetting",
+			celsius:   "22.0",
+			wantF:     71.6,
+		},
+		{
+			name:      "passenger temp setting",
+			field:     tpb.Field_HvacRightTemperatureRequest,
+			fieldName: "passengerTempSetting",
+			celsius:   "25.0",
+			wantF:     77.0,
+		},
+		{
+			name:      "negative celsius",
+			field:     tpb.Field_OutsideTemp,
+			fieldName: "outsideTemp",
+			celsius:   "-10.0",
+			wantF:     14.0,
+		},
+		{
+			name:      "100 celsius",
+			field:     tpb.Field_InsideTemp,
+			fieldName: "insideTemp",
+			celsius:   "100",
+			wantF:     212.0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			payload := makePayload([]*tpb.Datum{
+				makeDatum(tt.field, stringVal(tt.celsius)),
+			})
+
+			evt, fieldErrs, err := dec.DecodePayload(payload)
+			if err != nil {
+				t.Fatalf("DecodePayload() error = %v", err)
+			}
+			if len(fieldErrs) != 0 {
+				t.Errorf("unexpected field errors: %v", fieldErrs)
+			}
+
+			assertFloatApprox(t, evt.Fields, tt.fieldName, tt.wantF)
+		})
+	}
+}
+
+func TestDecoder_DecodePayload_TemperatureConversionFloat(t *testing.T) {
+	t.Parallel()
+	dec := NewDecoder()
+
+	// Test that float/double values also get converted.
+	payload := makePayload([]*tpb.Datum{
+		makeDatum(tpb.Field_InsideTemp, floatVal(20.0)),
+		makeDatum(tpb.Field_OutsideTemp, doubleVal(25.5)),
+	})
+
+	evt, fieldErrs, err := dec.DecodePayload(payload)
+	if err != nil {
+		t.Fatalf("DecodePayload() error = %v", err)
+	}
+	if len(fieldErrs) != 0 {
+		t.Errorf("unexpected field errors: %v", fieldErrs)
+	}
+
+	assertFloatApprox(t, evt.Fields, "insideTemp", 68.0)
+	assertFloatApprox(t, evt.Fields, "outsideTemp", 77.9)
+}
+
+func TestDecoder_DecodePayload_ClimateEnumFields(t *testing.T) {
+	t.Parallel()
+	dec := NewDecoder()
+
+	tests := []struct {
+		name       string
+		field      tpb.Field
+		value      *tpb.Value
+		fieldName  string
+		wantString string
+	}{
+		{
+			name:       "defrost mode off",
+			field:      tpb.Field_DefrostMode,
+			value:      defrostModeVal(tpb.DefrostModeState_DefrostModeStateOff),
+			fieldName:  "defrostMode",
+			wantString: "Off",
+		},
+		{
+			name:       "defrost mode max",
+			field:      tpb.Field_DefrostMode,
+			value:      defrostModeVal(tpb.DefrostModeState_DefrostModeStateMax),
+			fieldName:  "defrostMode",
+			wantString: "Max",
+		},
+		{
+			name:       "climate keeper dog",
+			field:      tpb.Field_ClimateKeeperMode,
+			value:      climateKeeperModeVal(tpb.ClimateKeeperModeState_ClimateKeeperModeStateDog),
+			fieldName:  "climateKeeperMode",
+			wantString: "Dog",
+		},
+		{
+			name:       "hvac power on",
+			field:      tpb.Field_HvacPower,
+			value:      hvacPowerVal(tpb.HvacPowerState_HvacPowerStateOn),
+			fieldName:  "hvacPower",
+			wantString: "On",
+		},
+		{
+			name:       "hvac power precondition",
+			field:      tpb.Field_HvacPower,
+			value:      hvacPowerVal(tpb.HvacPowerState_HvacPowerStatePrecondition),
+			fieldName:  "hvacPower",
+			wantString: "Precondition",
+		},
+		{
+			name:       "defrost string fallback",
+			field:      tpb.Field_DefrostMode,
+			value:      stringVal("Max"),
+			fieldName:  "defrostMode",
+			wantString: "Max",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			payload := makePayload([]*tpb.Datum{
+				makeDatum(tt.field, tt.value),
+			})
+
+			evt, fieldErrs, err := dec.DecodePayload(payload)
+			if err != nil {
+				t.Fatalf("DecodePayload() error = %v", err)
+			}
+			if len(fieldErrs) != 0 {
+				t.Errorf("unexpected field errors: %v", fieldErrs)
+			}
+
+			assertString(t, evt.Fields, tt.fieldName, tt.wantString)
+		})
+	}
+}
+
+func TestDecoder_DecodePayload_ClimateNumericFields(t *testing.T) {
+	t.Parallel()
+	dec := NewDecoder()
+
+	payload := makePayload([]*tpb.Datum{
+		makeDatum(tpb.Field_HvacFanSpeed, stringVal("5")),
+		makeDatum(tpb.Field_SeatHeaterLeft, stringVal("3")),
+		makeDatum(tpb.Field_SeatHeaterRight, stringVal("0")),
+	})
+
+	evt, fieldErrs, err := dec.DecodePayload(payload)
+	if err != nil {
+		t.Fatalf("DecodePayload() error = %v", err)
+	}
+	if len(fieldErrs) != 0 {
+		t.Errorf("unexpected field errors: %v", fieldErrs)
+	}
+
+	assertFloat(t, evt.Fields, "hvacFanSpeed", 5.0)
+	assertFloat(t, evt.Fields, "seatHeaterLeft", 3.0)
+	assertFloat(t, evt.Fields, "seatHeaterRight", 0.0)
+}
+
+func TestCelsiusToFahrenheit(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		celsius float64
+		wantF   float64
+	}{
+		{"freezing point", 0, 32},
+		{"boiling point", 100, 212},
+		{"body temp", 37, 98.6},
+		{"negative", -40, -40},
+		{"room temp", 20, 68},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := celsiusToFahrenheit(tt.celsius)
+			diff := got - tt.wantF
+			if diff < 0 {
+				diff = -diff
+			}
+			if diff > 0.01 {
+				t.Errorf("celsiusToFahrenheit(%f) = %f, want %f", tt.celsius, got, tt.wantF)
+			}
+		})
+	}
+}
+
+// defrostModeVal creates a Value with a defrost_mode_value.
+func defrostModeVal(dm tpb.DefrostModeState) *tpb.Value {
+	return &tpb.Value{Value: &tpb.Value_DefrostModeValue{DefrostModeValue: dm}}
+}
+
+// climateKeeperModeVal creates a Value with a climate_keeper_mode_value.
+func climateKeeperModeVal(ck tpb.ClimateKeeperModeState) *tpb.Value {
+	return &tpb.Value{Value: &tpb.Value_ClimateKeeperModeValue{ClimateKeeperModeValue: ck}}
+}
+
+// hvacPowerVal creates a Value with an hvac_power_value.
+func hvacPowerVal(hp tpb.HvacPowerState) *tpb.Value {
+	return &tpb.Value{Value: &tpb.Value_HvacPowerValue{HvacPowerValue: hp}}
 }

--- a/internal/telemetry/enum_strings.go
+++ b/internal/telemetry/enum_strings.go
@@ -104,3 +104,52 @@ func sentryModeString(sm tpb.SentryModeState) string {
 		return "Unknown"
 	}
 }
+
+// defrostModeString converts a DefrostModeState enum to a human-readable string.
+func defrostModeString(dm tpb.DefrostModeState) string {
+	switch dm {
+	case tpb.DefrostModeState_DefrostModeStateOff:
+		return "Off"
+	case tpb.DefrostModeState_DefrostModeStateNormal:
+		return "Normal"
+	case tpb.DefrostModeState_DefrostModeStateMax:
+		return "Max"
+	case tpb.DefrostModeState_DefrostModeStateAutoDefog:
+		return "AutoDefog"
+	default:
+		return "Unknown"
+	}
+}
+
+// climateKeeperModeString converts a ClimateKeeperModeState enum to a
+// human-readable string.
+func climateKeeperModeString(ck tpb.ClimateKeeperModeState) string {
+	switch ck {
+	case tpb.ClimateKeeperModeState_ClimateKeeperModeStateOff:
+		return "Off"
+	case tpb.ClimateKeeperModeState_ClimateKeeperModeStateOn:
+		return "On"
+	case tpb.ClimateKeeperModeState_ClimateKeeperModeStateDog:
+		return "Dog"
+	case tpb.ClimateKeeperModeState_ClimateKeeperModeStateParty:
+		return "Party"
+	default:
+		return "Unknown"
+	}
+}
+
+// hvacPowerString converts an HvacPowerState enum to a human-readable string.
+func hvacPowerString(hp tpb.HvacPowerState) string {
+	switch hp {
+	case tpb.HvacPowerState_HvacPowerStateOff:
+		return "Off"
+	case tpb.HvacPowerState_HvacPowerStateOn:
+		return "On"
+	case tpb.HvacPowerState_HvacPowerStatePrecondition:
+		return "Precondition"
+	case tpb.HvacPowerState_HvacPowerStateOverheatProtect:
+		return "OverheatProtect"
+	default:
+		return "Unknown"
+	}
+}

--- a/internal/telemetry/fields.go
+++ b/internal/telemetry/fields.go
@@ -21,9 +21,17 @@ const (
 	FieldEstBatteryRange    FieldName = "estimatedRange"
 	FieldChargeState        FieldName = "chargeState"
 	FieldOdometer           FieldName = "odometer"
-	FieldInsideTemp         FieldName = "insideTemp"
-	FieldOutsideTemp        FieldName = "outsideTemp"
-	FieldDestinationName    FieldName = "destinationName"
+	FieldInsideTemp           FieldName = "insideTemp"
+	FieldOutsideTemp          FieldName = "outsideTemp"
+	FieldHvacPower            FieldName = "hvacPower"
+	FieldHvacFanSpeed         FieldName = "hvacFanSpeed"
+	FieldDriverTempSetting    FieldName = "driverTempSetting"
+	FieldPassengerTempSetting FieldName = "passengerTempSetting"
+	FieldDefrostMode          FieldName = "defrostMode"
+	FieldSeatHeaterLeft       FieldName = "seatHeaterLeft"
+	FieldSeatHeaterRight      FieldName = "seatHeaterRight"
+	FieldClimateKeeperMode    FieldName = "climateKeeperMode"
+	FieldDestinationName      FieldName = "destinationName"
 	FieldRouteLine          FieldName = "routeLine"
 	FieldFSDMiles           FieldName = "fsdMilesSinceReset"
 	FieldBatteryLevel       FieldName = "batteryLevel"
@@ -58,9 +66,17 @@ var fieldMap = map[tpb.Field]FieldName{
 	tpb.Field_EstBatteryRange:          FieldEstBatteryRange,
 	tpb.Field_DetailedChargeState:      FieldChargeState,
 	tpb.Field_Odometer:                 FieldOdometer,
-	tpb.Field_InsideTemp:               FieldInsideTemp,
-	tpb.Field_OutsideTemp:              FieldOutsideTemp,
-	tpb.Field_DestinationName:          FieldDestinationName,
+	tpb.Field_InsideTemp:                  FieldInsideTemp,
+	tpb.Field_OutsideTemp:                 FieldOutsideTemp,
+	tpb.Field_HvacPower:                   FieldHvacPower,
+	tpb.Field_HvacFanSpeed:                FieldHvacFanSpeed,
+	tpb.Field_HvacLeftTemperatureRequest:  FieldDriverTempSetting,
+	tpb.Field_HvacRightTemperatureRequest: FieldPassengerTempSetting,
+	tpb.Field_DefrostMode:                 FieldDefrostMode,
+	tpb.Field_SeatHeaterLeft:              FieldSeatHeaterLeft,
+	tpb.Field_SeatHeaterRight:             FieldSeatHeaterRight,
+	tpb.Field_ClimateKeeperMode:           FieldClimateKeeperMode,
+	tpb.Field_DestinationName:             FieldDestinationName,
 	tpb.Field_RouteLine:                FieldRouteLine,
 	tpb.Field_SelfDrivingMilesSinceReset: FieldFSDMiles,
 	tpb.Field_BatteryLevel:             FieldBatteryLevel,

--- a/internal/telemetry/fleet_api_fields.go
+++ b/internal/telemetry/fleet_api_fields.go
@@ -49,8 +49,16 @@ const (
 // --- Climate ---
 
 const (
-	FleetFieldInsideTemp  = "InsideTemp"
-	FleetFieldOutsideTemp = "OutsideTemp"
+	FleetFieldInsideTemp           = "InsideTemp"
+	FleetFieldOutsideTemp          = "OutsideTemp"
+	FleetFieldHvacPower            = "HvacPower"
+	FleetFieldHvacFanSpeed         = "HvacFanSpeed"
+	FleetFieldDriverTempSetting    = "HvacLeftTemperatureRequest"
+	FleetFieldPassengerTempSetting = "HvacRightTemperatureRequest"
+	FleetFieldDefrostMode          = "DefrostMode"
+	FleetFieldSeatHeaterLeft       = "SeatHeaterLeft"
+	FleetFieldSeatHeaterRight      = "SeatHeaterRight"
+	FleetFieldClimateKeeperMode    = "ClimateKeeperMode"
 )
 
 // --- Vehicle State ---
@@ -112,9 +120,17 @@ func DefaultFieldConfig() map[string]FieldConfig {
 		FleetFieldPackCurrent:         {IntervalSeconds: 30},
 		FleetFieldDetailedChargeState: {IntervalSeconds: 30},
 
-		// Climate — low frequency
-		FleetFieldInsideTemp:  {IntervalSeconds: 60},
-		FleetFieldOutsideTemp: {IntervalSeconds: 60},
+		// Climate — medium/low frequency
+		FleetFieldInsideTemp:           {IntervalSeconds: 60},
+		FleetFieldOutsideTemp:          {IntervalSeconds: 60},
+		FleetFieldHvacPower:            {IntervalSeconds: 10},
+		FleetFieldHvacFanSpeed:         {IntervalSeconds: 30},
+		FleetFieldDriverTempSetting:    {IntervalSeconds: 30},
+		FleetFieldPassengerTempSetting: {IntervalSeconds: 30},
+		FleetFieldDefrostMode:          {IntervalSeconds: 30},
+		FleetFieldSeatHeaterLeft:       {IntervalSeconds: 30},
+		FleetFieldSeatHeaterRight:      {IntervalSeconds: 30},
+		FleetFieldClimateKeeperMode:    {IntervalSeconds: 60},
 
 		// Vehicle state — low frequency
 		FleetFieldOdometer:    {IntervalSeconds: 60},


### PR DESCRIPTION
## Summary

Part of #106

1. **Add 8 climate fields** to `DefaultFieldConfig()`: HvacPower, HvacFanSpeed, DriverTempSetting, PassengerTempSetting, DefrostMode, SeatHeaterLeft, SeatHeaterRight, ClimateKeeperMode
2. **Convert all temperatures C→F** in the decoder pipeline so WebSocket clients receive Fahrenheit (matching the REST API path which already converts)
3. **Add enum converters** for DefrostMode, ClimateKeeperMode, HvacPower states
4. **5 new tests** for temperature conversion and climate enum decoding

After merge + deploy, fleet config needs to be re-pushed to the vehicle.

## Test plan
- [x] `go vet`, `golangci-lint`, `go test`, `go build` — all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)