### PR TITLE
Fix driving/parked status flicker in real-time UI

### DIFF
--- a/internal/ws/broadcaster.go
+++ b/internal/ws/broadcaster.go
@@ -116,9 +116,16 @@ func (b *Broadcaster) handleTelemetry(ctx context.Context, event events.Event) {
 	// ordering) — lastUpdated is what the UI displays.
 	fields["lastUpdated"] = payload.CreatedAt.Format(time.RFC3339)
 
-	// Derive vehicle status from gear and speed. This is a synthetic field
-	// (not from Tesla telemetry) — it drives the frontend's driving/parked UI.
-	fields["status"] = deriveVehicleStatus(fields)
+	// Derive vehicle status from gear and speed only when one of those
+	// fields is present in this update. Tesla sends fields only on change,
+	// so most updates won't contain gear or speed. Injecting "parked"
+	// into those updates would override the frontend's current status and
+	// cause the driving/parked UI to flicker.
+	if _, hasGear := fields["gearPosition"]; hasGear {
+		fields["status"] = deriveVehicleStatus(fields)
+	} else if _, hasSpeed := fields["speed"]; hasSpeed {
+		fields["status"] = deriveVehicleStatus(fields)
+	}
 
 	msg, err := marshalWSMessage(msgTypeVehicleUpdate, vehicleUpdatePayload{
 		VehicleID: vehicleID,


### PR DESCRIPTION
## Summary

Fixes the bottom sheet flickering between driving and parked states during live driving.

**Root cause:** `deriveVehicleStatus()` ran on EVERY WebSocket update, but Tesla only sends `gear`/`speed` fields when their values change. Updates without those fields defaulted to `status: "parked"`, which the frontend merged over the existing `"driving"` status. The UI then flipped back to driving on the next update that included gear.

**Fix:** Only inject `status` into the update when `gearPosition` or `speed` is present. Updates without these fields no longer override the frontend's current status.

This also fixes the app crash — the rapid driving↔parked oscillation caused the map, bottom sheet, and all child components to remount on every update cycle.

## Test plan
- [x] `go vet`, `golangci-lint`, `go test`, `go build` — all pass
- [ ] Drive test: UI should stay stable in driving mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)