### PR TITLE
Address review feedback on nav accumulator

### DIFF
--- a/internal/ws/broadcaster.go
+++ b/internal/ws/broadcaster.go
@@ -69,10 +69,12 @@ func (b *Broadcaster) Start(ctx context.Context) error {
 	return nil
 }
 
-// Stop unsubscribes from all event bus topics. After Stop returns, no
-// further events will be processed.
+// Stop unsubscribes from all event bus topics and cancels any pending
+// nav accumulator timers. After Stop returns, no further events will
+// be processed and no timer callbacks will fire.
 func (b *Broadcaster) Stop() error {
 	b.unsubscribeAll()
+	b.nav.Stop()
 	b.logger.Info("broadcaster stopped")
 	return nil
 }
@@ -159,11 +161,11 @@ func (b *Broadcaster) handleDriveEnded(ctx context.Context, event events.Event) 
 	}
 	b.routes.Clear(payload.VIN)
 
-	// Flush and clear any pending nav fields for this VIN.
+	// Flush any pending nav fields for this VIN. Flush cancels the timer
+	// and clears state, so a separate Clear call is unnecessary.
 	if navFields := b.nav.Flush(payload.VIN); len(navFields) > 0 {
 		b.flushNav(payload.VIN, navFields)
 	}
-	b.nav.Clear(payload.VIN)
 
 	msg, err := marshalWSMessage(msgTypeDriveEnded, driveEndedPayload{
 		VehicleID: vehicleID,

--- a/internal/ws/nav_accumulator.go
+++ b/internal/ws/nav_accumulator.go
@@ -111,3 +111,20 @@ func (a *navAccumulator) Clear(vin string) {
 	}
 	delete(a.pending, vin)
 }
+
+// Stop cancels all pending timers across all VINs. Called during
+// Broadcaster shutdown to prevent timer callbacks from racing with
+// teardown. Does not invoke onFlush for pending fields.
+func (a *navAccumulator) Stop() {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+
+	for vin, timer := range a.timers {
+		timer.Stop()
+		delete(a.timers, vin)
+	}
+	// Clear all pending state.
+	for vin := range a.pending {
+		delete(a.pending, vin)
+	}
+}

--- a/internal/ws/nav_accumulator_test.go
+++ b/internal/ws/nav_accumulator_test.go
@@ -236,9 +236,11 @@ func TestNavAccumulator_FlushEmptyVIN(t *testing.T) {
 }
 
 func TestNavAccumulator_ClearRemovesState(t *testing.T) {
-	flushCount := 0
-	acc := newNavAccumulator(10*time.Second, func(_ string, _ map[string]events.TelemetryValue) {
-		flushCount++
+	// Use a short interval so we can verify the timer was cancelled by
+	// waiting for it NOT to fire within a bounded duration.
+	callbackFired := make(chan struct{}, 1)
+	acc := newNavAccumulator(50*time.Millisecond, func(_ string, _ map[string]events.TelemetryValue) {
+		callbackFired <- struct{}{}
 	})
 
 	vin := "5YJ3E1EA1NF000001"
@@ -254,10 +256,12 @@ func TestNavAccumulator_ClearRemovesState(t *testing.T) {
 		t.Fatal("expected nil after clear")
 	}
 
-	// Timer should have been cancelled.
-	time.Sleep(50 * time.Millisecond)
-	if flushCount != 0 {
-		t.Fatalf("expected 0 timer flushes after clear, got %d", flushCount)
+	// Timer should have been cancelled — verify no callback within 3x the interval.
+	select {
+	case <-callbackFired:
+		t.Fatal("expected no timer flush after clear, but callback fired")
+	case <-time.After(150 * time.Millisecond):
+		// Success — timer did not fire.
 	}
 }
 
@@ -302,6 +306,30 @@ func TestNavAccumulator_MultipleVINsIndependent(t *testing.T) {
 	}
 	if *flushedByVIN[vin2]["destinationName"].StringVal != "Work" {
 		t.Fatalf("vin2 expected Work, got %v", flushedByVIN[vin2]["destinationName"])
+	}
+}
+
+func TestNavAccumulator_StopCancelsAllTimers(t *testing.T) {
+	callbackFired := make(chan struct{}, 2)
+	acc := newNavAccumulator(50*time.Millisecond, func(_ string, _ map[string]events.TelemetryValue) {
+		callbackFired <- struct{}{}
+	})
+
+	acc.Add("VIN1", map[string]events.TelemetryValue{
+		"destinationName": {StringVal: ptrString("A")},
+	})
+	acc.Add("VIN2", map[string]events.TelemetryValue{
+		"destinationName": {StringVal: ptrString("B")},
+	})
+
+	acc.Stop()
+
+	// No callbacks should fire after Stop.
+	select {
+	case <-callbackFired:
+		t.Fatal("expected no callbacks after Stop")
+	case <-time.After(150 * time.Millisecond):
+		// Success.
 	}
 }
 

--- a/internal/ws/nav_broadcast.go
+++ b/internal/ws/nav_broadcast.go
@@ -95,12 +95,13 @@ func (b *Broadcaster) flushNav(vin string, fields map[string]events.TelemetryVal
 	if len(clientFields) == 0 {
 		return
 	}
-	clientFields["lastUpdated"] = time.Now().UTC().Format(time.RFC3339)
+	now := time.Now().UTC().Format(time.RFC3339)
+	clientFields["lastUpdated"] = now
 
 	msg, err := marshalWSMessage(msgTypeVehicleUpdate, vehicleUpdatePayload{
 		VehicleID: vehicleID,
 		Fields:    clientFields,
-		Timestamp: time.Now().UTC().Format(time.RFC3339),
+		Timestamp: now,
 	})
 	if err != nil {
 		b.logger.Error("broadcaster.flushNav: marshal failed",


### PR DESCRIPTION
## Summary

Addresses review feedback from #150:

- **Fix double `time.Now()`** in `flushNav` — capture once to prevent timestamp divergence between `lastUpdated` and envelope `Timestamp`
- **Replace `time.Sleep` in test** with channel-based `select`/`time.After` pattern per project rules
- **Add `navAccumulator.Stop()`** — cancels all pending timers on broadcaster shutdown, preventing callbacks from racing with teardown
- **Wire `Stop()` into `Broadcaster.Stop()`**
- **Remove redundant `Clear()` after `Flush()`** in `handleDriveEnded` — Flush already cancels timer and clears state

## Test plan

- [x] New test: `TestNavAccumulator_StopCancelsAllTimers`
- [x] Updated test: `TestNavAccumulator_ClearRemovesState` uses channel instead of sleep
- [ ] CI: lint, test, build, security

🤖 Generated with [Claude Code](https://claude.com/claude-code)