### PR TITLE
#123 Separate nav route and driven path into distinct WebSocket fields

### DIFF
--- a/internal/ws/broadcaster_test.go
+++ b/internal/ws/broadcaster_test.go
@@ -494,16 +494,16 @@ func TestFieldMapping(t *testing.T) {
 			},
 		},
 		{
-			name: "routeLine decodes to routeCoordinates in lng/lat order",
+			name: "routeLine decodes to navRouteCoordinates in lng/lat order",
 			fields: map[string]events.TelemetryValue{
 				"routeLine": {StringVal: ptrString("_p~iF~ps|U_ulLnnqC_mqNvxq`@")},
 			},
-			wantKeys: []string{"routeCoordinates"},
+			wantKeys: []string{"navRouteCoordinates"},
 			check: func(t *testing.T, result map[string]any) {
 				t.Helper()
-				coords, ok := result["routeCoordinates"].([][]float64)
+				coords, ok := result["navRouteCoordinates"].([][]float64)
 				if !ok {
-					t.Fatalf("expected routeCoordinates to be [][]float64, got %T", result["routeCoordinates"])
+					t.Fatalf("expected navRouteCoordinates to be [][]float64, got %T", result["navRouteCoordinates"])
 				}
 				if len(coords) != 3 {
 					t.Fatalf("expected 3 coordinates, got %d", len(coords))
@@ -528,8 +528,8 @@ func TestFieldMapping(t *testing.T) {
 			wantKeys: nil,
 			check: func(t *testing.T, result map[string]any) {
 				t.Helper()
-				if _, ok := result["routeCoordinates"]; ok {
-					t.Fatal("expected no routeCoordinates for empty routeLine")
+				if _, ok := result["navRouteCoordinates"]; ok {
+					t.Fatal("expected no navRouteCoordinates for empty routeLine")
 				}
 			},
 		},

--- a/internal/ws/field_mapping.go
+++ b/internal/ws/field_mapping.go
@@ -103,7 +103,7 @@ func splitLocationField(out map[string]any, name string, val events.TelemetryVal
 }
 
 // decodeRouteLineField decodes a Google Encoded Polyline string and adds
-// the resulting coordinates as "routeCoordinates" in [lng, lat] (Mapbox)
+// the resulting coordinates as "navRouteCoordinates" in [lng, lat] (Mapbox)
 // format. Empty or nil strings are silently skipped.
 func decodeRouteLineField(out map[string]any, val events.TelemetryValue) {
 	if val.StringVal == nil || *val.StringVal == "" {
@@ -121,7 +121,7 @@ func decodeRouteLineField(out map[string]any, val events.TelemetryValue) {
 	for i, c := range coords {
 		mapboxCoords[i] = []float64{c[1], c[0]}
 	}
-	out["routeCoordinates"] = mapboxCoords
+	out["navRouteCoordinates"] = mapboxCoords
 }
 
 // roundIfInteger rounds float64 values to integers for fields the frontend


### PR DESCRIPTION
## Summary

- Renamed the decoded `RouteLine` output key from `routeCoordinates` to `navRouteCoordinates` in `decodeRouteLineField()` so Tesla's planned navigation polyline no longer overwrites the accumulated GPS track (`routeCoordinates` in `route_broadcast.go`).
- Updated all related tests in `broadcaster_test.go` to assert on the new `navRouteCoordinates` key.

Closes #123

## Test plan

- [ ] Verify `go test ./internal/ws/...` passes (routeLine decode tests now check `navRouteCoordinates`)
- [ ] Verify the frontend correctly reads `navRouteCoordinates` for the planned nav route and `routeCoordinates` for the driven GPS path
- [ ] Confirm no other consumers depend on the old `routeCoordinates` key for the nav polyline

🤖 Generated with [Claude Code](https://claude.com/claude-code)