### PR TITLE
Address PR #148 review suggestions

### DIFF
--- a/internal/store/field_mapper.go
+++ b/internal/store/field_mapper.go
@@ -33,12 +33,12 @@ var fieldAppliers = map[telemetry.FieldName]fieldApplier{
 // navFieldColumns maps internal telemetry field names to the DB column
 // names that should be SET NULL when the vehicle marks the field invalid
 // (e.g. navigation cancelled).
-var navFieldColumns = map[string][]string{
-	string(telemetry.FieldDestinationName): {"destinationName"},
-	string(telemetry.FieldMinutesToArrival): {"etaMinutes"},
-	string(telemetry.FieldMilesToArrival):   {"tripDistanceRemaining"},
-	string(telemetry.FieldOriginLocation):   {"originLatitude", "originLongitude"},
-	string(telemetry.FieldDestLocation):     {"destinationLatitude", "destinationLongitude"},
+var navFieldColumns = map[telemetry.FieldName][]string{
+	telemetry.FieldDestinationName: {"destinationName"},
+	telemetry.FieldMinutesToArrival: {"etaMinutes"},
+	telemetry.FieldMilesToArrival:   {"tripDistanceRemaining"},
+	telemetry.FieldOriginLocation:   {"originLatitude", "originLongitude"},
+	telemetry.FieldDestLocation:     {"destinationLatitude", "destinationLongitude"},
 }
 
 // mapTelemetryToUpdate converts a map of telemetry field values into a
@@ -53,7 +53,7 @@ func mapTelemetryToUpdate(fields map[string]events.TelemetryValue) *VehicleUpdat
 	for name, val := range fields {
 		// Nav fields marked invalid → schedule DB columns for NULL.
 		if val.Invalid {
-			if cols, isNav := navFieldColumns[name]; isNav {
+			if cols, isNav := navFieldColumns[telemetry.FieldName(name)]; isNav {
 				u.ClearFields = append(u.ClearFields, cols...)
 				hasFields = true
 			}

--- a/internal/store/field_mapper_test.go
+++ b/internal/store/field_mapper_test.go
@@ -1,6 +1,7 @@
 package store
 
 import (
+	"slices"
 	"testing"
 
 	"github.com/tnando/my-robo-taxi-telemetry/internal/events"
@@ -309,8 +310,8 @@ func TestMapTelemetryToUpdate_InvalidNavFields(t *testing.T) {
 			copy(gotClear, u.ClearFields)
 			wantClear := make([]string, len(tt.wantClear))
 			copy(wantClear, tt.wantClear)
-			sortStrings(gotClear)
-			sortStrings(wantClear)
+			slices.Sort(gotClear)
+			slices.Sort(wantClear)
 
 			if len(gotClear) != len(wantClear) {
 				t.Fatalf("ClearFields = %v, want %v", gotClear, wantClear)
@@ -347,12 +348,3 @@ func ptrVal[T any](p *T) any {
 	return *p
 }
 
-func sortStrings(s []string) {
-	for i := range s {
-		for j := i + 1; j < len(s); j++ {
-			if s[i] > s[j] {
-				s[i], s[j] = s[j], s[i]
-			}
-		}
-	}
-}

--- a/internal/store/queries.go
+++ b/internal/store/queries.go
@@ -13,6 +13,7 @@ const vehicleSelectColumns = `"id", "userId", "vin", "name", "status",
 	"latitude", "longitude", "interiorTemp", "exteriorTemp",
 	"odometerMiles", "destinationName", "destinationLatitude",
 	"destinationLongitude", "originLatitude", "originLongitude",
+	"etaMinutes", "tripDistanceRemaining",
 	"lastUpdated"`
 
 const queryVehicleByVIN = `SELECT ` + vehicleSelectColumns + `

--- a/internal/store/types.go
+++ b/internal/store/types.go
@@ -39,6 +39,8 @@ type Vehicle struct {
 	DestinationLongitude *float64 // nullable
 	OriginLatitude       *float64 // nullable
 	OriginLongitude      *float64 // nullable
+	EtaMinutes           *int     // nullable
+	TripDistRemaining    *float64 // nullable
 	LastUpdated          time.Time
 }
 

--- a/internal/store/vehicle_repo.go
+++ b/internal/store/vehicle_repo.go
@@ -101,6 +101,7 @@ func (r *VehicleRepo) scanVehicle(ctx context.Context, query string, arg any) (V
 		&v.InteriorTemp, &v.ExteriorTemp, &v.OdometerMiles,
 		&v.DestinationName, &v.DestinationLatitude,
 		&v.DestinationLongitude, &v.OriginLatitude, &v.OriginLongitude,
+		&v.EtaMinutes, &v.TripDistRemaining,
 		&v.LastUpdated,
 	)
 	if errors.Is(err, pgx.ErrNoRows) {

--- a/internal/store/writer_coalesce.go
+++ b/internal/store/writer_coalesce.go
@@ -1,5 +1,7 @@
 package store
 
+import "slices"
+
 // coalesce merges an update into the pending map for the given VIN.
 // Returns true if the batch size threshold has been reached.
 func (w *Writer) coalesce(vin string, update *VehicleUpdate) bool {
@@ -76,8 +78,11 @@ func mergeUpdate(dst, src *VehicleUpdate) {
 		dst.TripDistRemaining = src.TripDistRemaining
 	}
 	// Append ClearFields from source so NULL writes survive coalescing.
-	if len(src.ClearFields) > 0 {
-		dst.ClearFields = append(dst.ClearFields, src.ClearFields...)
+	// Deduplicate to avoid redundant SET NULL clauses.
+	for _, col := range src.ClearFields {
+		if !slices.Contains(dst.ClearFields, col) {
+			dst.ClearFields = append(dst.ClearFields, col)
+		}
 	}
 	// Always take the later timestamp.
 	if src.LastUpdated.After(dst.LastUpdated) {


### PR DESCRIPTION
## Summary
- **slices.Sort**: Replaced hand-rolled bubble sort helper in `field_mapper_test.go` with `slices.Sort` from the Go 1.21+ standard library
- **Dedup ClearFields**: Changed `mergeUpdate` in `writer_coalesce.go` to deduplicate ClearFields during merge, preventing redundant SET NULL clauses when the same field is cleared in multiple coalesced events
- **Read model**: Added `EtaMinutes` and `TripDistRemaining` to the `Vehicle` struct, `vehicleSelectColumns`, and `scanVehicle` so these nav fields are available when reading vehicles from the database
- **Typed map key**: Changed `navFieldColumns` from `map[string][]string` to `map[telemetry.FieldName][]string`, removing unnecessary `string()` casts from keys and casting at the lookup site instead

## Test plan
- [ ] Existing tests pass (`go test ./internal/store/...`)
- [ ] `TestMapTelemetryToUpdate_InvalidNavFields` still sorts correctly with `slices.Sort`
- [ ] `TestMergeUpdate_ClearFields` validates dedup behavior (duplicate ClearFields should not appear after merge)
- [ ] Vehicle queries return `etaMinutes` and `tripDistanceRemaining` columns without scan errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)