### PR TITLE
Add PR template with agent attribution and contract impact

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,28 @@
+## Summary
+<!-- 1-3 bullet points describing what changed and why -->
+
+## Linear Issue
+<!-- Link to the Linear issue (e.g., MYR-42) -->
+
+## Agents Involved
+<!-- Check which agents contributed to this PR -->
+- [ ] `sdk-architect` — contract/architecture review
+- [ ] `go-engineer` — Go backend implementation
+- [ ] `sdk-typescript` — TypeScript SDK
+- [ ] `sdk-swift` — Swift SDK
+- [ ] `tesla-telemetry` — Tesla protocol/protobuf
+- [ ] `contract-tester` — contract/FR/NFR tests
+- [ ] `contract-guard` — drift enforcement
+- [ ] `security` — encryption/RBAC/classification
+- [ ] `testing` — unit tests
+- [ ] `infra` — CI/CD/deployment
+- [ ] `ux-audit` — UX review
+
+## Contract Impact
+<!-- Does this PR change any contract surface? If yes, which docs were updated? -->
+- [ ] No contract impact
+- [ ] Updated: <!-- e.g., websocket-protocol.md, data-classification.md -->
+
+## Test Plan
+<!-- How was this tested? -->
+


### PR DESCRIPTION
## Summary
- Adds `.github/pull_request_template.md` so every PR shows which agents contributed and whether contract surfaces were changed
- Gives visibility into agent involvement directly on GitHub

## Agents Involved
- [x] `sdk-architect` — designed the template structure

## Contract Impact
- [x] No contract impact

## Test Plan
- [ ] Open a new PR after merge and verify the template auto-populates

🤖 Generated with [Claude Code](https://claude.com/claude-code)