### PR TITLE
Fix gocognit lint: reduce mergeUpdate complexity with generic helper

### DIFF
--- a/internal/store/writer_coalesce.go
+++ b/internal/store/writer_coalesce.go
@@ -18,65 +18,36 @@ func (w *Writer) coalesce(vin string, update *VehicleUpdate) bool {
 	return w.count >= w.cfg.BatchSize
 }
 
+// mergePtr returns src if non-nil, otherwise dst (last-write-wins for pointer fields).
+func mergePtr[T any](dst, src *T) *T {
+	if src != nil {
+		return src
+	}
+	return dst
+}
+
 // mergeUpdate applies non-nil fields from src onto dst (latest wins).
 func mergeUpdate(dst, src *VehicleUpdate) {
-	if src.Speed != nil {
-		dst.Speed = src.Speed
-	}
-	if src.ChargeLevel != nil {
-		dst.ChargeLevel = src.ChargeLevel
-	}
-	if src.EstimatedRange != nil {
-		dst.EstimatedRange = src.EstimatedRange
-	}
-	if src.GearPosition != nil {
-		dst.GearPosition = src.GearPosition
-	}
-	if src.Heading != nil {
-		dst.Heading = src.Heading
-	}
-	if src.Latitude != nil {
-		dst.Latitude = src.Latitude
-	}
-	if src.Longitude != nil {
-		dst.Longitude = src.Longitude
-	}
-	if src.InteriorTemp != nil {
-		dst.InteriorTemp = src.InteriorTemp
-	}
-	if src.ExteriorTemp != nil {
-		dst.ExteriorTemp = src.ExteriorTemp
-	}
-	if src.OdometerMiles != nil {
-		dst.OdometerMiles = src.OdometerMiles
-	}
-	if src.LocationName != nil {
-		dst.LocationName = src.LocationName
-	}
-	if src.LocationAddr != nil {
-		dst.LocationAddr = src.LocationAddr
-	}
-	if src.DestinationName != nil {
-		dst.DestinationName = src.DestinationName
-	}
-	if src.DestinationLatitude != nil {
-		dst.DestinationLatitude = src.DestinationLatitude
-	}
-	if src.DestinationLongitude != nil {
-		dst.DestinationLongitude = src.DestinationLongitude
-	}
-	if src.OriginLatitude != nil {
-		dst.OriginLatitude = src.OriginLatitude
-	}
-	if src.OriginLongitude != nil {
-		dst.OriginLongitude = src.OriginLongitude
-	}
-	if src.EtaMinutes != nil {
-		dst.EtaMinutes = src.EtaMinutes
-	}
-	if src.TripDistRemaining != nil {
-		dst.TripDistRemaining = src.TripDistRemaining
-	}
+	dst.Speed = mergePtr(dst.Speed, src.Speed)
+	dst.ChargeLevel = mergePtr(dst.ChargeLevel, src.ChargeLevel)
+	dst.EstimatedRange = mergePtr(dst.EstimatedRange, src.EstimatedRange)
+	dst.GearPosition = mergePtr(dst.GearPosition, src.GearPosition)
+	dst.Heading = mergePtr(dst.Heading, src.Heading)
+	dst.Latitude = mergePtr(dst.Latitude, src.Latitude)
+	dst.Longitude = mergePtr(dst.Longitude, src.Longitude)
+	dst.InteriorTemp = mergePtr(dst.InteriorTemp, src.InteriorTemp)
+	dst.ExteriorTemp = mergePtr(dst.ExteriorTemp, src.ExteriorTemp)
+	dst.OdometerMiles = mergePtr(dst.OdometerMiles, src.OdometerMiles)
+	dst.LocationName = mergePtr(dst.LocationName, src.LocationName)
+	dst.LocationAddr = mergePtr(dst.LocationAddr, src.LocationAddr)
+	dst.DestinationName = mergePtr(dst.DestinationName, src.DestinationName)
+	dst.DestinationLatitude = mergePtr(dst.DestinationLatitude, src.DestinationLatitude)
+	dst.DestinationLongitude = mergePtr(dst.DestinationLongitude, src.DestinationLongitude)
+	dst.OriginLatitude = mergePtr(dst.OriginLatitude, src.OriginLatitude)
+	dst.OriginLongitude = mergePtr(dst.OriginLongitude, src.OriginLongitude)
+	dst.EtaMinutes = mergePtr(dst.EtaMinutes, src.EtaMinutes)
+	dst.TripDistRemaining = mergePtr(dst.TripDistRemaining, src.TripDistRemaining)
+
 	// Append ClearFields from source so NULL writes survive coalescing.
 	// Deduplicate to avoid redundant SET NULL clauses.
 	for _, col := range src.ClearFields {


### PR DESCRIPTION
## Summary

- Replace 18 sequential nil-check branches in `mergeUpdate` with a generic `mergePtr[T]` helper, dropping gocognit score from 23 to under 10
- No behavior change — pure refactor to fix pre-existing lint failure blocking CI on main

## Test plan

- [x] Existing `writer_coalesce_test.go` tests pass unchanged (behavior identical)
- [ ] CI lint passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)