### PR TITLE
Skip zero-zero origin/destination coordinates from Tesla

### DIFF
--- a/internal/store/field_mapper.go
+++ b/internal/store/field_mapper.go
@@ -89,9 +89,13 @@ func applyLocation(u *VehicleUpdate, val events.TelemetryValue) bool {
 }
 
 // applyDestLocation applies a LocationVal to DestinationLatitude and
-// DestinationLongitude fields.
+// DestinationLongitude fields. Zero-zero coordinates (protobuf default
+// for "not set") are ignored to prevent overwriting real values.
 func applyDestLocation(u *VehicleUpdate, val events.TelemetryValue) bool {
 	if val.LocationVal == nil {
+		return false
+	}
+	if val.LocationVal.Latitude == 0 && val.LocationVal.Longitude == 0 {
 		return false
 	}
 	u.DestinationLatitude = &val.LocationVal.Latitude
@@ -100,9 +104,12 @@ func applyDestLocation(u *VehicleUpdate, val events.TelemetryValue) bool {
 }
 
 // applyOriginLocation applies a LocationVal to OriginLatitude and
-// OriginLongitude fields.
+// OriginLongitude fields. Zero-zero coordinates are ignored.
 func applyOriginLocation(u *VehicleUpdate, val events.TelemetryValue) bool {
 	if val.LocationVal == nil {
+		return false
+	}
+	if val.LocationVal.Latitude == 0 && val.LocationVal.Longitude == 0 {
 		return false
 	}
 	u.OriginLatitude = &val.LocationVal.Latitude

--- a/internal/ws/field_mapping.go
+++ b/internal/ws/field_mapping.go
@@ -84,8 +84,17 @@ func mapFieldsForClient(fields map[string]events.TelemetryValue) map[string]any 
 
 // splitLocationField adds a LocationVal as separate latitude/longitude keys
 // to the output map. If the LocationVal is nil, no keys are added.
+// For origin and destination locations, zero-zero coordinates (protobuf
+// default for "not set") are skipped to prevent overwriting real values.
 func splitLocationField(out map[string]any, name string, val events.TelemetryValue) {
 	if val.LocationVal == nil {
+		return
+	}
+	// Skip zero-zero for origin/destination — protobuf default means "not set".
+	// Vehicle Location is not skipped because it updates frequently and 0,0 is
+	// filtered upstream by the minimum_delta config.
+	if name != "location" &&
+		val.LocationVal.Latitude == 0 && val.LocationVal.Longitude == 0 {
 		return
 	}
 	latLng := locationFieldSplit[name]


### PR DESCRIPTION
Tesla sends `{latitude: 0, longitude: 0}` for OriginLocation/DestinationLocation when not set. This overwrites real coordinates. Fix: treat (0, 0) as "not set" in both WS broadcast and DB persistence.

This is why the UI showed "0.0000, 0.0000" as the origin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)