### PR TITLE
MYR-5 Scaffold docs/contracts/ with README and placeholder specs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -132,40 +132,44 @@ cmd/ → internal/* → pkg/sdk (interfaces only)
 - **Test coverage target:** 80%+ on `internal/` packages
 - **No test pollution:** Each test creates its own data, cleans up after itself
 
-## GitHub Issues and Agent Routing
+## Linear Issues and Agent Routing
 
-Every GitHub issue is labeled with the **agent** that should implement it. When picking up an issue, Claude MUST use the specified agent(s) for implementation.
+**Linear is the source of truth for issues and roadmap.** Team key: `MYR` (e.g., `MYR-42`). GitHub is connected to Linear for automatic status sync. Every Linear issue is labeled with the **agent** that should implement it. When picking up an issue, Claude MUST use the specified agent(s) for implementation.
 
 ### Agent Labels
 
-Issues carry one or more `agent:<name>` labels that map directly to `.claude/agents/<name>.md`:
+Issues carry one or more `Agent/<name>` labels in Linear that map directly to `.claude/agents/<name>.md`:
 
-| Label | Agent File | When to Use |
+| Linear Label | Agent File | When to Use |
 |-------|-----------|-------------|
-| `agent:sdk-architect` | `sdk-architect.md` | **Supervisor** — owns requirements + contract docs, reviews every PR for contract adherence, coordinates SDK work. Auto-invoked on contract-relevant paths. |
-| `agent:sdk-typescript` | `sdk-typescript.md` | TypeScript SDK implementation (core, React, RN, Node) |
-| `agent:sdk-swift` | `sdk-swift.md` | Swift SDK implementation (iOS, iPadOS, macOS, watchOS, visionOS) |
-| `agent:contract-tester` | `contract-tester.md` | Contract conformance, FR/NFR, chaos test scenarios |
-| `agent:contract-guard` | `contract-guard.md` | Automated PR gate — blocks contract drift (session + CI) |
-| `agent:go-engineer` | `go-engineer.md` | Go implementation, constrained by SDK contract |
-| `agent:tesla-telemetry` | `tesla-telemetry.md` | Tesla protocol, protobuf, mTLS, cert management |
-| `agent:security` | `security.md` | Security, encryption, data classification (P0/P1/P2), RBAC |
-| `agent:testing` | `testing.md` | Unit tests (contract/FR/NFR/chaos owned by `contract-tester`) |
-| `agent:infra` | `infra.md` | CI/CD, observability stack, deployment, release pipelines |
-| `agent:ux-audit` | `ux-audit.md` | End-user experience quality audit |
+| `Agent/sdk-architect` | `sdk-architect.md` | **Supervisor** — owns requirements + contract docs, reviews every PR for contract adherence, coordinates SDK work. Auto-invoked on contract-relevant paths. |
+| `Agent/sdk-typescript` | `sdk-typescript.md` | TypeScript SDK implementation (core, React, RN, Node) |
+| `Agent/sdk-swift` | `sdk-swift.md` | Swift SDK implementation (iOS, iPadOS, macOS, watchOS, visionOS) |
+| `Agent/contract-tester` | `contract-tester.md` | Contract conformance, FR/NFR, chaos test scenarios |
+| `Agent/contract-guard` | `contract-guard.md` | Automated PR gate — blocks contract drift (session + CI) |
+| `Agent/go-engineer` | `go-engineer.md` | Go implementation, constrained by SDK contract |
+| `Agent/tesla-telemetry` | `tesla-telemetry.md` | Tesla protocol, protobuf, mTLS, cert management |
+| `Agent/security` | `security.md` | Security, encryption, data classification (P0/P1/P2), RBAC |
+| `Agent/testing` | `testing.md` | Unit tests (contract/FR/NFR/chaos owned by `contract-tester`) |
+| `Agent/infra` | `infra.md` | CI/CD, observability stack, deployment, release pipelines |
+| `Agent/ux-audit` | `ux-audit.md` | End-user experience quality audit |
 
-**Retired agents (do not use):** `agent:architect`, `agent:event-system`, `agent:websocket-sdk`, `agent:frontend-integration` — their responsibilities are absorbed by `sdk-architect`, `go-engineer`, `sdk-typescript`, and the SDK pattern (UI is a dumb SDK consumer; no dedicated frontend-integration agent needed).
+### Picking up issues
+
+- Trigger work from Linear via `W` then `O` (Open in Claude Code) — loads the issue into a new session with the configured prompt
+- Or say "pick up MYR-42" in an active session — Claude fetches the issue via the Linear MCP
+- Always fetch the latest issue body via the Linear MCP before implementing; comments may have newer context than the prompt snapshot
 
 ### Workflow (MUST FOLLOW)
 
 When picking up an issue, execute these steps in order:
 
-1. **Read the issue** — title, body, labels, milestone, and acceptance criteria
-2. **Create a feature branch** from main (see Branching Strategy below)
-3. **Identify ALL `agent:*` labels** on the issue — these are your implementation agents
+1. **Read the issue** — title, body, `Agent/*` labels, project, acceptance criteria, anchored FRs/NFRs
+2. **Create a feature branch** from main using Linear's `{{issue.branchName}}` (see Branching Strategy below)
+3. **Identify ALL `Agent/*` labels** on the issue — these are your implementation agents
 4. **Spin up the tagged agents** using the Agent tool following the execution order below
-5. **Commit in reasonable chunks** with the issue number in every commit message
-6. **Open a PR** when the issue is complete, carrying over the issue's labels
+5. **Commit in reasonable chunks** with the Linear identifier in every commit message (`MYR-<num> <verb> <what>`)
+6. **Open a PR** when the issue is complete; Linear auto-links it and transitions the issue to "In Review"
 
 ### Agent Execution Order (ENFORCED)
 
@@ -178,36 +182,36 @@ When picking up an issue, execute these steps in order:
 
 The architect reviews the plan, references FRs/NFRs in `docs/architecture/requirements.md`, and approves or redirects before implementation starts.
 
-**Phase 1 — Design (if `agent:sdk-architect` is explicitly tagged):**
+**Phase 1 — Design (if `Agent/sdk-architect` is explicitly tagged):**
 For planning sessions, architectural decisions, or new contract docs. Wait for its output before implementation.
 
 **Phase 2 — Implementation (spin up in parallel where possible):**
 Launch independent agents in parallel via multiple Agent tool calls in one message:
-- `agent:go-engineer` — server-side Go implementation
-- `agent:sdk-typescript` — TypeScript SDK implementation
-- `agent:sdk-swift` — Swift SDK implementation
-- `agent:tesla-telemetry` — Tesla protocol work
-- `agent:infra` — CI/CD, observability, deployment
+- `Agent/go-engineer` — server-side Go implementation
+- `Agent/sdk-typescript` — TypeScript SDK implementation
+- `Agent/sdk-swift` — Swift SDK implementation
+- `Agent/tesla-telemetry` — Tesla protocol work
+- `Agent/infra` — CI/CD, observability, deployment
 
 **Phase 3 — Contract enforcement (AUTO-INVOKED before PR):**
 `contract-guard` runs session-time against the working diff to catch contract drift before the PR is opened. Runs again at CI-time as a required check.
 
 **Phase 4 — Testing:**
-- `agent:testing` for unit tests
-- `agent:contract-tester` for contract conformance, FR/NFR, and chaos scenarios
+- `Agent/testing` for unit tests
+- `Agent/contract-tester` for contract conformance, FR/NFR, and chaos scenarios
 
-**Phase 5 — Security review (if `agent:security` is tagged):**
+**Phase 5 — Security review (if `Agent/security` is tagged):**
 Reviews for data classification, encryption, RBAC enforcement, audit logging.
 
 **Phase 6 — UX audit (ALWAYS runs):**
-`agent:ux-audit` reviews end-user experience impact.
+`Agent/ux-audit` reviews end-user experience impact.
 
 **Phase 7 — Architect PR review (AUTO-INVOKED on contract-touching PRs):**
 `sdk-architect` performs the final contract-adherence review before merge.
 
 ### Examples
 
-**Issue with labels `agent:sdk-architect, agent:go-engineer, agent:testing`:**
+**Issue with labels `Agent/sdk-architect`, `Agent/go-engineer`, `Agent/testing`:**
 1. `sdk-architect` → defines contract + scopes work (WAIT for output)
 2. `go-engineer` → implements against contract
 3. `contract-guard` → checks diff before PR
@@ -216,7 +220,7 @@ Reviews for data classification, encryption, RBAC enforcement, audit logging.
 6. `ux-audit` → UX impact
 7. `sdk-architect` → final PR review
 
-**Issue with labels `agent:sdk-typescript, agent:contract-tester`:**
+**Issue with labels `Agent/sdk-typescript`, `Agent/contract-tester`:**
 1. `sdk-architect` (auto) → approves the task scope
 2. `sdk-typescript` → implements TS SDK feature
 3. `contract-guard` → checks diff
@@ -224,7 +228,7 @@ Reviews for data classification, encryption, RBAC enforcement, audit logging.
 5. `ux-audit` → UX impact
 6. `sdk-architect` → final review
 
-**Issue with labels `agent:tesla-telemetry, agent:go-engineer, agent:security`:**
+**Issue with labels `Agent/tesla-telemetry`, `Agent/go-engineer`, `Agent/security`:**
 1. `sdk-architect` (auto) → approves scope
 2. `tesla-telemetry` + `go-engineer` in parallel → implement
 3. `contract-guard` → checks diff
@@ -232,16 +236,20 @@ Reviews for data classification, encryption, RBAC enforcement, audit logging.
 5. `ux-audit` → UX impact
 6. `sdk-architect` → final review
 
-### Milestones
+### Projects (SDK v1 roadmap)
 
-| Milestone | Phase | Focus |
-|-----------|-------|-------|
-| `Phase 1: Foundation` | Weeks 1-2 | Project scaffolding, event bus, config, DB layer, CI/CD |
-| `Phase 2: Tesla Integration` | Weeks 2-3 | mTLS, protobuf, telemetry receiver, Fleet API |
-| `Phase 3: Real-Time Processing` | Weeks 3-4 | Drive detection, geocoding, persistence, batch writes |
-| `Phase 4: Client WebSocket` | Weeks 4-5 | Auth, broadcast, SDK interfaces, frontend integration |
-| `Phase 5: Hardening` | Weeks 5-6 | Load tests, security audit, monitoring, deployment |
-| `Phase 6: Test Bench` | Ongoing | TUI dashboard, simulator, developer tooling |
+Work is organized into Linear Projects anchored to `docs/architecture/requirements.md` FRs/NFRs:
+
+| Project | Focus |
+|---------|-------|
+| P1 — Contract foundation | AsyncAPI/OpenAPI specs, JSON Schema, fixtures, data classification |
+| P2 — Backend SDK v1 | Go server: atomicity, 1s nav intervals, AES-256-GCM encryption, RBAC, audit |
+| P3 — TypeScript SDK v1 | Isomorphic SDK: core + React + RN adapters, <75KB bundle |
+| P4 — Swift SDK v1 | iOS 26+/iPadOS/macOS/watchOS/visionOS |
+| P5 — Observability & Scale | OTel, Prometheus/Grafana, 5K-client load tests, SLOs |
+| P6 — Web test bench | Contract/FR/NFR/chaos validation UI |
+| P7 — Frontend integration | Next.js consumes TS SDK (depends on P3) |
+| P8 — Autonomous agent | Linear Agent bot for hands-off issue delegation (post-v1) |
 
 ## Dev Tools (cmd/testbench, cmd/simulator)
 
@@ -280,35 +288,38 @@ go run ./cmd/simulator --server wss://localhost:443 --vehicles 5 --scenario high
 
 ## Branching Strategy (Enforced)
 
-When picking up a GitHub issue, ALWAYS create a feature branch from the latest `main`:
+When picking up a Linear issue, ALWAYS create a feature branch from the latest `main` using **Linear's auto-generated branch name**:
 
 ```bash
-git checkout main && git pull origin main && git checkout -b <issue-number>-<short-kebab-description>
+git checkout main && git pull origin main && git checkout -b <linear-branch-name>
 ```
 
-Branch name format: `<issue-number>-<short-kebab-description>` derived from the issue title.
+Branch name format: use the value Linear provides via `{{issue.branchName}}` in the Claude Code prompt (or copy from the Linear issue via `⌘⇧.`). This ensures GitHub ↔ Linear auto-sync (status transitions, PR linking) works correctly.
 
 Examples:
-- Issue #2 "Implement in-process event bus" → `2-event-bus`
-- Issue #9 "Telemetry receiver: mTLS WebSocket server" → `9-telemetry-receiver`
-- Issue #17 "Security audit" → `17-security-audit`
+- MYR-42 "Implement in-process event bus" → `thomas/myr-42-implement-in-process-event-bus`
+- MYR-9 "Telemetry receiver: mTLS WebSocket server" → `thomas/myr-9-telemetry-receiver-mtls-websocket-server`
+
+Do NOT hand-craft branch names — Linear's format is what the GitHub integration matches against.
 
 ## Commit Strategy
 
 ### Commit Message Format
 
-Every commit message MUST include the issue number and use imperative mood:
+Every commit message MUST include the Linear issue identifier and use imperative mood:
 
 ```
-#<issue> <Imperative verb> <what changed>
+MYR-<num> <Imperative verb> <what changed>
 ```
 
 Examples:
-- `#2 Add Bus interface and channel-based implementation`
-- `#2 Add backpressure handling with drop-oldest policy`
-- `#2 Add comprehensive tests for concurrent pub/sub`
-- `#9 Implement mTLS WebSocket server for Tesla vehicles`
-- `#9 Add protobuf decoding with field validation`
+- `MYR-42 Add Bus interface and channel-based implementation`
+- `MYR-42 Add backpressure handling with drop-oldest policy`
+- `MYR-42 Add comprehensive tests for concurrent pub/sub`
+- `MYR-9 Implement mTLS WebSocket server for Tesla vehicles`
+- `MYR-9 Add protobuf decoding with field validation`
+
+Linear auto-links commits containing `MYR-<num>` to the referenced issue.
 
 ### Commit Cadence
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -132,6 +132,14 @@ cmd/ → internal/* → pkg/sdk (interfaces only)
 - **Test coverage target:** 80%+ on `internal/` packages
 - **No test pollution:** Each test creates its own data, cleans up after itself
 
+## Contracts
+
+The SDK v1 contract surface lives in [`docs/contracts/`](docs/contracts/README.md). It is the authoritative source for every WebSocket message, REST endpoint, persisted field, atomic group, classification label, and state transition exposed by the SDK.
+
+- Read [`docs/contracts/README.md`](docs/contracts/README.md) before touching WebSocket messages, DB schema, or public SDK API surface.
+- Every contract change follows the PR workflow: `sdk-architect` review + `contract-guard` gate, per the Merge Policy above.
+- Contract drift (schema change without doc update, missing P0/P1/P2 label, broken atomic group) blocks merge unconditionally.
+
 ## Linear Issues and Agent Routing
 
 **Linear is the source of truth for issues and roadmap.** Team key: `MYR` (e.g., `MYR-42`). GitHub is connected to Linear for automatic status sync. Every Linear issue is labeled with the **agent** that should implement it. When picking up an issue, Claude MUST use the specified agent(s) for implementation.

--- a/docs/contracts/README.md
+++ b/docs/contracts/README.md
@@ -1,0 +1,97 @@
+# MyRoboTaxi SDK v1 — Contracts
+
+**Status:** Scaffold — individual contracts are TODO placeholders
+**Owner:** `sdk-architect` agent
+**Anchors:** All contracts in this directory trace back to [`docs/architecture/requirements.md`](../architecture/requirements.md).
+
+---
+
+## What lives here
+
+This directory holds the **machine- and human-readable contracts** that bind the telemetry server, the TypeScript SDK, the Swift SDK, and the web/mobile consumers together. Every wire message, persisted field, and public SDK type has its authoritative definition here.
+
+These contracts are the single source of truth. If the code and the contract disagree, the contract wins and the code is a bug.
+
+---
+
+## The seven contract documents
+
+| Document | Purpose | Target artifact |
+|----------|---------|-----------------|
+| [`websocket-protocol.md`](websocket-protocol.md) | Defines every WebSocket message exchanged between server and clients: message shapes, atomic group payloads, connection lifecycle, server→client and client→server message catalogs. | AsyncAPI 3.0 spec |
+| [`rest-api.md`](rest-api.md) | Defines REST endpoints for snapshot fetches, drive history pagination, sharing/invite flows, and user data deletion. | OpenAPI 3.1 spec |
+| [`vehicle-state-schema.md`](vehicle-state-schema.md) | Canonical JSON Schema for vehicle, nav, charge, GPS, and gear state. Declares atomic groups and per-field types, nullability, and units. | JSON Schema draft-2020-12 |
+| [`data-classification.md`](data-classification.md) | Labels every persisted field P0 (public), P1 (sensitive, encrypted at rest), or P2 (sensitive + access-logged). Drives logging redaction rules and encryption boundaries. | Reference table |
+| [`data-lifecycle.md`](data-lifecycle.md) | Retention windows, deletion semantics, audit log format, and the single-source-of-truth rule for every persisted field. | Policy doc + DB schema notes |
+| [`state-machine.md`](state-machine.md) | Connection state machine (`initializing | connecting | connected | disconnected | error`), drive lifecycle states, and per-group data freshness states (`loading | ready | stale | cleared | error`). | State diagrams + transition tables |
+| [`fixtures/README.md`](fixtures/README.md) | Index of canonical payload fixtures used for contract conformance testing across both SDKs and the server. | Fixture library |
+
+---
+
+## How the contracts relate
+
+```
+                     requirements.md (FRs + NFRs)
+                              │
+                              ▼
+                    data-classification.md
+                              │
+              ┌───────────────┼───────────────┐
+              ▼               ▼               ▼
+   vehicle-state-schema   data-lifecycle   state-machine
+              │               │               │
+              └───────┬───────┴───────┬───────┘
+                      ▼               ▼
+              websocket-protocol   rest-api
+                      │               │
+                      └───────┬───────┘
+                              ▼
+                       fixtures/ (canonical payloads)
+                              │
+                              ▼
+                     contract-tester (CI gate)
+```
+
+- **`data-classification.md`** is foundational — it labels fields P0/P1/P2, which every other contract references.
+- **`vehicle-state-schema.md`** defines the shape of state (fields, types, atomic groups). Both the wire protocol and the DB lifecycle reference it.
+- **`data-lifecycle.md`** pins each field to its source of truth (DB row vs. WebSocket event) and retention rules.
+- **`state-machine.md`** defines transitions consumed by both protocols — e.g., `connectionState` affects WebSocket framing, `dataState` per group is exposed over both transports.
+- **`websocket-protocol.md`** and **`rest-api.md`** are the wire-level contracts derived from the above.
+- **`fixtures/`** holds canonical payloads (happy-path and edge-case) validated against the schemas, consumed by `contract-tester`, both SDKs, and the web test bench.
+
+---
+
+## How consumers use these contracts
+
+- **TypeScript SDK (`sdk-typescript`)** generates TypeScript types from `vehicle-state-schema.md` and the AsyncAPI/OpenAPI specs, wires parsers and type guards against the fixtures, and exposes `connectionState` / per-group `dataState` from `state-machine.md`.
+- **Swift SDK (`sdk-swift`)** generates Swift types the same way and consumes the same fixtures for round-trip parse tests.
+- **Go server (`go-engineer`, `tesla-telemetry`)** validates outgoing messages against the schemas and enforces atomic-group debouncing per `NFR-3.1`/`NFR-3.2`.
+- **`contract-tester`** runs the four ship-gate layers (`NFR-3.45`): conformance, FR validation, NFR measurement, chaos. Every layer reads from these contracts.
+- **`contract-guard`** blocks any PR that drifts from these contracts — see merge policy below.
+
+---
+
+## How to update a contract
+
+Contract changes are high-stakes. Follow this workflow:
+
+1. **Open a Linear issue** anchored to the FR/NFR that justifies the change. If no FR/NFR fits, update `requirements.md` first in a separate issue.
+2. **Draft the contract change on a feature branch.** Update the contract doc AND any code/fixtures that depend on it in the same PR. A contract PR that leaves the code out of sync will be blocked.
+3. **Tag `Agent/sdk-architect` on the PR.** The architect performs the Contract Adherence review per `CLAUDE.md` §Merge Policy, verifying:
+   - Atomic group integrity (nav/charge/GPS/gear)
+   - Data classification label for every new persisted field
+   - Latency budget preserved (NFR-3.1)
+   - Change is in v1 scope (not in `requirements.md` §5 Out-of-Scope)
+4. **`contract-guard` must pass.** It runs session-time against the working diff and again in CI as a required check. Drift — missing contract updates, missing P0/P1/P2 labels, broken atomic groups — blocks merge unconditionally.
+5. **Bump SDK versions if the wire changes.** Per `NFR-3.37`, a breaking protocol change requires a major version bump and a migration note.
+6. **Update fixtures.** Any schema or message shape change requires corresponding fixture updates so `contract-tester` stays green.
+
+**Never bypass this workflow.** No `--admin` merges, no silent drift, no contract-then-code-later split PRs.
+
+---
+
+## Related docs
+
+- [`docs/architecture/requirements.md`](../architecture/requirements.md) — FRs and NFRs (the north star)
+- [`docs/architecture/`](../architecture/) — higher-level architecture and design notes
+- [`CLAUDE.md`](../../CLAUDE.md) — agent routing, merge policy, and contract enforcement rules

--- a/docs/contracts/data-classification.md
+++ b/docs/contracts/data-classification.md
@@ -1,0 +1,32 @@
+# Data Classification Contract
+
+**Status:** TODO — placeholder
+**Target artifact:** Classification reference table
+**Owner:** `sdk-architect` agent + `security` agent
+
+## Purpose
+
+Labels every persisted field with a classification tier — **P0**, **P1**, or **P2** — driving logging redaction rules, encryption-at-rest boundaries, access-log requirements, and role-mask visibility. This contract is consulted by `contract-guard` on every PR that adds or modifies a persisted field.
+
+## Classification tiers (per NFR-3.9)
+
+- **P0 (Public)** — may appear in logs, no encryption required. Examples: VIN last-4, vehicle name, vehicle model.
+- **P1 (Sensitive, encrypted at rest)** — AES-256-GCM column-level encryption. Never in logs. Examples: GPS coordinates, destination data, OAuth tokens.
+- **P2 (Sensitive + access-logged)** — P1 requirements plus every read/write writes an access-log entry. Reserved for future fields (e.g., payment info, health data).
+
+## Anchored requirements
+
+- **NFR-3.9** — tier definitions
+- **NFR-3.22** — TLS in transit for all connections
+- **NFR-3.23** — AES-256-GCM column-level encryption for P1 fields (OAuth tokens, GPS coordinates, destination coordinates, route points)
+- **NFR-3.24** — encryption key stored as Fly.io secret (`ENCRYPTION_KEY`)
+- **NFR-3.25** — encryption transparent to SDK (server store layer only)
+- **NFR-3.26** — key rotation strategy (separate contract doc)
+
+## Sections to author (TODO)
+
+- [ ] Per-field classification table (every column in every persisted table)
+- [ ] Redaction rules for each tier (log handlers, error messages, crash reports)
+- [ ] Encryption scope mapping (which P1 fields ↔ which DB columns)
+- [ ] Key rotation procedure reference
+- [ ] Rules for classifying new fields (checklist added by `contract-guard`)

--- a/docs/contracts/data-lifecycle.md
+++ b/docs/contracts/data-lifecycle.md
@@ -1,0 +1,26 @@
+# Data Lifecycle Contract
+
+**Status:** TODO — placeholder
+**Target artifact:** Lifecycle policy doc + DB schema notes
+**Owner:** `sdk-architect` agent
+
+## Purpose
+
+Defines — for every persisted field — its **single source of truth**, its **retention window**, its **deletion semantics**, and the **audit log entry** written on user-initiated deletion. Enforces the "raw telemetry is never persisted as a historical log" principle (`requirements.md` §1 design principle 5).
+
+## Anchored requirements
+
+- **FR-10.1** — user-initiated deletion of all user data (drive history, vehicle snapshot, invites, sessions)
+- **FR-10.2** — immutable audit log entry per deletion (user ID, timestamp, what, initiator)
+- **NFR-3.27** — drive records: 1 year rolling window, background pruning >365 days
+- **NFR-3.28** — raw telemetry NOT persisted; only `Vehicle` snapshot (overwritten) and `Drive.routePoints` (bounded by drive lifetime)
+- **NFR-3.29** — audit logs retained indefinitely
+
+## Sections to author (TODO)
+
+- [ ] Single-source-of-truth mapping (per field: DB vs. WebSocket-only)
+- [ ] Retention windows per table
+- [ ] Deletion cascade and ordering for FR-10.1
+- [ ] Audit log schema (table definition, write path, immutability enforcement)
+- [ ] Pruning job definition (schedule, batch size, failure handling)
+- [ ] Partial-group persistence rules (NFR-3.3 alignment with schema contract)

--- a/docs/contracts/fixtures/README.md
+++ b/docs/contracts/fixtures/README.md
@@ -1,0 +1,22 @@
+# Canonical Fixtures
+
+**Status:** TODO — placeholder
+**Target artifact:** Canonical payload library (JSON files)
+**Owner:** `sdk-architect` agent + `contract-tester` agent
+
+## Purpose
+
+Canonical payload library used for **Layer 1 — Contract Conformance** of the v1 test bench ship-gate (`NFR-3.45`). Every WebSocket message type, REST response, and atomic group payload defined in the other contracts has at least one happy-path fixture here plus edge-case fixtures (nulls, cleared groups, boundary values, malformed messages). Both SDKs parse these fixtures in round-trip tests; the server validates outgoing messages against them in CI.
+
+## Anchored requirements
+
+- **NFR-3.45** — test bench ship-gate, Layer 1 (contract conformance): every WS message type and REST endpoint validated against AsyncAPI/OpenAPI spec; SDK parsing verified against canonical fixtures.
+- **NFR-3.46** — fixtures are consumed by both the TUI test bench (`cmd/testbench`) and the web test bench (`my-robo-taxi-testbench` standalone repo).
+
+## Sections to author (TODO)
+
+- [ ] Directory layout (`websocket/`, `rest/`, `atomic-groups/`, `edge-cases/`)
+- [ ] File naming convention (`<message-type>.<scenario>.json`)
+- [ ] Fixture index (one row per fixture: name, references schema, description)
+- [ ] Round-trip validation harness reference
+- [ ] Rules for adding a fixture when a new message/schema is introduced

--- a/docs/contracts/rest-api.md
+++ b/docs/contracts/rest-api.md
@@ -1,0 +1,25 @@
+# REST API Contract
+
+**Status:** TODO — placeholder
+**Target artifact:** OpenAPI 3.1 specification
+**Owner:** `sdk-architect` agent
+
+## Purpose
+
+Defines the HTTP REST surface served by the telemetry server: cold-page snapshot fetches, paginated drive history, per-drive detail and route playback, sharing/invite flows, viewer management, and user-initiated data deletion. This is the non-streaming half of the SDK contract — the WebSocket protocol handles live state, REST handles snapshots and lifecycle actions.
+
+## Anchored requirements
+
+- **FR-3.2, FR-3.3, FR-3.4** — paginated drive history, per-drive route playback, per-drive stats
+- **FR-5.1, FR-5.2, FR-5.3, FR-5.4, FR-5.5** — invite creation, viewer list, revocation, role model
+- **FR-9.1, FR-9.2** — one-shot paginated fetch + reactive subscription pairing
+- **FR-10.1, FR-10.2** — user-initiated deletion + audit log write
+
+## Sections to author (TODO)
+
+- [ ] Authentication scheme (bearer token from `getToken()` per FR-6.1)
+- [ ] Endpoint catalog: `GET /vehicles/{id}/snapshot`, `GET /vehicles/{id}/drives` (paginated), `GET /drives/{id}`, `GET /drives/{id}/route`, invite endpoints, deletion endpoint
+- [ ] Pagination scheme (cursor-based, page size limits)
+- [ ] Error response envelope (typed error codes per FR-7.1)
+- [ ] RBAC enforcement notes (role field masks per NFR-3.19, NFR-3.20)
+- [ ] OpenAPI document link + generation instructions

--- a/docs/contracts/state-machine.md
+++ b/docs/contracts/state-machine.md
@@ -1,0 +1,29 @@
+# State Machine Contract
+
+**Status:** TODO — placeholder
+**Target artifact:** State diagrams + transition tables
+**Owner:** `sdk-architect` agent
+
+## Purpose
+
+Formalizes the two independent state dimensions the SDK exposes to consumers — **`connectionState`** (transport health) and **`dataState`** (per-atomic-group freshness) — plus the drive lifecycle state machine. This contract is shared verbatim by the TypeScript and Swift SDKs so both expose identical state transitions.
+
+## Anchored requirements
+
+- **FR-8.1** — two independent state dimensions exposed as separate enums
+  - `connectionState`: `initializing | connecting | connected | disconnected | error`
+  - `dataState` per atomic group: `loading | ready | stale | cleared | error`
+- **FR-8.2** — UI composes the two dimensions; SDK never collapses them
+- **FR-3.1** — drive lifecycle: `drive_started | drive_updated | drive_ended`
+- **NFR-3.7, NFR-3.8, NFR-3.9** — freshness is event-driven (no client TTLs); stale only on server-signaled clear or WS disconnect; clears apply atomically per group
+- **NFR-3.10, NFR-3.11** — reconnect behavior drives connection transitions; snapshot re-fetch resets `dataState` to `loading → ready`
+- **NFR-3.12, NFR-3.13** — offline tolerance: cached state visible indefinitely
+
+## Sections to author (TODO)
+
+- [ ] `connectionState` state diagram + transition table (events, guards, actions)
+- [ ] `dataState` per-group state diagram + transition table
+- [ ] Drive lifecycle state machine (idle → driving → ended)
+- [ ] Mapping of server events to state transitions
+- [ ] Reconnect sequence diagram (disconnect → backoff → reconnect → snapshot → resume)
+- [ ] Consumer usage examples (UI composition patterns, NOT implementations)

--- a/docs/contracts/vehicle-state-schema.md
+++ b/docs/contracts/vehicle-state-schema.md
@@ -1,0 +1,27 @@
+# Vehicle State Schema Contract
+
+**Status:** TODO — placeholder
+**Target artifact:** JSON Schema (draft-2020-12)
+**Owner:** `sdk-architect` agent
+
+## Purpose
+
+Canonical shape of vehicle state as consumed by the SDKs and rendered by consumer UIs. Defines every field name, type, unit, nullability rule, and — critically — which fields belong to which **atomic group**. Both the WebSocket protocol and the REST snapshot endpoint return subsets of this schema. Both SDKs generate types from it.
+
+## Anchored requirements
+
+- **FR-1.1, FR-1.2** — telemetry field set (position, speed, heading, gear, battery, charge state, range)
+- **FR-2.1** — nav field set (destinationName, ETA, polyline, origin, etc.)
+- **FR-4.2** — vehicle-scoped API signatures
+- **NFR-3.1** — atomic groups declared here: `navigation`, `charge`, `gps`, `gear`
+- **NFR-3.3, NFR-3.4** — self-consistency rules (partial groups are invalid)
+- **NFR-3.5** — every UI-rendered field is persisted and returned in the snapshot
+
+## Sections to author (TODO)
+
+- [ ] Root `VehicleState` schema
+- [ ] Atomic group sub-schemas: `navigation`, `charge`, `gps`, `gear`
+- [ ] Per-field types, units (km vs mi, kW vs kWh, degrees), nullability rules
+- [ ] Atomic-group consistency predicates (NFR-3.3)
+- [ ] Field-to-source-of-truth mapping (see `data-lifecycle.md`)
+- [ ] JSON Schema file link + type generation targets (TS via json-schema-to-typescript, Swift via generator)

--- a/docs/contracts/websocket-protocol.md
+++ b/docs/contracts/websocket-protocol.md
@@ -1,0 +1,28 @@
+# WebSocket Protocol Contract
+
+**Status:** TODO — placeholder
+**Target artifact:** AsyncAPI 3.0 specification
+**Owner:** `sdk-architect` agent
+
+## Purpose
+
+Defines every WebSocket message exchanged between the telemetry server and SDK clients (TypeScript and Swift). This contract binds the server's broadcaster to the SDKs' parsers and is the authoritative source for message shapes, atomic group payloads, connection handshake, heartbeat/ping cadence, and error framing.
+
+## Anchored requirements
+
+- **FR-1.1, FR-1.2, FR-1.3** — live vehicle telemetry stream (position, speed, heading, gear, charge, extensibility)
+- **FR-2.1, FR-2.2, FR-2.3** — nav group streaming and atomic clear on cancel
+- **FR-3.1** — live drive events (`drive_started`, `drive_updated`, `drive_ended`)
+- **FR-8.1, FR-8.2** — `connectionState` surface and independent `dataState` per group
+- **NFR-3.1, NFR-3.2** — server-side atomic grouping with 200ms debounce
+- **NFR-3.10, NFR-3.11** — reconnect handshake, snapshot resume
+
+## Sections to author (TODO)
+
+- [ ] Connection handshake (auth header, token in first frame, server accept/reject)
+- [ ] Server→client message catalog (one entry per atomic group + drive events + clears + error frames)
+- [ ] Client→server message catalog (subscribe, unsubscribe, ping)
+- [ ] Heartbeat / keepalive cadence
+- [ ] Close codes and reconnection semantics
+- [ ] AsyncAPI document link + generation instructions
+- [ ] Canonical example payloads (link to `fixtures/`)


### PR DESCRIPTION
## Summary

- Creates `docs/contracts/` with an authoritative README (seven-doc index, relationship diagram, consumer map, update workflow) and seven placeholder files anchored to FRs/NFRs from `docs/architecture/requirements.md`.
- Placeholders have stub headers + TODO section lists only — no real spec content. Subsequent P1 issues fill each file.
- Adds a "Contracts" section to `CLAUDE.md` pointing at `docs/contracts/README.md` and naming the `sdk-architect` + `contract-guard` enforcement path.

Closes MYR-5.

## Placeholder files

- `websocket-protocol.md` → AsyncAPI 3.0 (anchors: FR-1.x, FR-2.x, FR-3.1, FR-8.x, NFR-3.1/3.2/3.10/3.11)
- `rest-api.md` → OpenAPI 3.1 (anchors: FR-3.2/3.3/3.4, FR-5.x, FR-9.x, FR-10.1)
- `vehicle-state-schema.md` → JSON Schema draft-2020-12 (anchors: FR-1.x, FR-2.x, NFR-3.1, NFR-3.5)
- `data-classification.md` → P0/P1/P2 tiers (anchors: NFR-3.9, NFR-3.22–3.26)
- `data-lifecycle.md` → retention/deletion/audit (anchors: FR-10.1/10.2, NFR-3.27–3.29)
- `state-machine.md` → connection/drive/data states (anchors: FR-8.1/8.2, FR-3.1, NFR-3.10–3.13)
- `fixtures/README.md` → canonical payload library (anchors: NFR-3.45, NFR-3.46)

## Test plan

- [ ] Directory structure exists post-merge
- [ ] README links resolve (all internal links use relative paths to existing docs)
- [ ] `contract-guard` recognizes the paths (smoke test once the guard is implemented)

🤖 Generated with [Claude Code](https://claude.com/claude-code)