### PR TITLE
MYR-11 Author websocket-protocol.md and AsyncAPI 3.0 spec

### DIFF
--- a/docs/contracts/README.md
+++ b/docs/contracts/README.md
@@ -18,13 +18,24 @@ These contracts are the single source of truth. If the code and the contract dis
 
 | Document | Purpose | Target artifact |
 |----------|---------|-----------------|
-| [`websocket-protocol.md`](websocket-protocol.md) | Defines every WebSocket message exchanged between server and clients: message shapes, atomic group payloads, connection lifecycle, server→client and client→server message catalogs. | AsyncAPI 3.0 spec |
+| [`websocket-protocol.md`](websocket-protocol.md) | Defines every WebSocket message exchanged between server and clients: message shapes, atomic group payloads, connection lifecycle, server→client and client→server message catalogs. | AsyncAPI 3.0 spec at [`specs/websocket.asyncapi.yaml`](specs/websocket.asyncapi.yaml) + JSON Schemas under [`schemas/`](schemas/) |
 | [`rest-api.md`](rest-api.md) | Defines REST endpoints for snapshot fetches, drive history pagination, sharing/invite flows, and user data deletion. | OpenAPI 3.1 spec |
-| [`vehicle-state-schema.md`](vehicle-state-schema.md) | Canonical JSON Schema for vehicle, nav, charge, GPS, and gear state. Declares atomic groups and per-field types, nullability, and units. | JSON Schema draft-2020-12 |
+| [`vehicle-state-schema.md`](vehicle-state-schema.md) | Canonical JSON Schema for vehicle, nav, charge, GPS, and gear state. Declares atomic groups and per-field types, nullability, and units. | JSON Schema draft-2020-12 at [`schemas/vehicle-state.schema.json`](schemas/vehicle-state.schema.json) |
 | [`data-classification.md`](data-classification.md) | Labels every persisted field P0 (public), P1 (sensitive, encrypted at rest), or P2 (sensitive + access-logged). Drives logging redaction rules and encryption boundaries. | Reference table |
 | [`data-lifecycle.md`](data-lifecycle.md) | Retention windows, deletion semantics, audit log format, and the single-source-of-truth rule for every persisted field. | Policy doc + DB schema notes |
 | [`state-machine.md`](state-machine.md) | Connection state machine (`initializing | connecting | connected | disconnected | error`), drive lifecycle states, and per-group data freshness states (`loading | ready | stale | cleared | error`). | State diagrams + transition tables |
 | [`fixtures/README.md`](fixtures/README.md) | Index of canonical payload fixtures used for contract conformance testing across both SDKs and the server. | Fixture library |
+
+### Machine-readable specs and schemas
+
+The human-readable contract docs above are paired with machine-readable specs and schemas that SDK code generators, contract-tester, and contract-guard consume directly. Drift between a markdown doc and its machine twin is a CI failure.
+
+| File | Anchored doc | Purpose |
+|------|--------------|---------|
+| [`specs/websocket.asyncapi.yaml`](specs/websocket.asyncapi.yaml) | [`websocket-protocol.md`](websocket-protocol.md) | AsyncAPI 3.0 description of the `/api/ws` channel, every server↔client message, and the auth security scheme. References JSON Schemas via `$ref` rather than duplicating payloads. |
+| [`schemas/vehicle-state.schema.json`](schemas/vehicle-state.schema.json) | [`vehicle-state-schema.md`](vehicle-state-schema.md) | Canonical `VehicleState` shape, atomic-group annotations, classification labels. |
+| [`schemas/ws-envelope.schema.json`](schemas/ws-envelope.schema.json) | [`websocket-protocol.md`](websocket-protocol.md) §3 | Top-level envelope (`type` discriminator, `payload`, planned `seq`/`ts`). |
+| [`schemas/ws-messages.schema.json`](schemas/ws-messages.schema.json) | [`websocket-protocol.md`](websocket-protocol.md) §4–§5 | Per-message payload schemas: auth, vehicle_update, drive_started, drive_ended, connectivity, heartbeat, error, plus the planned subscribe/unsubscribe/ping/pong control messages. |
 
 ---
 

--- a/docs/contracts/fixtures/README.md
+++ b/docs/contracts/fixtures/README.md
@@ -20,3 +20,26 @@ Canonical payload library used for **Layer 1 — Contract Conformance** of the v
 - [ ] Fixture index (one row per fixture: name, references schema, description)
 - [ ] Round-trip validation harness reference
 - [ ] Rules for adding a fixture when a new message/schema is introduced
+
+## Planned WebSocket fixtures (MYR-11 forward-references)
+
+The [`websocket-protocol.md`](../websocket-protocol.md) catalog (added in MYR-11) links every server->client and client->server message type to a fixture under `fixtures/websocket/`. The fixture files themselves are not yet authored — the table below is the TODO checklist for the follow-up issue that will land them. Until then, the markdown links resolve to 404 in the rendered docs; this is intentional and tracked in `websocket-protocol.md` §10 follow-up #9.
+
+| Planned path | Source schema | Description |
+|--------------|---------------|-------------|
+| `websocket/auth.json` | `schemas/ws-messages.schema.json#/$defs/AuthPayload` | Happy-path client->server auth frame |
+| `websocket/vehicle_update.charge.json` | `schemas/ws-messages.schema.json#/$defs/VehicleUpdatePayload` | Atomic charge group update (chargeLevel + estimatedRange) |
+| `websocket/vehicle_update.gps.json` | `schemas/ws-messages.schema.json#/$defs/VehicleUpdatePayload` | Atomic GPS group update (latitude + longitude + heading) |
+| `websocket/vehicle_update.gear.json` | `schemas/ws-messages.schema.json#/$defs/VehicleUpdatePayload` | Atomic gear group update (gearPosition + derived status) |
+| `websocket/vehicle_update.nav_active.json` | `schemas/ws-messages.schema.json#/$defs/VehicleUpdatePayload` | Atomic navigation group update with active route, ETA, polyline |
+| `websocket/vehicle_update.nav_clear.json` | `schemas/ws-messages.schema.json#/$defs/VehicleUpdatePayload` | Atomic navigation clear (Tesla nav cancelled — every nav field null) |
+| `websocket/vehicle_update.route.json` | `schemas/ws-messages.schema.json#/$defs/VehicleUpdatePayload` | Drive route accumulator flush carrying `routeCoordinates` |
+| `websocket/drive_started.json` | `schemas/ws-messages.schema.json#/$defs/DriveStartedPayload` | Drive detector announcing a new drive |
+| `websocket/drive_ended.json` | `schemas/ws-messages.schema.json#/$defs/DriveEndedPayload` | Completed drive with summary stats |
+| `websocket/connectivity.online.json` | `schemas/ws-messages.schema.json#/$defs/ConnectivityPayload` | Vehicle mTLS connection came online |
+| `websocket/connectivity.offline.json` | `schemas/ws-messages.schema.json#/$defs/ConnectivityPayload` | Vehicle mTLS connection went offline |
+| `websocket/heartbeat.json` | `schemas/ws-messages.schema.json#/$defs/HeartbeatPayload` | Bare server keepalive frame |
+| `websocket/error.auth_failed.json` | `schemas/ws-messages.schema.json#/$defs/ErrorPayload` | Auth failure error frame (precedes close code 1008) |
+| `websocket/error.auth_timeout.json` | `schemas/ws-messages.schema.json#/$defs/ErrorPayload` | Auth deadline exceeded error frame |
+
+> **Owner note:** Fixture authoring is non-blocking for MYR-11 (the spec captures the wire shape exhaustively via JSON Schemas + AsyncAPI). The follow-up issue must (a) emit each fixture above, (b) validate it against its schema in CI, and (c) wire the fixtures into the `contract-tester` round-trip suite for both the TypeScript and Swift SDKs.

--- a/docs/contracts/schemas/ws-envelope.schema.json
+++ b/docs/contracts/schemas/ws-envelope.schema.json
@@ -1,0 +1,63 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://myrobotaxi.com/schemas/ws-envelope.schema.json",
+  "title": "WebSocketEnvelope",
+  "description": "Top-level envelope for every WebSocket frame exchanged between the telemetry server and SDK clients. Both directions (server->client and client->server) use this envelope. The `type` discriminator selects the payload schema; `seq` and `ts` are server-authoritative fields populated only on server->client frames to support snapshot resume per NFR-3.11.",
+  "type": "object",
+  "required": ["type"],
+  "additionalProperties": false,
+  "properties": {
+    "type": {
+      "type": "string",
+      "description": "Discriminator naming the message type. Server->client values: 'vehicle_update', 'drive_started', 'drive_ended', 'connectivity', 'heartbeat', 'error'. Client->server values: 'auth' (only message currently accepted; 'subscribe', 'unsubscribe', 'ping' are reserved for follow-up — see websocket-protocol.md §10).",
+      "enum": [
+        "auth",
+        "vehicle_update",
+        "drive_started",
+        "drive_ended",
+        "connectivity",
+        "heartbeat",
+        "error",
+        "subscribe",
+        "unsubscribe",
+        "ping",
+        "pong"
+      ],
+      "x-classification": "P0"
+    },
+    "payload": {
+      "description": "Type-specific payload object. Schema is selected by the `type` discriminator. Omitted on bare control frames such as 'heartbeat'. See websocket-protocol.md §4 (server->client) and §5 (client->server) for the catalog.",
+      "x-classification": "P0"
+    },
+    "seq": {
+      "type": "integer",
+      "minimum": 0,
+      "description": "PLANNED (not yet emitted by the server). Monotonic per-connection sequence number assigned by the server, starting at 0 on each successful authenticated session. Used by clients on reconnect to request snapshot-resume from sequence N (NFR-3.11). Until the server is extended to emit `seq`, clients MUST tolerate its absence and treat every frame as gap-free. Tracked by follow-up issue (see websocket-protocol.md §10 open questions).",
+      "x-classification": "P0"
+    },
+    "ts": {
+      "type": "string",
+      "format": "date-time",
+      "description": "PLANNED top-level timestamp (not yet emitted by the server). Server-authoritative ISO 8601 UTC timestamp for the envelope itself, distinct from any payload-internal `timestamp` field. Clients MUST tolerate its absence today; the per-payload `timestamp` field (e.g., `vehicle_update.timestamp`, `drive_started.timestamp`) carries the same information in v1.0. Tracked by follow-up issue.",
+      "x-classification": "P0"
+    }
+  },
+  "$defs": {
+    "MessageType": {
+      "type": "string",
+      "enum": [
+        "auth",
+        "vehicle_update",
+        "drive_started",
+        "drive_ended",
+        "connectivity",
+        "heartbeat",
+        "error",
+        "subscribe",
+        "unsubscribe",
+        "ping",
+        "pong"
+      ]
+    }
+  }
+}

--- a/docs/contracts/schemas/ws-messages.schema.json
+++ b/docs/contracts/schemas/ws-messages.schema.json
@@ -1,0 +1,255 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://myrobotaxi.com/schemas/ws-messages.schema.json",
+  "title": "WebSocketMessages",
+  "description": "JSON Schemas for every WebSocket payload exchanged between the telemetry server and SDK clients. The vehicle_update payload's `fields` map is a subset of the canonical VehicleState (see vehicle-state.schema.json); per-field types/units/classification live there and are NOT duplicated here. This file holds the wire-only shapes (envelope payloads, control messages, errors).",
+  "$defs": {
+    "AuthPayload": {
+      "type": "object",
+      "description": "Client->server authentication payload. The first frame on every WebSocket connection MUST be {type: 'auth', payload: {token: '...'}}. The token is opaque to the server's transport layer and is validated by the configured Authenticator (JWT in production, NoopAuthenticator in dev). Anchored by FR-6.1, NFR-3.21.",
+      "required": ["token"],
+      "additionalProperties": false,
+      "properties": {
+        "token": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Bearer-style session token resolved by the consumer's getToken() callback (FR-6.1). Server validates via Authenticator.ValidateToken. P1 — never log this value (data-classification.md §1.2).",
+          "x-classification": "P1"
+        }
+      }
+    },
+    "VehicleUpdatePayload": {
+      "type": "object",
+      "description": "Server->client telemetry update for a single vehicle. The `fields` map carries one or more atomic-group members from VehicleState (see vehicle-state.schema.json). Each call to broadcast carries fields from at most ONE atomic group plus optionally non-grouped fields delivered alongside (NFR-3.1). Anchored by FR-1.1, FR-1.2, FR-1.3, FR-2.1, FR-2.2, FR-2.3, NFR-3.1, NFR-3.2.",
+      "required": ["vehicleId", "fields", "timestamp"],
+      "additionalProperties": false,
+      "properties": {
+        "vehicleId": {
+          "type": "string",
+          "description": "Opaque database cuid for the vehicle (NOT the VIN). All SDK API calls use this ID per FR-4.2. VINs are P0 with mandatory last-4 redaction in logs (data-classification.md §2.1) and MUST NOT appear in this payload under any circumstance.",
+          "x-classification": "P0"
+        },
+        "fields": {
+          "type": "object",
+          "description": "Map of field name -> value. Field names and per-field classifications are defined in vehicle-state.schema.json. A single vehicle_update message contains the members of at most ONE atomic group (navigation, charge, gps, gear) plus any individually-delivered fields (speed, odometerMiles, interiorTemp, exteriorTemp, fsdMilesToday, locationName, locationAddress, lastUpdated). Server explicitly clears a navigation field by sending it as JSON null; the SDK MUST atomically null all members of the affected group per NFR-3.9. The optional `routeCoordinates` field (array of [lng, lat] pairs) carries an active drive's accumulated GPS trail and is not part of a normal atomic group — it is always paired with an active drive and routed to dataState.gps.",
+          "additionalProperties": true,
+          "x-classification": "mixed (per-field; see vehicle-state.schema.json)"
+        },
+        "timestamp": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Server-authoritative ISO 8601 UTC timestamp for this update. Not the Tesla telemetry emission time — this is the server's `time.Now().UTC()` at broadcast (or the event's CreatedAt for non-nav fields). Drives the SDK's lastUpdated state and feeds NFR-3.11 snapshot resume.",
+          "x-classification": "P0"
+        }
+      }
+    },
+    "DriveStartedPayload": {
+      "type": "object",
+      "description": "Server->client message announcing the start of a new drive. Anchored by FR-3.1.",
+      "required": ["vehicleId", "driveId", "startLocation", "timestamp"],
+      "additionalProperties": false,
+      "properties": {
+        "vehicleId": {
+          "type": "string",
+          "description": "Opaque vehicle cuid.",
+          "x-classification": "P0"
+        },
+        "driveId": {
+          "type": "string",
+          "description": "Opaque drive cuid. Matches the eventual Drive row's id when the drive completes and is persisted.",
+          "x-classification": "P0"
+        },
+        "startLocation": {
+          "type": "object",
+          "description": "GPS coordinates where the drive began. Encrypted at rest in the eventual Drive row but transported plaintext over WSS (NFR-3.22, NFR-3.25).",
+          "required": ["latitude", "longitude"],
+          "additionalProperties": false,
+          "properties": {
+            "latitude": {
+              "type": "number",
+              "minimum": -90,
+              "maximum": 90,
+              "x-classification": "P1",
+              "x-encrypted-at-rest": true
+            },
+            "longitude": {
+              "type": "number",
+              "minimum": -180,
+              "maximum": 180,
+              "x-classification": "P1",
+              "x-encrypted-at-rest": true
+            }
+          }
+        },
+        "timestamp": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Server-authoritative ISO 8601 UTC timestamp at which the drive detector (`internal/drives/`) declared the drive started.",
+          "x-classification": "P0"
+        }
+      }
+    },
+    "DriveEndedPayload": {
+      "type": "object",
+      "description": "Server->client message announcing a completed drive that passed the micro-drive filter (state-machine.md §3.5). The summary fields here are for immediate UI feedback; the full FR-3.4 drive record (energy used, FSD miles, intervention count, start/end charge level, start/end addresses, full route polyline) is fetched via REST `/drives/{id}` (see rest-api.md). Anchored by FR-3.1, FR-3.4.",
+      "required": ["vehicleId", "driveId", "distance", "duration", "avgSpeed", "maxSpeed", "timestamp"],
+      "additionalProperties": false,
+      "properties": {
+        "vehicleId": {
+          "type": "string",
+          "description": "Opaque vehicle cuid.",
+          "x-classification": "P0"
+        },
+        "driveId": {
+          "type": "string",
+          "description": "Opaque drive cuid (matches the persisted Drive row id).",
+          "x-classification": "P0"
+        },
+        "distance": {
+          "type": "number",
+          "minimum": 0,
+          "description": "Total distance driven in miles. Computed as the haversine sum of route points at drive completion.",
+          "x-unit": "miles",
+          "x-classification": "P0"
+        },
+        "duration": {
+          "type": "string",
+          "description": "Drive duration as a Go time.Duration string (e.g., '12m34.5s'). The SDK SHOULD parse this and re-expose it as seconds/minutes for consumers.",
+          "x-classification": "P0"
+        },
+        "avgSpeed": {
+          "type": "number",
+          "minimum": 0,
+          "x-unit": "mph",
+          "x-classification": "P0"
+        },
+        "maxSpeed": {
+          "type": "number",
+          "minimum": 0,
+          "x-unit": "mph",
+          "x-classification": "P0"
+        },
+        "timestamp": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Server-authoritative ISO 8601 UTC timestamp at which the drive detector declared the drive ended.",
+          "x-classification": "P0"
+        }
+      }
+    },
+    "ConnectivityPayload": {
+      "type": "object",
+      "description": "Server->client signal that a vehicle's mTLS connection to the telemetry server has changed state. This is vehicle<->server connectivity, NOT client<->server connectivity (the latter is implicit in the WebSocket connection itself). Anchored by FR-1.3 (extensibility) and FR-8.1 (state surface).",
+      "required": ["vehicleId", "online", "timestamp"],
+      "additionalProperties": false,
+      "properties": {
+        "vehicleId": {
+          "type": "string",
+          "x-classification": "P0"
+        },
+        "online": {
+          "type": "boolean",
+          "description": "True when the vehicle has an active mTLS Tesla Fleet Telemetry stream into the server. False on disconnect (e.g., vehicle asleep, network drop).",
+          "x-classification": "P0"
+        },
+        "timestamp": {
+          "type": "string",
+          "format": "date-time",
+          "x-classification": "P0"
+        }
+      }
+    },
+    "HeartbeatPayload": {
+      "type": "object",
+      "description": "Server->client keepalive frame. The current server emits a bare envelope `{\"type\":\"heartbeat\"}` with NO payload (heartbeat.go computes the message once at init). The optional `timestamp` field is reserved for future use. Anchored by NFR-3.10 (reconnect cadence).",
+      "additionalProperties": false,
+      "properties": {
+        "timestamp": {
+          "type": "string",
+          "format": "date-time",
+          "description": "OPTIONAL and NOT currently emitted. Reserved for future use to expose server clock to clients (would also enable client clock-skew detection). Tracked by follow-up issue.",
+          "x-classification": "P0"
+        }
+      }
+    },
+    "ErrorPayload": {
+      "type": "object",
+      "description": "Server->client error frame. The server sends this for transport-level failures the client must surface (auth rejection, auth timeout). The Code field is a stable enum that consumers branch on (FR-7.1) — never string-match the Message field. Anchored by FR-7.1, FR-7.3.",
+      "required": ["code", "message"],
+      "additionalProperties": false,
+      "properties": {
+        "code": {
+          "type": "string",
+          "description": "Stable typed error code from the catalog in websocket-protocol.md §6. Consumer SDKs map these to typed errors per FR-7.1.",
+          "enum": [
+            "auth_failed",
+            "auth_timeout",
+            "permission_denied",
+            "vehicle_not_owned",
+            "rate_limited",
+            "internal_error"
+          ],
+          "x-classification": "P0"
+        },
+        "message": {
+          "type": "string",
+          "description": "Human-readable description for logs and developer tooling. P0 BUT MUST NOT contain P1 values (no GPS, no addresses, no tokens, no emails, no VINs unless redacted to ***XXXX). Per data-classification.md §2.1-2.2, error message construction sites MUST use opaque IDs only.",
+          "x-classification": "P0"
+        }
+      }
+    },
+    "SubscribePayload": {
+      "type": "object",
+      "description": "PLANNED (not yet accepted by the server). Client->server request to begin or resume streaming a specific vehicle. Today the server implicitly subscribes the client to ALL vehicles owned by the authenticated user as part of the auth handshake (handler.go authenticateClient -> Authenticator.GetUserVehicles). Adding explicit subscribe/unsubscribe is tracked as a follow-up issue (see websocket-protocol.md §10). When implemented, `sinceSeq` enables per-vehicle snapshot-resume per NFR-3.11.",
+      "required": ["vehicleId"],
+      "additionalProperties": false,
+      "properties": {
+        "vehicleId": {
+          "type": "string",
+          "x-classification": "P0"
+        },
+        "sinceSeq": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "PLANNED. Last envelope `seq` the client successfully processed for this vehicle. The server uses this to choose between snapshot-resume (replay missed frames) and full-refresh (REST snapshot fetch + live stream from current seq).",
+          "x-classification": "P0"
+        }
+      }
+    },
+    "UnsubscribePayload": {
+      "type": "object",
+      "description": "PLANNED (not yet accepted by the server). Client->server request to stop receiving updates for a specific vehicle. Tracked as a follow-up issue.",
+      "required": ["vehicleId"],
+      "additionalProperties": false,
+      "properties": {
+        "vehicleId": {
+          "type": "string",
+          "x-classification": "P0"
+        }
+      }
+    },
+    "PingPayload": {
+      "type": "object",
+      "description": "PLANNED (not yet accepted by the server). Client->server ping. Today, browser clients rely on the server's outbound `heartbeat` frames and the underlying WebSocket protocol's PING/PONG control frames (handled transparently by coder/websocket) to detect liveness. An app-level `ping` is a follow-up to enable client-driven keepalive on platforms where the WebSocket library does not expose RFC 6455 PING/PONG (some React Native runtimes, watchOS background sessions).",
+      "additionalProperties": false,
+      "properties": {
+        "nonce": {
+          "type": "string",
+          "description": "Optional opaque value echoed back in the corresponding `pong` for round-trip latency measurement.",
+          "x-classification": "P0"
+        }
+      }
+    },
+    "PongPayload": {
+      "type": "object",
+      "description": "PLANNED. Server->client response to a client-initiated `ping`. Echoes the nonce.",
+      "additionalProperties": false,
+      "properties": {
+        "nonce": {
+          "type": "string",
+          "x-classification": "P0"
+        }
+      }
+    }
+  }
+}

--- a/docs/contracts/specs/websocket.asyncapi.yaml
+++ b/docs/contracts/specs/websocket.asyncapi.yaml
@@ -1,0 +1,451 @@
+asyncapi: 3.0.0
+info:
+  title: MyRoboTaxi Telemetry WebSocket Protocol
+  version: 1.0.0
+  description: |
+    Real-time WebSocket channel that binds the Go telemetry server's broadcaster
+    (`internal/ws/`) to the MyRoboTaxi TypeScript and Swift SDKs. This document
+    is the machine-readable twin of `docs/contracts/websocket-protocol.md`. The
+    markdown is the human source of truth; this YAML is consumed by AsyncAPI
+    tooling, contract-tester fixtures, and SDK code generators.
+
+    All payload shapes are defined in sibling JSON Schemas under
+    `docs/contracts/schemas/` and referenced via `$ref`. Schemas are NOT
+    duplicated in this file — drift between schemas and this spec is a CI
+    failure (contract-guard).
+
+    Anchored requirements: FR-1.1, FR-1.2, FR-1.3, FR-2.1, FR-2.2, FR-2.3,
+    FR-3.1, FR-8.1, FR-8.2, NFR-3.1, NFR-3.2, NFR-3.10, NFR-3.11.
+  contact:
+    name: sdk-architect
+    url: https://github.com/tnando/my-robo-taxi-telemetry/tree/main/docs/contracts
+  license:
+    name: Proprietary
+  tags:
+    - name: contract
+      description: P1 contract foundation (Linear project)
+    - name: sdk
+
+defaultContentType: application/json
+
+servers:
+  production:
+    host: api.myrobotaxi.com
+    pathname: /api/ws
+    protocol: wss
+    description: |
+      Production telemetry server. WSS (TLS, NFR-3.22). Browser clients connect
+      from `https://app.myrobotaxi.com`. Origin enforcement is configured via
+      `WebSocketConfig.AllowedOrigins`.
+    security:
+      - $ref: '#/components/securitySchemes/sessionToken'
+  development:
+    host: localhost:8080
+    pathname: /api/ws
+    protocol: ws
+    description: |
+      Local development server. Plain WS allowed. Use --dev mode to bypass
+      auth via NoopAuthenticator (accepts any non-empty token).
+    security:
+      - $ref: '#/components/securitySchemes/sessionToken'
+
+channels:
+  vehicleStream:
+    address: /api/ws
+    title: Vehicle telemetry stream
+    description: |
+      Single bidirectional WebSocket channel per authenticated client. After the
+      auth handshake completes, the server implicitly subscribes the client to
+      every vehicle returned by `Authenticator.GetUserVehicles(userID)` and
+      streams updates for them. Per-vehicle subscribe/unsubscribe is PLANNED
+      (see websocket-protocol.md §10).
+
+      Anchored: FR-1.1, FR-1.2, FR-1.3, FR-2.1, FR-2.2, FR-2.3, FR-3.1,
+      FR-8.1, NFR-3.1, NFR-3.2.
+    messages:
+      auth:
+        $ref: '#/components/messages/Auth'
+      vehicleUpdate:
+        $ref: '#/components/messages/VehicleUpdate'
+      driveStarted:
+        $ref: '#/components/messages/DriveStarted'
+      driveEnded:
+        $ref: '#/components/messages/DriveEnded'
+      connectivity:
+        $ref: '#/components/messages/Connectivity'
+      heartbeat:
+        $ref: '#/components/messages/Heartbeat'
+      error:
+        $ref: '#/components/messages/Error'
+      subscribe:
+        $ref: '#/components/messages/Subscribe'
+      unsubscribe:
+        $ref: '#/components/messages/Unsubscribe'
+      ping:
+        $ref: '#/components/messages/Ping'
+      pong:
+        $ref: '#/components/messages/Pong'
+
+operations:
+  receiveServerEvents:
+    action: receive
+    channel:
+      $ref: '#/channels/vehicleStream'
+    title: Receive server events
+    summary: SDK consumes telemetry, drive, connectivity, heartbeat, and error frames from the server.
+    description: |
+      The server pushes one envelope per logical event. Multiple atomic-group
+      payloads may arrive interleaved across vehicles, but a single envelope
+      always corresponds to AT MOST ONE atomic group (NFR-3.1) plus optionally
+      individually-delivered fields (speed, odometerMiles, etc.).
+
+      Anchored: NFR-3.1, NFR-3.2 (200ms target debounce; current
+      implementation uses 500ms — see websocket-protocol.md §3.2).
+    messages:
+      - $ref: '#/channels/vehicleStream/messages/vehicleUpdate'
+      - $ref: '#/channels/vehicleStream/messages/driveStarted'
+      - $ref: '#/channels/vehicleStream/messages/driveEnded'
+      - $ref: '#/channels/vehicleStream/messages/connectivity'
+      - $ref: '#/channels/vehicleStream/messages/heartbeat'
+      - $ref: '#/channels/vehicleStream/messages/error'
+      - $ref: '#/channels/vehicleStream/messages/pong'
+
+  sendClientControl:
+    action: send
+    channel:
+      $ref: '#/channels/vehicleStream'
+    title: Send client control frames
+    summary: SDK sends auth (and, in future, subscribe/unsubscribe/ping) frames to the server.
+    description: |
+      The first frame on every connection MUST be `auth`. Today, the server
+      ignores all post-auth client frames (`internal/ws/client.go:74-90`). The
+      `subscribe`, `unsubscribe`, and `ping` operations are reserved for a
+      follow-up implementation (see websocket-protocol.md §10).
+    messages:
+      - $ref: '#/channels/vehicleStream/messages/auth'
+      - $ref: '#/channels/vehicleStream/messages/subscribe'
+      - $ref: '#/channels/vehicleStream/messages/unsubscribe'
+      - $ref: '#/channels/vehicleStream/messages/ping'
+
+components:
+  securitySchemes:
+    sessionToken:
+      type: userPassword
+      description: |
+        Bearer-style session token resolved by the consumer's `getToken()`
+        callback (FR-6.1). Token is validated by the configured Authenticator
+        (`internal/ws/auth.go`). Today the JWT validator (production) checks
+        signature, issuer, audience, and expiry against the Auth config.
+
+        IMPORTANT: the token is delivered in the FIRST WebSocket frame
+        (`{"type":"auth","payload":{"token":"..."}}`), NOT as an
+        `Authorization` HTTP header on the upgrade request. Browsers cannot
+        set arbitrary headers on the WebSocket upgrade, so the in-band frame
+        is the only portable channel. The server enforces a 5-second deadline
+        for receiving this frame (`HandlerConfig.AuthTimeout`).
+
+  messages:
+    Auth:
+      name: auth
+      title: Auth (client->server)
+      summary: First-frame authentication handshake.
+      description: |
+        Sent by the client immediately after the WebSocket connection is
+        upgraded. The server validates the token, loads the user's vehicles,
+        and registers the client. Failure closes the socket with WebSocket
+        close code 1008 (Policy Violation) preceded by an `error` frame whose
+        `code` is `auth_failed` or `auth_timeout`.
+
+        Anchored: FR-6.1, FR-6.2, NFR-3.21.
+      contentType: application/json
+      payload:
+        type: object
+        required: [type, payload]
+        properties:
+          type:
+            const: auth
+          payload:
+            $ref: 'https://myrobotaxi.com/schemas/ws-messages.schema.json#/$defs/AuthPayload'
+      examples:
+        - name: happy-path
+          summary: Valid session token
+          payload:
+            type: auth
+            payload:
+              token: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...
+
+    VehicleUpdate:
+      name: vehicle_update
+      title: Vehicle update (server->client)
+      summary: Telemetry field update for a single vehicle, scoped to one atomic group.
+      description: |
+        The primary server->client payload. Each frame carries the members of
+        AT MOST ONE atomic group (navigation, charge, gps, gear) plus
+        individually-delivered fields (speed, odometerMiles, interiorTemp,
+        exteriorTemp, fsdMilesToday, locationName, locationAddress,
+        lastUpdated, routeCoordinates).
+
+        Per-field types, units, nullability, and classification are defined
+        in vehicle-state.schema.json. This message intentionally references
+        the canonical schema rather than re-declaring fields.
+
+        Atomic clears: the server signals nav cancellation by sending the
+        affected nav fields with JSON `null` values inside `fields`. The SDK
+        MUST atomically null ALL fields in the group per NFR-3.9 (see
+        state-machine.md §2.4 constraint 3 and Rule CG-SM-3).
+
+        Anchored: FR-1.1, FR-1.2, FR-1.3, FR-2.1, FR-2.2, FR-2.3, NFR-3.1,
+        NFR-3.2, NFR-3.5.
+      contentType: application/json
+      payload:
+        type: object
+        required: [type, payload]
+        properties:
+          type:
+            const: vehicle_update
+          payload:
+            $ref: 'https://myrobotaxi.com/schemas/ws-messages.schema.json#/$defs/VehicleUpdatePayload'
+      examples:
+        - name: charge-group
+          summary: Atomic charge update (chargeLevel + estimatedRange)
+          payload:
+            type: vehicle_update
+            payload:
+              vehicleId: clxyz1234567890abcdef
+              fields:
+                chargeLevel: 78
+                estimatedRange: 245
+                lastUpdated: '2026-04-13T18:22:01Z'
+              timestamp: '2026-04-13T18:22:01Z'
+        - name: nav-clear
+          summary: Atomic navigation clear (Tesla nav cancelled)
+          payload:
+            type: vehicle_update
+            payload:
+              vehicleId: clxyz1234567890abcdef
+              fields:
+                destinationName: null
+                destinationLatitude: null
+                destinationLongitude: null
+                etaMinutes: null
+                tripDistanceRemaining: null
+                navRouteCoordinates: null
+                lastUpdated: '2026-04-13T18:22:05Z'
+              timestamp: '2026-04-13T18:22:05Z'
+
+    DriveStarted:
+      name: drive_started
+      title: Drive started (server->client)
+      summary: Drive detector announced a new drive for a vehicle.
+      description: Anchored by FR-3.1.
+      contentType: application/json
+      payload:
+        type: object
+        required: [type, payload]
+        properties:
+          type:
+            const: drive_started
+          payload:
+            $ref: 'https://myrobotaxi.com/schemas/ws-messages.schema.json#/$defs/DriveStartedPayload'
+      examples:
+        - name: happy-path
+          payload:
+            type: drive_started
+            payload:
+              vehicleId: clxyz1234567890abcdef
+              driveId: clmno9876543210zyxw
+              startLocation:
+                latitude: 37.7749
+                longitude: -122.4194
+              timestamp: '2026-04-13T18:22:00Z'
+
+    DriveEnded:
+      name: drive_ended
+      title: Drive ended (server->client)
+      summary: Completed drive that passed the micro-drive filter.
+      description: |
+        Summary fields for immediate UI feedback. Full FR-3.4 fields are
+        retrieved via REST `/drives/{id}` after this frame.
+
+        Anchored: FR-3.1, FR-3.4.
+      contentType: application/json
+      payload:
+        type: object
+        required: [type, payload]
+        properties:
+          type:
+            const: drive_ended
+          payload:
+            $ref: 'https://myrobotaxi.com/schemas/ws-messages.schema.json#/$defs/DriveEndedPayload'
+      examples:
+        - name: happy-path
+          payload:
+            type: drive_ended
+            payload:
+              vehicleId: clxyz1234567890abcdef
+              driveId: clmno9876543210zyxw
+              distance: 12.4
+              duration: 24m18s
+              avgSpeed: 30.5
+              maxSpeed: 65.2
+              timestamp: '2026-04-13T18:46:18Z'
+
+    Connectivity:
+      name: connectivity
+      title: Connectivity (server->client)
+      summary: Vehicle<->server (Tesla mTLS) connection state changed.
+      description: |
+        Distinct from client<->server connectivity (which is implicit in the
+        WebSocket itself). When the underlying vehicle goes offline, the
+        broadcaster also clears any pending nav accumulator state for that
+        VIN to prevent stale nav data on reconnect.
+      contentType: application/json
+      payload:
+        type: object
+        required: [type, payload]
+        properties:
+          type:
+            const: connectivity
+          payload:
+            $ref: 'https://myrobotaxi.com/schemas/ws-messages.schema.json#/$defs/ConnectivityPayload'
+      examples:
+        - name: vehicle-online
+          payload:
+            type: connectivity
+            payload:
+              vehicleId: clxyz1234567890abcdef
+              online: true
+              timestamp: '2026-04-13T18:22:00Z'
+
+    Heartbeat:
+      name: heartbeat
+      title: Heartbeat (server->client)
+      summary: Bare server keepalive frame. Default cadence 15 seconds.
+      description: |
+        Server emits this frame to all connected clients on a fixed interval
+        (default 15s, configurable via `WebSocketConfig.HeartbeatInterval`).
+        The wire form is a bare envelope `{"type":"heartbeat"}` with NO
+        `payload` field — heartbeat.go pre-marshals the message once at init
+        for zero-allocation broadcast. The optional `timestamp` field shown
+        in the schema is RESERVED for a future revision.
+
+        Clients use heartbeats to detect silent server-side disconnects: if
+        no frame (heartbeat or otherwise) arrives within 2x the heartbeat
+        interval, the SDK SHOULD initiate the reconnect sequence per
+        NFR-3.10. The SDK MUST NOT use the heartbeat as a freshness signal —
+        per NFR-3.7, dataState staleness is event-driven, not time-based.
+      contentType: application/json
+      payload:
+        type: object
+        required: [type]
+        properties:
+          type:
+            const: heartbeat
+          payload:
+            $ref: 'https://myrobotaxi.com/schemas/ws-messages.schema.json#/$defs/HeartbeatPayload'
+      examples:
+        - name: bare
+          payload:
+            type: heartbeat
+
+    Error:
+      name: error
+      title: Error (server->client)
+      summary: Typed error frame. Consumers branch on `code`, never on `message`.
+      description: |
+        Anchored by FR-7.1, FR-7.3. The server sends this frame for transport
+        and authorization failures. After sending an `auth_failed` or
+        `auth_timeout` error, the server immediately closes the WebSocket
+        with close code 1008 (Policy Violation).
+
+        See websocket-protocol.md §6 for the close-code matrix.
+      contentType: application/json
+      payload:
+        type: object
+        required: [type, payload]
+        properties:
+          type:
+            const: error
+          payload:
+            $ref: 'https://myrobotaxi.com/schemas/ws-messages.schema.json#/$defs/ErrorPayload'
+      examples:
+        - name: auth-failed
+          payload:
+            type: error
+            payload:
+              code: auth_failed
+              message: invalid token
+        - name: auth-timeout
+          payload:
+            type: error
+            payload:
+              code: auth_timeout
+              message: 'hub.authenticateClient: auth timeout'
+
+    Subscribe:
+      name: subscribe
+      title: Subscribe (client->server, PLANNED)
+      summary: PLANNED — explicit per-vehicle subscription with optional snapshot resume.
+      description: |
+        NOT yet accepted by the server. Today, the server implicitly
+        subscribes the client to ALL vehicles returned by
+        `Authenticator.GetUserVehicles(userID)` during the auth handshake.
+        See websocket-protocol.md §10 follow-up.
+      contentType: application/json
+      payload:
+        type: object
+        required: [type, payload]
+        properties:
+          type:
+            const: subscribe
+          payload:
+            $ref: 'https://myrobotaxi.com/schemas/ws-messages.schema.json#/$defs/SubscribePayload'
+
+    Unsubscribe:
+      name: unsubscribe
+      title: Unsubscribe (client->server, PLANNED)
+      summary: PLANNED — release a per-vehicle subscription.
+      description: NOT yet accepted by the server. Tracked as a follow-up.
+      contentType: application/json
+      payload:
+        type: object
+        required: [type, payload]
+        properties:
+          type:
+            const: unsubscribe
+          payload:
+            $ref: 'https://myrobotaxi.com/schemas/ws-messages.schema.json#/$defs/UnsubscribePayload'
+
+    Ping:
+      name: ping
+      title: Ping (client->server, PLANNED)
+      summary: PLANNED — application-level ping for round-trip latency probing.
+      description: |
+        NOT yet accepted by the server. Today, RFC 6455 PING/PONG frames are
+        handled transparently by the underlying coder/websocket library, and
+        the server's outbound `heartbeat` provides keepalive in the other
+        direction.
+      contentType: application/json
+      payload:
+        type: object
+        required: [type]
+        properties:
+          type:
+            const: ping
+          payload:
+            $ref: 'https://myrobotaxi.com/schemas/ws-messages.schema.json#/$defs/PingPayload'
+
+    Pong:
+      name: pong
+      title: Pong (server->client, PLANNED)
+      summary: PLANNED — response to a client `ping`.
+      description: NOT yet emitted by the server. Tracked as a follow-up.
+      contentType: application/json
+      payload:
+        type: object
+        required: [type]
+        properties:
+          type:
+            const: pong
+          payload:
+            $ref: 'https://myrobotaxi.com/schemas/ws-messages.schema.json#/$defs/PongPayload'

--- a/docs/contracts/websocket-protocol.md
+++ b/docs/contracts/websocket-protocol.md
@@ -1,28 +1,814 @@
 # WebSocket Protocol Contract
 
-**Status:** TODO — placeholder
-**Target artifact:** AsyncAPI 3.0 specification
+**Status:** Draft -- v1
+**Target artifact:** AsyncAPI 3.0 specification at [`specs/websocket.asyncapi.yaml`](specs/websocket.asyncapi.yaml)
 **Owner:** `sdk-architect` agent
+**Last updated:** 2026-04-13
 
 ## Purpose
 
-Defines every WebSocket message exchanged between the telemetry server and SDK clients (TypeScript and Swift). This contract binds the server's broadcaster to the SDKs' parsers and is the authoritative source for message shapes, atomic group payloads, connection handshake, heartbeat/ping cadence, and error framing.
+Defines every WebSocket message exchanged between the telemetry server (`internal/ws/`) and SDK clients (TypeScript, Swift, web, mobile). This contract is the authoritative source for:
+
+- The connection handshake (auth frame, token validation, accept/reject)
+- Server->client and client->server message catalogs
+- The envelope schema (type discriminator, payload, planned sequence/timestamp)
+- Heartbeat cadence and close-code semantics
+- Reconnection and snapshot-resume rules
+
+The markdown is the human source of truth. Its machine-readable twin is [`specs/websocket.asyncapi.yaml`](specs/websocket.asyncapi.yaml). Per-message JSON Schemas live alongside in [`schemas/`](schemas/). Drift between this doc, the AsyncAPI spec, the schemas, and `internal/ws/` is a CI failure ([`contract-guard`](../../CLAUDE.md#merge-policy-non-negotiable)).
 
 ## Anchored requirements
 
-- **FR-1.1, FR-1.2, FR-1.3** — live vehicle telemetry stream (position, speed, heading, gear, charge, extensibility)
-- **FR-2.1, FR-2.2, FR-2.3** — nav group streaming and atomic clear on cancel
-- **FR-3.1** — live drive events (`drive_started`, `drive_updated`, `drive_ended`)
-- **FR-8.1, FR-8.2** — `connectionState` surface and independent `dataState` per group
-- **NFR-3.1, NFR-3.2** — server-side atomic grouping with 200ms debounce
-- **NFR-3.10, NFR-3.11** — reconnect handshake, snapshot resume
+| ID | Requirement | Where it lands in this doc |
+|----|-------------|----------------------------|
+| **FR-1.1** | Live telemetry stream: position, speed, heading, gear | §4.1 vehicle_update; §4.1.3 GPS group; §4.1.5 gear group |
+| **FR-1.2** | Live charge state: battery level, charge state, range | §4.1.4 charge group |
+| **FR-1.3** | Architecture allows new telemetry fields without architectural change | §4.1 (extensibility), §10 |
+| **FR-2.1** | Nav: destination, ETA, distance, polyline, origin, trip start | §4.1.2 navigation group |
+| **FR-2.2** | Nav fields delivered as an atomic group | §4.1.2; §3.2 atomic-group rule |
+| **FR-2.3** | Nav cancellation clears the entire group atomically | §4.1.2 nav clear; §3.3 clear semantics |
+| **FR-3.1** | Live drive events: drive_started, drive_updated, drive_ended | §4.2 drive_started; §4.3 drive_ended; §4.1.6 drive_updated routing |
+| **FR-6.1** | SDK accepts a getToken() callback | §2.1 handshake; §5.1 auth message |
+| **FR-7.1** | Typed error codes (no string-matching) | §6.1 error frame; §6.2 close codes |
+| **FR-8.1** | connectionState surface | §2 handshake; §7 reconnect |
+| **FR-8.2** | dataState per atomic group, independent | §4.1 group routing; §4.5 group/clear signaling |
+| **NFR-3.1** | Atomic grouping of related fields | §3.2 atomic-group rule; §4.1 catalog |
+| **NFR-3.2** | 200ms server-side debounce window | §3.2.1 debounce note (and 500ms drift) |
+| **NFR-3.10** | Reconnect with exponential backoff (1s/2x/30s/jitter) | §7.1 backoff parameters |
+| **NFR-3.11** | Reconnect re-fetches DB snapshot, resumes live stream | §7.2 reconnect sequence; §7.3 snapshot-resume semantics |
+| **NFR-3.21** | Vehicle ownership enforced on every subscription | §2.2 server-side ownership check |
+| **NFR-3.22** | TLS in transit (WSS for browsers/apps) | §2 transport |
 
-## Sections to author (TODO)
+---
 
-- [ ] Connection handshake (auth header, token in first frame, server accept/reject)
-- [ ] Server→client message catalog (one entry per atomic group + drive events + clears + error frames)
-- [ ] Client→server message catalog (subscribe, unsubscribe, ping)
-- [ ] Heartbeat / keepalive cadence
-- [ ] Close codes and reconnection semantics
-- [ ] AsyncAPI document link + generation instructions
-- [ ] Canonical example payloads (link to `fixtures/`)
+## 1. Transport and URL
+
+### 1.1 Endpoint
+
+| Field | Value |
+|-------|-------|
+| Path | `/api/ws` (registered in [`internal/ws/handler.go`](../../internal/ws/handler.go)) |
+| Production scheme | `wss://` (TLS termination at the edge, NFR-3.22) |
+| Local dev scheme | `ws://` (allowed only for `localhost`/`127.0.0.1` origins) |
+| HTTP method | `GET` (WebSocket upgrade) |
+| Content type | `application/json`, framed as WebSocket text messages |
+| Upgrade library | [`github.com/coder/websocket`](https://github.com/coder/websocket) (NEVER `gorilla/websocket` -- unmaintained per `CLAUDE.md`) |
+
+### 1.2 Origin enforcement
+
+The server passes `WebSocketConfig.AllowedOrigins` to `websocket.AcceptOptions.OriginPatterns`. Cross-origin requests from origins not in the allow-list are rejected with HTTP 403 BEFORE the upgrade completes. There is no in-band error frame for this case -- the client receives an HTTP error response on the upgrade attempt.
+
+| Mode | Default | Source |
+|------|---------|--------|
+| Production | Configured allow-list (`https://app.myrobotaxi.com`, etc.) | `cfg.WebSocket().AllowedOrigins` |
+| Dev | `["*"]` (allow all) | `cmd/telemetry-server/main.go` fallback |
+
+### 1.3 Per-IP connection cap
+
+The handler enforces an optional per-IP connection limit (`HandlerConfig.MaxConnectionsPerIP`). When the cap is reached, new upgrade attempts are rejected with HTTP 429 BEFORE the WebSocket is opened. SDKs MUST treat HTTP 429 on the upgrade as `rate_limited` and apply the standard reconnect backoff (NFR-3.10). The client IP is resolved from the leftmost `X-Forwarded-For` entry when present (`internal/ws/handler.go:resolveClientIP`).
+
+---
+
+## 2. Connection handshake
+
+> **Anchored:** FR-6.1, FR-6.2, NFR-3.21, NFR-3.22, FR-8.1.
+
+### 2.1 Sequence
+
+```
+Client                                       Server
+  |                                            |
+  |--- HTTP GET /api/ws (Upgrade: websocket) ->|
+  |                                            |
+  |                              [origin check]
+  |                              [per-IP cap check]
+  |                                            |
+  |<-- HTTP 101 Switching Protocols -----------|
+  |                                            |
+  |                              [auth deadline starts: 5s]
+  |                                            |
+  |--- {"type":"auth","payload":{"token":"..."}} ->
+  |                                            |
+  |                              [Authenticator.ValidateToken]
+  |                              [Authenticator.GetUserVehicles]
+  |                                            |
+  |  -- success path --                        |
+  |                              [Hub.Register, start read+write pumps]
+  |                                            |
+  |   <-- vehicle_update / drive_* / heartbeat |   (live stream begins)
+  |                                            |
+  |  -- failure path --                        |
+  |<-- {"type":"error","payload":{"code":"auth_failed",...}}
+  |<-- WebSocket close code 1008 (policy violation)
+```
+
+Implementation: [`internal/ws/handler.go`](../../internal/ws/handler.go) `handleUpgrade` -> `authenticateClient`.
+
+### 2.2 Auth frame requirements
+
+1. **First frame.** The client MUST send the auth frame as its FIRST WebSocket frame after the upgrade. Any other frame type before auth is treated as an auth failure.
+2. **No HTTP header.** The token MUST NOT be sent as an `Authorization` header on the upgrade request. Browsers cannot set arbitrary headers on the WebSocket upgrade, so the in-band frame is the only portable channel. (Native clients MAY send a duplicate header for defense-in-depth, but the server ignores it.)
+3. **Deadline.** The server enforces a 5-second deadline (`HandlerConfig.AuthTimeout`, default `5*time.Second`) for the auth frame. Exceeding the deadline produces error code `auth_timeout` and close code 1008.
+4. **Token format.** Opaque to the WebSocket layer. The configured `Authenticator` validates it. Production uses [`internal/auth.NewJWTAuthenticator`](../../internal/auth) which checks signature, issuer, audience, and expiry. Dev uses [`ws.NoopAuthenticator`](../../internal/ws/auth.go) which accepts any non-empty token.
+5. **Vehicle resolution.** On a valid token, the server calls `Authenticator.GetUserVehicles(ctx, userID)` and stores the resulting vehicle IDs on the `Client` struct. The set is a snapshot of ownership at handshake time; per-broadcast ownership filtering uses this snapshot (§4.4).
+6. **Token redaction.** The token is **P1** per [`data-classification.md`](data-classification.md) §1.2. It MUST NOT appear in any structured log, error message, metric label, or crash report. The server never logs the token value -- only the resulting `userID` (P0) and `vehicle_count` (P0).
+
+### 2.3 Auth result envelope
+
+The server does **not** send a success acknowledgement frame. Successful auth is implicit: the next frames the client receives are normal `vehicle_update` / `heartbeat` traffic.
+
+The server **does** send an explicit error frame on failure (§6.1) followed by a close frame with code 1008. The SDK MUST tolerate the absence of an acknowledgement on success.
+
+> **PLANNED:** A future revision will introduce an `auth_ok` frame echoing the resolved `userID`, vehicle count, and (when sequence numbers ship per NFR-3.11) the initial server `seq`. Tracked as a follow-up (§10).
+
+### 2.4 Connection state mapping
+
+The handshake drives the following [`state-machine.md`](state-machine.md) transitions:
+
+| Wire event | `connectionState` transition | Notes |
+|------------|------------------------------|-------|
+| HTTP 101 + `auth` frame sent | `connecting` (no change yet) | Token in flight |
+| `Authenticator.ValidateToken` returns success | `connecting -> connected` (C-3) | Reset retry counter, start heartbeat watchdog |
+| `Authenticator.ValidateToken` returns error | `connecting -> error` (C-8) | Surface `auth_failed` |
+| Auth deadline exceeded | `connecting -> error` (C-8) | Surface `auth_timeout` |
+| HTTP 429 on upgrade | `connecting -> disconnected` (C-4) | Apply backoff |
+| HTTP 403 on upgrade (origin) | `connecting -> error` (C-5) | Terminal -- consumer must fix origin config |
+
+---
+
+## 3. Envelope schema
+
+> **Anchored:** FR-1.3 (extensibility), NFR-3.1, NFR-3.11.
+>
+> **Schema reference:** [`schemas/ws-envelope.schema.json`](schemas/ws-envelope.schema.json) and [`schemas/ws-messages.schema.json`](schemas/ws-messages.schema.json).
+
+### 3.1 Wire shape
+
+Every frame is a JSON object with the following top-level keys:
+
+```jsonc
+{
+  "type": "vehicle_update",   // string discriminator (required)
+  "payload": { ... },         // type-specific object (omitted on bare control frames)
+  "seq":  42,                 // PLANNED: monotonic per-connection sequence (NFR-3.11)
+  "ts":   "2026-04-13T18:22:01Z" // PLANNED: server-authoritative envelope timestamp
+}
+```
+
+| Field | Required (today) | Direction | Description |
+|-------|------------------|-----------|-------------|
+| `type` | YES | both | Discriminator. See §4 (server->client) and §5 (client->server) for the catalog. |
+| `payload` | Per-type | both | Type-specific object. Omitted on `heartbeat` (server emits a bare envelope -- see [`internal/ws/heartbeat.go`](../../internal/ws/heartbeat.go)). |
+| `seq` | NO (PLANNED) | server->client | Monotonic per-connection sequence number. NOT yet emitted. See §3.3. |
+| `ts` | NO (PLANNED) | server->client | Server-authoritative ISO 8601 UTC envelope timestamp. NOT yet emitted at the envelope level; `vehicle_update.payload.timestamp`, `drive_started.payload.timestamp`, etc. carry the same information today. See §3.3. |
+
+The Go struct that produces this envelope is [`internal/ws/messages.go:wsMessage`](../../internal/ws/messages.go):
+
+```go
+type wsMessage struct {
+    Type    string          `json:"type"`
+    Payload json.RawMessage `json:"payload,omitempty"`
+}
+```
+
+### 3.2 Atomic-group rule (NFR-3.1)
+
+A single `vehicle_update` frame's `payload.fields` map MUST contain members of **at most one** atomic group, plus any number of individually-delivered fields. The atomic groups are defined in [`vehicle-state-schema.md`](vehicle-state-schema.md) §2:
+
+| Group | Members |
+|-------|---------|
+| `navigation` | `destinationName`, `destinationAddress`*, `destinationLatitude`, `destinationLongitude`, `originLatitude`, `originLongitude`, `etaMinutes`, `tripDistanceRemaining`, `navRouteCoordinates` |
+| `charge` | `chargeLevel`, `estimatedRange` |
+| `gps` | `latitude`, `longitude`, `heading` |
+| `gear` | `gearPosition`, `status` |
+
+\* `destinationAddress` is currently spec-only (MYR-24); see [`vehicle-state-schema.md`](vehicle-state-schema.md) §1.1.
+
+Individually-delivered fields (no atomic group): `speed`, `odometerMiles`, `interiorTemp`, `exteriorTemp`, `fsdMilesToday`, `locationName`, `locationAddress`, `lastUpdated`, and the drive-only `routeCoordinates` field (§4.1.6).
+
+The server enforces this rule by routing nav-group fields through the `navAccumulator` ([`internal/ws/nav_accumulator.go`](../../internal/ws/nav_accumulator.go)) and flushing them as a single message; non-nav fields broadcast immediately. SDKs MUST validate the rule on receipt and treat a frame containing fields from two different atomic groups as a contract violation (log + reject).
+
+#### 3.2.1 Debounce window (NFR-3.2)
+
+NFR-3.2 specifies a **200ms** server-side debounce window. The current navigation accumulator implementation uses **500ms** (`defaultNavFlushInterval` in [`internal/ws/nav_accumulator.go`](../../internal/ws/nav_accumulator.go) line 12) because Tesla emits `RouteLine` and `MinutesToArrival` on independent ~1-second tickers and a 200ms window produces incomplete batches in practice. This drift between requirements text and implementation is documented in [`vehicle-state-schema.md`](vehicle-state-schema.md) §2.1 ("Server-side implementation: ... 500ms flush window") and is tracked in §10 of this doc.
+
+For the purpose of the protocol contract: SDKs MUST NOT assume timing finer than the debounce window. Two updates to the same atomic group within 500ms MAY be coalesced into one frame.
+
+### 3.3 Sequence and timestamp (NFR-3.11) -- gap from spec
+
+The Linear AC for MYR-11 calls for a "type discriminator, sequence, timestamp" envelope. Today only the `type` discriminator and per-payload `timestamp` field exist. The envelope-level `seq` and `ts` fields are **PLANNED** for a follow-up issue (see §10). The reasons:
+
+1. The current server has no per-connection sequence counter ([`internal/ws/client.go:Client`](../../internal/ws/client.go) struct exposes `userID`, `vehicleIDs`, `send`, `remoteAddr`, `hub`, `logger` -- no `nextSeq` field).
+2. Reconnect-resume is currently implemented entirely client-side via REST snapshot fetch (see [`state-machine.md`](state-machine.md) §5), which establishes a consistent baseline without needing wire-level sequence numbers. The trade-off: clients cannot detect dropped frames within a connection.
+3. Adding `seq` requires a coordinated server + SDK change AND a fixture migration. It is a v1.x extension, not a v1.0 ship blocker.
+
+This doc and the AsyncAPI spec describe the **target shape** including `seq` and `ts` so SDK consumers can plan for it. Until the server emits these fields, SDKs MUST tolerate their absence -- per JSON's open-object semantics, an unknown future field appearing on the wire is also acceptable.
+
+> **SDK MUST:** Treat `seq` and `ts` as optional today. When they appear, prefer envelope `ts` over payload `timestamp` for ordering.
+>
+> **SDK SHOULD:** Maintain a per-connection "highest seq seen" counter as soon as the server begins emitting `seq`, and pass it as `subscribe.sinceSeq` (§5.2) on reconnect.
+
+### 3.4 Frame size
+
+The server enforces a 4 KiB read limit on inbound (client->server) frames via `Conn.SetReadLimit(readLimit)` ([`internal/ws/client.go:readLimit`](../../internal/ws/client.go) line 19). The expected client traffic is exclusively `auth` plus future control frames -- 4 KiB is generous.
+
+Outbound (server->client) frames have no hard cap. Long `navRouteCoordinates` payloads from city-scale Tesla routes are the largest realistic frames (~5-15 KB serialized). SDKs MUST tolerate frames up to 1 MB without truncation.
+
+---
+
+## 4. Server -> client message catalog
+
+> **Anchored:** FR-1.1, FR-1.2, FR-1.3, FR-2.1, FR-2.2, FR-2.3, FR-3.1, FR-7.1, FR-8.1, FR-8.2, NFR-3.1, NFR-3.2.
+
+This section is the wire-level catalog. Field-level types, units, nullability, and per-field data classification live in [`vehicle-state-schema.md`](vehicle-state-schema.md) and the canonical JSON Schema ([`schemas/vehicle-state.schema.json`](schemas/vehicle-state.schema.json)) -- they are not duplicated here.
+
+### Catalog summary
+
+| `type` | Direction | Source (Go) | Atomic group | Triggers `dataState` transition | Fixture |
+|--------|-----------|-------------|--------------|---------------------------------|---------|
+| `vehicle_update` | server->client | [`broadcaster.go` / `nav_broadcast.go` / `route_broadcast.go`](../../internal/ws/) | one of `navigation`, `charge`, `gps`, `gear`, or none | per-group `ready/cleared/error -> ready` | [`fixtures/websocket/vehicle_update.charge.json`](fixtures/websocket/vehicle_update.charge.json) (TODO) |
+| `drive_started` | server->client | [`broadcaster.go:handleDriveStarted`](../../internal/ws/broadcaster.go) | n/a | drive lifecycle `idle -> driving` | [`fixtures/websocket/drive_started.json`](fixtures/websocket/drive_started.json) (TODO) |
+| `drive_ended` | server->client | [`broadcaster.go:handleDriveEnded`](../../internal/ws/broadcaster.go) | n/a | drive lifecycle `driving -> ended` | [`fixtures/websocket/drive_ended.json`](fixtures/websocket/drive_ended.json) (TODO) |
+| `connectivity` | server->client | [`broadcaster.go:handleConnectivity`](../../internal/ws/broadcaster.go) | n/a | none (vehicle<->server signal, not SDK<->server) | [`fixtures/websocket/connectivity.json`](fixtures/websocket/connectivity.json) (TODO) |
+| `heartbeat` | server->client | [`heartbeat.go`](../../internal/ws/heartbeat.go) | n/a | resets liveness watchdog | [`fixtures/websocket/heartbeat.json`](fixtures/websocket/heartbeat.json) (TODO) |
+| `error` | server->client | [`handler.go:sendError`](../../internal/ws/handler.go) | n/a | `connecting -> error` (during handshake) | [`fixtures/websocket/error.auth_failed.json`](fixtures/websocket/error.auth_failed.json) (TODO) |
+
+All fixture paths are TODO entries in [`fixtures/README.md`](fixtures/README.md). Adding the actual fixture JSON files is tracked in a follow-up (see §10).
+
+### 4.1 `vehicle_update`
+
+> **Anchored:** FR-1.1, FR-1.2, FR-1.3, FR-2.1, FR-2.2, FR-2.3, NFR-3.1, NFR-3.2, NFR-3.5, NFR-3.9.
+>
+> **Schema:** [`schemas/ws-messages.schema.json#/$defs/VehicleUpdatePayload`](schemas/ws-messages.schema.json)
+
+The primary telemetry payload. One frame carries field updates for one vehicle, scoped to at most one atomic group.
+
+```jsonc
+{
+  "type": "vehicle_update",
+  "payload": {
+    "vehicleId": "clxyz1234567890abcdef",
+    "fields": {
+      // members of AT MOST one atomic group + any individually-delivered fields
+    },
+    "timestamp": "2026-04-13T18:22:01Z"
+  }
+}
+```
+
+| Field | Type | Classification | Notes |
+|-------|------|----------------|-------|
+| `payload.vehicleId` | `string` (cuid) | **P0** | Opaque DB ID. NEVER VIN. FR-4.2. |
+| `payload.fields` | `object` | mixed (per-field) | See [`vehicle-state-schema.md`](vehicle-state-schema.md) §1.1 for per-field classification. |
+| `payload.timestamp` | `string` (ISO 8601 UTC) | **P0** | Server `time.Now().UTC()` at broadcast (or telemetry `CreatedAt` for non-nav fields). |
+
+#### 4.1.1 Field name translation
+
+The wire field names in `payload.fields` are the **frontend** field names, not Tesla's protobuf names. The server translates internal telemetry names to client names in [`internal/ws/field_mapping.go:internalToClientField`](../../internal/ws/field_mapping.go):
+
+| Tesla / internal name | Wire name |
+|-----------------------|-----------|
+| `soc` | `chargeLevel` |
+| `gear` | `gearPosition` |
+| `odometer` | `odometerMiles` |
+| `insideTemp` | `interiorTemp` |
+| `outsideTemp` | `exteriorTemp` |
+| `minutesToArrival` | `etaMinutes` |
+| `milesToArrival` | `tripDistanceRemaining` |
+| `fsdMilesSinceReset` | `fsdMilesToday` |
+| `location` | split into `latitude` + `longitude` |
+| `destinationLocation` | split into `destinationLatitude` + `destinationLongitude` |
+| `originLocation` | split into `originLatitude` + `originLongitude` |
+| `routeLine` (Tesla polyline) | `navRouteCoordinates` (decoded `[lng, lat]` array) |
+| `hvacFanSpeed` | `fanSpeed` |
+
+Integer rounding is applied server-side to fields listed in `integerFields` (`speed`, `heading`, `chargeLevel`, `estimatedRange`, `etaMinutes`, `interiorTemp`, `exteriorTemp`, `odometerMiles`, ...).
+
+#### 4.1.2 Navigation group
+
+> **Anchored:** FR-2.1, FR-2.2, FR-2.3, NFR-3.1, NFR-3.2, NFR-3.9.
+> **dataState target:** `dataState.navigation` (per [`state-machine.md`](state-machine.md) §2)
+> **Fixture:** [`fixtures/websocket/vehicle_update.nav_active.json`](fixtures/websocket/vehicle_update.nav_active.json) (TODO), [`fixtures/websocket/vehicle_update.nav_clear.json`](fixtures/websocket/vehicle_update.nav_clear.json) (TODO)
+
+Members (per [`vehicle-state-schema.md`](vehicle-state-schema.md) §2.1): `destinationName`, `destinationAddress`, `destinationLatitude`, `destinationLongitude`, `originLatitude`, `originLongitude`, `etaMinutes`, `tripDistanceRemaining`, `navRouteCoordinates`.
+
+| Field | Classification | Encrypted at rest |
+|-------|----------------|-------------------|
+| `destinationName` | **P1** | No (disk encryption only) |
+| `destinationAddress` | **P1** (spec-only, MYR-24) | No |
+| `destinationLatitude` | **P1** | Yes (AES-256-GCM) |
+| `destinationLongitude` | **P1** | Yes |
+| `originLatitude` | **P1** | Yes |
+| `originLongitude` | **P1** | Yes |
+| `etaMinutes` | **P0** | No |
+| `tripDistanceRemaining` | **P0** | No |
+| `navRouteCoordinates` | **P1** | Yes |
+
+**Server flow:** All nav-related fields are routed through [`navAccumulator.Add`](../../internal/ws/nav_accumulator.go). The first nav field for a VIN starts a 500ms timer (see §3.2.1 for the 200ms-vs-500ms drift). Subsequent nav fields within the window are merged. On timer expiry (or on `drive_ended` / `connectivity:offline`), the broadcaster flushes the accumulated batch as a single `vehicle_update`.
+
+**Nav clear (FR-2.3):** When Tesla cancels navigation, it marks the corresponding telemetry fields as `Invalid`. The server translates each invalid nav field to a JSON `null` value in `payload.fields`. The mapping is defined by [`navClearFields`](../../internal/ws/field_mapping.go) line 78:
+
+| Internal field invalidated | Client fields set to `null` |
+|----------------------------|------------------------------|
+| `destinationName` | `destinationName` |
+| `milesToArrival` | `tripDistanceRemaining` |
+| `minutesToArrival` | `etaMinutes` |
+| `routeLine` | `navRouteCoordinates` |
+| `originLocation` | `originLatitude`, `originLongitude` |
+| `destinationLocation` | `destinationLatitude`, `destinationLongitude` |
+
+**SDK requirement:** Per NFR-3.9 and Rule CG-SM-3 ([`state-machine.md`](state-machine.md) §7), when ANY navigation field arrives as `null`, the SDK MUST atomically null ALL navigation group fields in its in-memory state, regardless of whether the server explicitly sent every member. The server is permitted to send a partial clear (e.g., just `destinationName: null`) -- the SDK is responsible for amplifying it to the full group.
+
+#### 4.1.3 GPS group
+
+> **Anchored:** FR-1.1, NFR-3.1.
+> **dataState target:** `dataState.gps`
+> **Fixture:** [`fixtures/websocket/vehicle_update.gps.json`](fixtures/websocket/vehicle_update.gps.json) (TODO)
+
+Members: `latitude`, `longitude`, `heading`.
+
+| Field | Classification | Encrypted at rest |
+|-------|----------------|-------------------|
+| `latitude` | **P1** | Yes (AES-256-GCM) |
+| `longitude` | **P1** | Yes |
+| `heading` | **P0** | No |
+
+**Server flow:** When Tesla emits a `Location` (compound `{lat, lng}`) field, the server splits it into separate `latitude` and `longitude` keys (`splitLocationField` in field_mapping.go). `heading` is delivered alongside whenever Tesla emits `GpsHeading`. There is no nav-style accumulator for GPS -- updates broadcast immediately.
+
+**0,0 sentinel:** Per [`vehicle-state-schema.md`](vehicle-state-schema.md) §2.3, the DB default for unset coordinates is `(0, 0)`. SDKs MUST treat `latitude == 0 && longitude == 0` as "no fix" rather than a valid point in the Gulf of Guinea.
+
+#### 4.1.4 Charge group
+
+> **Anchored:** FR-1.2, NFR-3.1.
+> **dataState target:** `dataState.charge`
+> **Fixture:** [`fixtures/websocket/vehicle_update.charge.json`](fixtures/websocket/vehicle_update.charge.json) (TODO)
+
+Members: `chargeLevel`, `estimatedRange`.
+
+| Field | Classification |
+|-------|----------------|
+| `chargeLevel` | **P0** |
+| `estimatedRange` | **P0** |
+
+Both fields are P0 (no encryption, log-safe). Tesla emits these on a 30-second cadence. The broadcaster delivers them in the same `vehicle_update` whenever either changes.
+
+#### 4.1.5 Gear group
+
+> **Anchored:** NFR-3.1.
+> **dataState target:** `dataState.gear`
+> **Fixture:** [`fixtures/websocket/vehicle_update.gear.json`](fixtures/websocket/vehicle_update.gear.json) (TODO)
+
+Members: `gearPosition`, `status`.
+
+| Field | Classification |
+|-------|----------------|
+| `gearPosition` | **P0** |
+| `status` | **P0** |
+
+`status` is **derived server-side** by [`deriveVehicleStatus`](../../internal/ws/field_mapping.go) from `gearPosition` (and `speed` as a fallback when gear is missing). The broadcaster injects `status` into the `vehicle_update` whenever `gearPosition` is present in the same frame:
+
+```go
+if _, hasGear := fields["gearPosition"]; hasGear {
+    fields["status"] = deriveVehicleStatus(fields)
+}
+```
+
+Per [`vehicle-state-schema.md`](vehicle-state-schema.md) §3.4, the SDK MUST validate the gear-to-status derivation predicate on receipt: `D` or `R` => `driving`, `P` or `N` => `parked` (unless overridden by `charging`/`offline`/`in_service`).
+
+#### 4.1.6 Drive route updates (`drive_updated` is virtual)
+
+> **Anchored:** FR-3.1.
+> **dataState target:** `dataState.gps`
+> **Drive lifecycle target:** `driving -> driving` (DR-2)
+> **Fixture:** [`fixtures/websocket/vehicle_update.route.json`](fixtures/websocket/vehicle_update.route.json) (TODO)
+
+Per [`state-machine.md`](state-machine.md) §4.1, `drive_updated` is **NOT a distinct wire message**. During an active drive, the broadcaster's [`handleDriveUpdated`](../../internal/ws/route_broadcast.go) appends each GPS point to a per-VIN [`routeAccumulator`](../../internal/ws/route_accumulator.go). When the accumulator hits its batch threshold (5 new points by default) or its flush interval (3 seconds by default), the broadcaster sends a `vehicle_update` whose `payload.fields` contains a **single key**:
+
+```jsonc
+{
+  "type": "vehicle_update",
+  "payload": {
+    "vehicleId": "clxyz1234567890abcdef",
+    "fields": {
+      "routeCoordinates": [[-122.4194, 37.7749], [-122.4193, 37.7750], ...]
+    },
+    "timestamp": "2026-04-13T18:23:05Z"
+  }
+}
+```
+
+`routeCoordinates` is `[lng, lat]` order (GeoJSON / Mapbox), distinct from the navigation group's `navRouteCoordinates`. The route accumulator's buffer is **not cleared on flush** -- each batch contains the **complete driven path** so the SDK can render the full polyline by replacing rather than appending. The buffer is cleared only on `drive_ended`.
+
+**SDK requirement:** When a `vehicle_update` carrying `routeCoordinates` arrives during an active drive, the SDK MUST emit `drive_updated` as a logical event to consumers AND merge the array into its in-memory drive state. Per Rule CG-SM-6 in [`state-machine.md`](state-machine.md) §7, the SDK MUST NOT synthesize `drive_updated` from any other source.
+
+### 4.2 `drive_started`
+
+> **Anchored:** FR-3.1.
+> **Drive lifecycle target:** `idle -> driving` (DR-1) or `ended -> driving` (DR-6)
+> **Schema:** [`schemas/ws-messages.schema.json#/$defs/DriveStartedPayload`](schemas/ws-messages.schema.json)
+> **Fixture:** [`fixtures/websocket/drive_started.json`](fixtures/websocket/drive_started.json) (TODO)
+
+```jsonc
+{
+  "type": "drive_started",
+  "payload": {
+    "vehicleId": "clxyz1234567890abcdef",
+    "driveId": "clmno9876543210zyxw",
+    "startLocation": {
+      "latitude": 37.7749,
+      "longitude": -122.4194
+    },
+    "timestamp": "2026-04-13T18:22:00Z"
+  }
+}
+```
+
+| Field | Classification |
+|-------|----------------|
+| `vehicleId` | **P0** |
+| `driveId` | **P0** (matches the eventual persisted `Drive.id`) |
+| `startLocation.latitude` | **P1** (encrypted at rest in the `Drive.routePoints` JSONB, plaintext on the wire under WSS per NFR-3.22) |
+| `startLocation.longitude` | **P1** |
+| `timestamp` | **P0** |
+
+### 4.3 `drive_ended`
+
+> **Anchored:** FR-3.1, FR-3.4.
+> **Drive lifecycle target:** `driving -> ended` (DR-3)
+> **Schema:** [`schemas/ws-messages.schema.json#/$defs/DriveEndedPayload`](schemas/ws-messages.schema.json)
+> **Fixture:** [`fixtures/websocket/drive_ended.json`](fixtures/websocket/drive_ended.json) (TODO)
+
+```jsonc
+{
+  "type": "drive_ended",
+  "payload": {
+    "vehicleId": "clxyz1234567890abcdef",
+    "driveId": "clmno9876543210zyxw",
+    "distance": 12.4,
+    "duration": "24m18s",
+    "avgSpeed": 30.5,
+    "maxSpeed": 65.2,
+    "timestamp": "2026-04-13T18:46:18Z"
+  }
+}
+```
+
+| Field | Type | Classification |
+|-------|------|----------------|
+| `vehicleId` | `string` | **P0** |
+| `driveId` | `string` | **P0** |
+| `distance` | `number` (miles) | **P0** |
+| `duration` | `string` (Go `time.Duration` format, e.g., `24m18s`) | **P0** |
+| `avgSpeed` | `number` (mph) | **P0** |
+| `maxSpeed` | `number` (mph) | **P0** |
+| `timestamp` | `string` (ISO 8601 UTC) | **P0** |
+
+> **Scope note:** Per [`state-machine.md`](state-machine.md) §4.1, the WebSocket `drive_ended` payload contains only the summary fields above. The full FR-3.4 record (energy used, FSD miles, intervention count, start/end charge level, start/end addresses, full route polyline) is fetched via REST `/drives/{id}` (see [`rest-api.md`](rest-api.md)). The SDK SHOULD fire a REST fetch on `drive_ended` if the consumer needs the full record.
+
+> **Micro-drive filter:** Drives that fail the micro-drive filter (default 2 minutes / 0.1 miles, see [`state-machine.md`](state-machine.md) §3.5) NEVER produce a `drive_ended` frame. The SDK relies on `WS_DISCONNECTED` (transition DR-4) or an extended absence of route updates as the only signal that an in-progress drive has been suppressed.
+
+### 4.4 `connectivity`
+
+> **Schema:** [`schemas/ws-messages.schema.json#/$defs/ConnectivityPayload`](schemas/ws-messages.schema.json)
+> **Fixture:** [`fixtures/websocket/connectivity.online.json`](fixtures/websocket/connectivity.online.json) (TODO), [`fixtures/websocket/connectivity.offline.json`](fixtures/websocket/connectivity.offline.json) (TODO)
+
+```jsonc
+{
+  "type": "connectivity",
+  "payload": {
+    "vehicleId": "clxyz1234567890abcdef",
+    "online": true,
+    "timestamp": "2026-04-13T18:22:00Z"
+  }
+}
+```
+
+| Field | Classification |
+|-------|----------------|
+| `vehicleId` | **P0** |
+| `online` | **P0** |
+| `timestamp` | **P0** |
+
+**Important distinction:** `connectivity.online` reports the **vehicle<->server** (Tesla mTLS) connection status, NOT the **client<->server** (WebSocket) status. The latter is implicit in the WebSocket connection itself (an absent connection IS the disconnected state).
+
+Per [`state-machine.md`](state-machine.md) §4.2, `connectivity` does NOT directly transition `connectionState` -- the SDK already knows its WebSocket is open, since it just received a frame on it. The signal is informational: the UI may show "Vehicle offline" while continuing to display cached data. When the server emits `connectivity.online: false`, the broadcaster also clears any pending nav accumulator state for that VIN to prevent stale nav data on reconnect ([`broadcaster.go:handleConnectivity`](../../internal/ws/broadcaster.go) line 227).
+
+### 4.5 Per-vehicle ownership filtering
+
+> **Anchored:** NFR-3.21.
+
+`Hub.Broadcast(vehicleID, msg)` ([`internal/ws/hub.go`](../../internal/ws/hub.go) line 70) iterates every connected client and calls `client.hasVehicle(vehicleID)`. Only clients whose `vehicleIDs` slice (populated at handshake time from `Authenticator.GetUserVehicles`) contains the target vehicle ID receive the frame. Clients with an empty vehicle list (the `NoopAuthenticator` dev mode) receive ALL broadcasts.
+
+The SDK can rely on this contract: **a client will NEVER receive a `vehicle_update`, `drive_started`, `drive_ended`, or `connectivity` frame for a vehicle it does not own.** If ownership changes after the handshake (e.g., an invite is revoked), the change takes effect only on the next reconnection -- the in-memory `vehicleIDs` snapshot is not refreshed mid-connection. This is a known limitation and is tracked as a follow-up in §10.
+
+`heartbeat` frames are broadcast to ALL clients regardless of vehicle ownership ([`Hub.BroadcastAll`](../../internal/ws/hub.go) line 90).
+
+---
+
+## 5. Client -> server message catalog
+
+> **Anchored:** FR-6.1, FR-6.2, NFR-3.21.
+
+### Catalog summary
+
+| `type` | Status | Implementation | Notes |
+|--------|--------|----------------|-------|
+| `auth` | **Implemented** | [`handler.go:authenticateClient`](../../internal/ws/handler.go) | The only client->server frame the server accepts today. |
+| `subscribe` | **PLANNED** | n/a | Reserved. See §10 follow-up. |
+| `unsubscribe` | **PLANNED** | n/a | Reserved. See §10 follow-up. |
+| `ping` | **PLANNED** | n/a | Reserved. RFC 6455 PING/PONG handled transparently by the underlying library today. |
+
+**Critical fact:** After auth completes, the server's `readPump` ([`internal/ws/client.go`](../../internal/ws/client.go) lines 74-90) **explicitly ignores** all incoming client frames. The read loop exists only to detect socket disconnect:
+
+```go
+// Post-auth messages are ignored; the read is only to detect
+// disconnects and keep the connection alive.
+```
+
+This means SDK consumers MUST NOT today rely on subscribe/unsubscribe/ping wire frames -- the server will silently drop them. The TypeScript and Swift SDKs MUST gate any such send sites behind a feature flag tied to a future server version.
+
+### 5.1 `auth`
+
+> **Schema:** [`schemas/ws-messages.schema.json#/$defs/AuthPayload`](schemas/ws-messages.schema.json)
+> **Fixture:** [`fixtures/websocket/auth.json`](fixtures/websocket/auth.json) (TODO)
+
+```jsonc
+{
+  "type": "auth",
+  "payload": {
+    "token": "<opaque session token>"
+  }
+}
+```
+
+| Field | Classification | Notes |
+|-------|----------------|-------|
+| `token` | **P1** | Never log. See [`data-classification.md`](data-classification.md) §1.2. |
+
+See §2.2 for full handshake semantics.
+
+### 5.2 `subscribe` (PLANNED)
+
+> **Schema:** [`schemas/ws-messages.schema.json#/$defs/SubscribePayload`](schemas/ws-messages.schema.json)
+
+NOT yet implemented. Today, the server implicitly subscribes the client to ALL vehicles owned by the authenticated user as part of the auth handshake. A future revision will let the client narrow the subscription per-vehicle and pass a `sinceSeq` for snapshot-resume per NFR-3.11.
+
+```jsonc
+{
+  "type": "subscribe",
+  "payload": {
+    "vehicleId": "clxyz1234567890abcdef",
+    "sinceSeq": 4271
+  }
+}
+```
+
+When implemented, the server response will be either:
+
+- A normal `vehicle_update` stream starting at `sinceSeq + 1`, OR
+- An `error` frame with `code: snapshot_required` indicating the client must perform a full REST snapshot fetch (NFR-3.11) and reconnect.
+
+### 5.3 `unsubscribe` (PLANNED)
+
+NOT yet implemented. Will release a per-vehicle subscription without closing the entire WebSocket.
+
+```jsonc
+{
+  "type": "unsubscribe",
+  "payload": {
+    "vehicleId": "clxyz1234567890abcdef"
+  }
+}
+```
+
+### 5.4 `ping` (PLANNED)
+
+NOT yet implemented. Today, application-level ping is unnecessary because:
+
+1. The underlying [`coder/websocket`](https://github.com/coder/websocket) library handles RFC 6455 PING/PONG control frames transparently in both directions.
+2. The server emits `heartbeat` frames at a 15-second cadence (§7.4), giving the SDK a frequent positive liveness signal.
+
+A future application-level `ping` is reserved for platforms where the WebSocket library does not expose RFC 6455 PING/PONG (some React Native runtimes, watchOS background sessions per NFR-3.36).
+
+```jsonc
+{
+  "type": "ping",
+  "payload": {
+    "nonce": "<opaque round-trip ID>"
+  }
+}
+```
+
+The server response will be a `pong` echoing the nonce.
+
+---
+
+## 6. Errors and close codes
+
+> **Anchored:** FR-7.1, FR-7.3, NFR-3.10, NFR-3.21.
+
+### 6.1 Error frame
+
+> **Schema:** [`schemas/ws-messages.schema.json#/$defs/ErrorPayload`](schemas/ws-messages.schema.json)
+> **Fixture:** [`fixtures/websocket/error.auth_failed.json`](fixtures/websocket/error.auth_failed.json) (TODO), [`fixtures/websocket/error.auth_timeout.json`](fixtures/websocket/error.auth_timeout.json) (TODO)
+
+```jsonc
+{
+  "type": "error",
+  "payload": {
+    "code": "auth_failed",
+    "message": "invalid token"
+  }
+}
+```
+
+| Field | Type | Classification |
+|-------|------|----------------|
+| `code` | `string` (enum) | **P0** |
+| `message` | `string` | **P0** (MUST NOT contain P1 values; see [`data-classification.md`](data-classification.md) §2.2) |
+
+Per FR-7.1, consumer SDKs map `code` to typed error values and branch on the typed value, NEVER on the human-readable `message`. The `message` is intended for logs and developer tooling only.
+
+### 6.1.1 Error code catalog
+
+| Code | Today | Direction | Reconnect policy | Description |
+|------|-------|-----------|------------------|-------------|
+| `auth_failed` | **Implemented** ([`messages.go`](../../internal/ws/messages.go) `errCodeAuthFailed`) | server->client (handshake) | Surface to UI; require user to re-auth. **Do not auto-retry.** | Token signature/issuer/audience/expiry check failed, or `GetUserVehicles` failed. |
+| `auth_timeout` | **Implemented** (`errCodeAuthTimeout`) | server->client (handshake) | Auto-retry with backoff (NFR-3.10) | Client did not send the auth frame within `HandlerConfig.AuthTimeout` (default 5s). |
+| `permission_denied` | **PLANNED** | server->client | Surface to UI; do not auto-retry | Authenticated user attempted to subscribe to a vehicle they do not own. Today this is enforced silently by `Hub.Broadcast` filtering. |
+| `vehicle_not_owned` | **PLANNED** | server->client | Surface to UI; do not auto-retry | Specific case of `permission_denied` for explicit subscribe (§5.2). |
+| `rate_limited` | **PLANNED** | server->client / HTTP 429 | Auto-retry with backoff | Per-IP cap exceeded (currently surfaced as HTTP 429 on upgrade, not as an in-band frame). |
+| `internal_error` | **PLANNED** | server->client | Auto-retry with backoff | Catch-all for unexpected server failures during a live session. |
+
+The PLANNED codes are reserved in the AsyncAPI spec / message schema today so SDKs can match against them once the server emits them.
+
+### 6.2 WebSocket close codes
+
+> **Anchored:** RFC 6455 §7.4. Application-specific codes use the 4000-4999 range.
+
+The Go server uses [`coder/websocket`](https://github.com/coder/websocket) status constants. Today the server explicitly closes the socket with the following codes:
+
+| Code | Name | Today | Source (Go) | When | SDK reconnect policy |
+|------|------|-------|-------------|------|----------------------|
+| `1001` | Going Away | **Implemented** | [`client.go:writePump`](../../internal/ws/client.go) line 56 (`websocket.StatusGoingAway`) | Server is shutting down; hub closed the client's send channel | Auto-reconnect with backoff |
+| `1008` | Policy Violation | **Implemented** | [`handler.go:handleUpgrade`](../../internal/ws/handler.go) line 93 (`websocket.StatusPolicyViolation`) | Authentication failed (sent immediately after the `error` frame) | Surface to UI; do NOT auto-retry on `auth_failed`. For `auth_timeout`, treat as transient and retry. |
+| `1000` | Normal Closure | Tolerated | n/a (never explicitly emitted by server today; client-initiated only) | Client closed the socket cleanly | n/a (client-initiated) |
+
+In addition, RFC 6455 reserves codes 4000-4999 for **application-specific** usage. The following application-specific codes are **PLANNED** (reserved by this contract for future server emission). SDKs SHOULD recognize them but MUST NOT panic on receipt of any 4xxx code they don't know.
+
+| Code | Name | When | SDK reconnect policy |
+|------|------|------|----------------------|
+| `4001` | Auth Token Expired | Server detected mid-session token expiry (e.g., JWT `exp` passed) | Refresh token via `getToken()`, reconnect |
+| `4002` | Permission Revoked | Vehicle ownership revoked while connected (e.g., invite removed) | Surface to UI, do not auto-retry the same vehicle |
+| `4003` | Server Overload | Per-vehicle or per-user backpressure cap exceeded | Auto-reconnect with extended backoff |
+| `4004` | Protocol Violation | Client sent a malformed frame or violated the atomic-group contract | Surface to UI as a bug; do not auto-retry |
+| `4005` | Snapshot Required | Server cannot satisfy the requested `subscribe.sinceSeq` (gap too large) -- client must re-fetch the REST snapshot | Run the standard reconnect sequence (§7.2) |
+
+The mapping between `error.payload.code` and the close code, when both are emitted, is:
+
+| `error.code` | Following close code |
+|--------------|---------------------|
+| `auth_failed` | `1008` Policy Violation (today) |
+| `auth_timeout` | `1008` Policy Violation (today) |
+| `permission_denied` | `4002` Permission Revoked (PLANNED) |
+| `vehicle_not_owned` | `4002` Permission Revoked (PLANNED) |
+| `rate_limited` | `4003` Server Overload (PLANNED) |
+| `internal_error` | `1011` Internal Error (PLANNED) |
+
+### 6.3 No P1 in error messages
+
+Per [`data-classification.md`](data-classification.md) §2.2 and Rule CG-DC-2: the `error.payload.message` field is P0, but error message construction sites MUST NOT include P1 values (no GPS, no addresses, no tokens, no email, no full VINs). Use opaque IDs (vehicle ID, drive ID, user ID) for correlation, or `redactVIN()` for VINs that absolutely must appear. The current implementation in [`handler.go:sendError`](../../internal/ws/handler.go) only sends static strings (`"invalid token"`, `"failed to load vehicles"`) and is therefore compliant.
+
+---
+
+## 7. Heartbeat, reconnect, and snapshot resume
+
+> **Anchored:** NFR-3.10, NFR-3.11, NFR-3.12, NFR-3.13, FR-8.1.
+
+### 7.1 Reconnect backoff parameters (NFR-3.10)
+
+These are the canonical values from [`state-machine.md`](state-machine.md) §1.4 and MUST be implemented identically in both SDKs:
+
+| Parameter | Value | Rationale |
+|-----------|-------|-----------|
+| Initial delay | 1 second | First reconnect attempt after disconnect |
+| Backoff multiplier | 2x | Each subsequent attempt doubles the delay |
+| Maximum delay | 30 seconds | Cap regardless of attempt count |
+| Jitter | +/- 25% of computed delay | Prevents thundering herd at scale (NFR-3.6 5K concurrent clients) |
+| Maximum retries | Unlimited (default) | SDK retries indefinitely unless `USER_STOPPED` or consumer configures a limit |
+
+```
+delay = min(initialDelay * 2^(attempt - 1), maxDelay)
+jitter = delay * random(-0.25, +0.25)
+effectiveDelay = delay + jitter
+```
+
+### 7.2 Reconnect sequence
+
+The full reconnect sequence is documented end-to-end in [`state-machine.md`](state-machine.md) §5 (sequence diagram + reconnect invariants). The protocol-relevant invariants are:
+
+1. **Snapshot before stream (NFR-3.11).** On reconnect, the SDK MUST re-fetch the REST snapshot ([`rest-api.md`](rest-api.md) `GET /vehicles/{id}/snapshot`) BEFORE processing any new WebSocket frames. The snapshot is the cold-load source of truth; the WebSocket stream resumes from the consistent baseline.
+2. **All groups -> loading.** When the SDK begins the reconnect, every `dataState` group transitions to `loading` (see [`state-machine.md`](state-machine.md) §4.2 D-7). Cached values remain visible per NFR-3.12 / NFR-3.13.
+3. **No forced reload (NFR-3.12).** The reconnect is entirely SDK-internal. The UI is never asked to refresh.
+4. **Ordering guarantee.** Live frames received during the snapshot fetch are queued and applied AFTER the snapshot, NEVER before.
+5. **Idempotent.** Multiple rapid disconnect/reconnect cycles MUST NOT cause duplicate snapshot fetches. The SDK cancels any in-flight fetch when a new reconnect begins.
+
+The full reconnect handshake replays §2 verbatim: open WSS, send `auth` frame, await live frames.
+
+### 7.3 Snapshot-resume semantics (NFR-3.11)
+
+NFR-3.11 says: "On reconnect, SDK MUST re-fetch the DB snapshot and resume live stream without user intervention."
+
+There are two valid implementations of this requirement, and the contract supports both:
+
+1. **REST-snapshot resume (current v1.0 implementation).** Reconnect always fetches the full REST snapshot. No wire-level sequence numbers needed. Trade-off: extra HTTP round-trip on every reconnect, and gaps within a single connection are invisible.
+2. **Sequence-resume (PLANNED, v1.x).** When the server begins emitting envelope `seq` (§3.3), the client passes its highest-seen `seq` as `subscribe.sinceSeq` (§5.2). The server replays missed frames OR responds with `error.code: snapshot_required` to fall back to mode 1. Trade-off: requires server-side per-connection retention of recent frames.
+
+The SDK contract today is mode 1. The contract reserves the wire shape for mode 2 so v1.x can ship without a breaking change.
+
+### 7.4 Heartbeat / keepalive
+
+> **Anchored:** NFR-3.10 (reconnect cadence).
+
+| Direction | Cadence | Wire form | Source (Go) |
+|-----------|---------|-----------|-------------|
+| Server -> client | Default 15 seconds (configurable via `WebSocketConfig.HeartbeatInterval`) | Bare envelope `{"type":"heartbeat"}` (no payload) | [`heartbeat.go:RunHeartbeat`](../../internal/ws/heartbeat.go) |
+| Client -> server | None (today; PLANNED `ping` per §5.4) | n/a | n/a |
+| Transport-level (RFC 6455 PING/PONG) | Handled transparently by `coder/websocket` | Binary control frames | Library internals |
+
+The server pre-marshals the heartbeat message once at init (`heartbeatMessage = mustMarshal(...)`) and broadcasts it via [`Hub.BroadcastAll`](../../internal/ws/hub.go) line 90 to ALL connected clients regardless of vehicle ownership.
+
+#### 7.4.1 SDK liveness watchdog
+
+The SDK uses the heartbeat as a positive liveness signal:
+
+- Reset a watchdog timer on every received frame (heartbeat, vehicle_update, anything).
+- If the watchdog fires (no frame for `2 * heartbeatInterval`, default 30s), the SDK treats it as a silent disconnect and triggers `WS_CLOSED` -> `connecting` (state-machine.md C-9).
+
+Per Rule CG-SM-1 ([`state-machine.md`](state-machine.md) §7), the watchdog MUST NOT be used to mark dataState `stale`. dataState transitions to `stale` only when the WebSocket actually closes (NFR-3.7, NFR-3.8b).
+
+#### 7.4.2 SDK MUST NOT use heartbeat for freshness
+
+The heartbeat is purely a liveness signal. Per NFR-3.7, freshness is event-driven and not time-based. The SDK MUST NOT:
+
+- Mark fields stale because no `vehicle_update` for that field arrived in the last N heartbeats.
+- Use heartbeat cadence to derive any data-state transition.
+
+The only legitimate uses of heartbeat in the SDK are: (a) reset the liveness watchdog, (b) update an internal "last frame received" timestamp for debug telemetry.
+
+---
+
+## 8. Cross-references
+
+| Topic | Document |
+|-------|----------|
+| Atomic group definitions and consistency predicates | [`vehicle-state-schema.md`](vehicle-state-schema.md) §2, §3 |
+| Per-field types, units, classification, schemas | [`vehicle-state-schema.md`](vehicle-state-schema.md) §1 + [`schemas/vehicle-state.schema.json`](schemas/vehicle-state.schema.json) |
+| Data classification (P0/P1/P2) | [`data-classification.md`](data-classification.md) |
+| Data lifecycle (DB vs WebSocket source-of-truth, retention) | [`data-lifecycle.md`](data-lifecycle.md) |
+| connectionState / dataState / drive lifecycle state machines | [`state-machine.md`](state-machine.md) |
+| Reconnect sequence diagram | [`state-machine.md`](state-machine.md) §5 |
+| REST snapshot endpoint | [`rest-api.md`](rest-api.md) |
+| AsyncAPI 3.0 spec (machine-readable) | [`specs/websocket.asyncapi.yaml`](specs/websocket.asyncapi.yaml) |
+| Envelope JSON Schema | [`schemas/ws-envelope.schema.json`](schemas/ws-envelope.schema.json) |
+| Per-message JSON Schemas | [`schemas/ws-messages.schema.json`](schemas/ws-messages.schema.json) |
+| Server implementation entry points | [`internal/ws/handler.go`](../../internal/ws/handler.go), [`internal/ws/broadcaster.go`](../../internal/ws/broadcaster.go), [`internal/ws/nav_accumulator.go`](../../internal/ws/nav_accumulator.go), [`internal/ws/route_accumulator.go`](../../internal/ws/route_accumulator.go), [`internal/ws/heartbeat.go`](../../internal/ws/heartbeat.go) |
+| Functional / non-functional requirements | [`docs/architecture/requirements.md`](../architecture/requirements.md) |
+
+---
+
+## 9. Type generation targets
+
+### 9.1 TypeScript (AsyncAPI -> TS types)
+
+The `gen-ts-ws-types` Makefile target (PLANNED) will invoke an AsyncAPI -> TypeScript generator against [`specs/websocket.asyncapi.yaml`](specs/websocket.asyncapi.yaml) and write the result to `sdk/typescript/src/types/ws-messages.ts`. The generator MUST consume the linked JSON Schemas via `$ref` rather than inlining. Drift between the generated file and the spec fails CI.
+
+### 9.2 Swift (AsyncAPI -> Codable structs)
+
+Per NFR-3.34, the Swift SDK uses `Codable`/`Sendable` structs. A code generator (PLANNED) will produce one struct per `$defs` entry in [`schemas/ws-messages.schema.json`](schemas/ws-messages.schema.json) plus the envelope from [`schemas/ws-envelope.schema.json`](schemas/ws-envelope.schema.json). The discriminator is implemented as an enum-with-associated-values per Swift idiom.
+
+---
+
+## 10. Open questions and follow-ups
+
+These items are documented gaps between the protocol spec and the current `internal/ws/` implementation. They are non-blocking for MYR-11 (the spec captures the target shape and reserves the wire surface) but MUST be tracked as Linear follow-ups.
+
+| # | Topic | Current behavior | Target | Proposed Linear issue title |
+|---|-------|------------------|--------|------------------------------|
+| 1 | **Envelope `seq` field (NFR-3.11)** | Server does not emit a per-connection sequence number. `wsMessage` struct has no `seq` field. | Server adds a `nextSeq` counter to `Client`, increments on every `Hub.Broadcast`/`BroadcastAll`, and includes it in every envelope. SDK uses it for gap detection and `subscribe.sinceSeq`. | `MYR-XX Add monotonic per-connection seq to WebSocket envelope (NFR-3.11)` |
+| 2 | **Envelope-level `ts` field** | Server sets `payload.timestamp` on each payload type but no envelope-level `ts`. | Add envelope `ts` (server-authoritative ISO 8601 UTC) to disambiguate from any payload-internal timestamps and make ordering rules trivial. | `MYR-XX Add envelope-level ts to WebSocket frames` |
+| 3 | **Client `subscribe`/`unsubscribe` frames** | `readPump` ignores all post-auth client frames. The client is implicitly subscribed to all owned vehicles at handshake time. | Implement `subscribe`/`unsubscribe` per §5.2-5.3 to enable per-vehicle routing and `sinceSeq` snapshot resume. | `MYR-XX Implement per-vehicle subscribe/unsubscribe on WebSocket` |
+| 4 | **Application-level `ping`/`pong`** | Relies on RFC 6455 PING/PONG handled by `coder/websocket`. | Add app-level `ping`/`pong` for platforms where the WebSocket library does not expose RFC 6455 control frames (some RN runtimes, watchOS). | `MYR-XX Add application-level ping/pong frames` |
+| 5 | **App-specific close codes (4001-4005)** | Server uses only `1001` (going away) and `1008` (policy violation). | Adopt the 4001-4005 catalog in §6.2 so the SDK can route reconnect/error UX precisely. | `MYR-XX Emit 4xxx WebSocket close codes for typed app failures` |
+| 6 | **Nav debounce 200ms vs 500ms** | `defaultNavFlushInterval = 500ms`. NFR-3.2 specifies 200ms. Documented divergence in [`vehicle-state-schema.md`](vehicle-state-schema.md) §2.1. | EITHER tighten to 200ms (and accept partial-batch risk) OR amend NFR-3.2 to 500ms. Architect decision required. | `MYR-XX Reconcile nav debounce window: NFR-3.2 (200ms) vs implementation (500ms)` |
+| 7 | **Vehicle ownership refresh mid-connection** | `Client.vehicleIDs` is a snapshot taken at handshake time. Revoking an invite while a viewer is connected does not stop the viewer's stream until they reconnect. | Add a hub-side ownership refresh hook (server-pushed) OR force-disconnect affected clients with close code 4002. | `MYR-XX Refresh WebSocket client vehicle scope on invite revocation` |
+| 8 | **Auth success acknowledgement** | Server sends nothing on successful auth -- success is implicit in the next frame received. | Optionally send an `auth_ok` frame echoing `userID`, vehicle count, and (when seq lands) initial `seq`. | `MYR-XX Add auth_ok acknowledgement frame to WebSocket handshake` |
+| 9 | **Fixture files for every message type** | Fixtures README lists no concrete files yet. The `fixtures/websocket/*.json` paths in this doc are forward references. | Author one happy-path fixture and at least one edge-case fixture per `type` listed in §4 / §5. Wire them into `contract-tester`. | `MYR-XX Author canonical WebSocket fixtures for every message type` |
+
+---
+
+## Change log
+
+| Date | Change | Author |
+|------|--------|--------|
+| 2026-04-13 | Initial full draft replacing 28-line stub: handshake, envelope, server->client and client->server catalogs, error/close-code matrix, heartbeat/reconnect/snapshot semantics, AsyncAPI 3.0 spec at `specs/websocket.asyncapi.yaml`, sibling `ws-envelope.schema.json` and `ws-messages.schema.json`, follow-ups for envelope seq/ts, subscribe/unsubscribe/ping, 4xxx close codes, nav debounce reconciliation, ownership refresh, fixture authoring. | sdk-architect agent |


### PR DESCRIPTION
## Summary

Fills the P1 contract foundation's last remaining gap: the WebSocket protocol contract that binds the Go telemetry server's broadcaster (`internal/ws/`) to the TypeScript and Swift SDKs. Replaces the 28-line stub in `docs/contracts/websocket-protocol.md` with a full 814-line spec and adds the AsyncAPI 3.0 machine-readable twin at `docs/contracts/specs/websocket.asyncapi.yaml`, plus sibling JSON Schemas for the envelope and per-message payloads.

Linear: [MYR-11](https://linear.app/myrobotaxi/issue/MYR-11/author-websocket-protocolmd-asyncapi-spec-for-real-time-channel)

## What landed

- `docs/contracts/websocket-protocol.md` — full spec (handshake, envelope, server→client catalog, client→server catalog, heartbeat, close codes, reconnect, snapshot resume); every section anchors its FR/NFR
- `docs/contracts/specs/websocket.asyncapi.yaml` — AsyncAPI 3.0 (new `specs/` directory); 38 `$ref`s into sibling schemas, zero duplication
- `docs/contracts/schemas/ws-envelope.schema.json` — envelope JSON Schema (type + payload, plus PLANNED seq/ts)
- `docs/contracts/schemas/ws-messages.schema.json` — per-message payload `$defs`
- `docs/contracts/fixtures/README.md` — planned WebSocket fixture index (TODO entries for follow-up)
- `docs/contracts/README.md` — indexes the new machine-readable spec alongside existing JSON Schemas

Docs-only change — no `.go` files touched.

## Acceptance criteria (all 8 satisfied)

- [x] Connection handshake (auth header, token validation, accept/reject) — §1 + §2
- [x] Server→client message catalog — §4 (`vehicle_update` broken out per atomic group, `drive_started`, `drive_ended`, `connectivity`, `heartbeat`, `error`); each field cites its P0/P1/P2 classification
- [x] Client→server message catalog — §5 (`auth` implemented; `subscribe`/`unsubscribe`/`ping` PLANNED with follow-up issues)
- [x] Message envelope schema (type discriminator, sequence, timestamp) — §3 + `ws-envelope.schema.json`
- [x] Heartbeat/keepalive cadence — §7.4
- [x] Close codes and reconnection semantics — §6.2 + §7.1-§7.3
- [x] AsyncAPI 3.0 YAML at `docs/contracts/specs/websocket.asyncapi.yaml`
- [x] Link to canonical fixtures for each message type (fixture files themselves are tracked as a follow-up in `fixtures/README.md`)

Anchored: FR-1.1, FR-1.2, FR-1.3, FR-2.1, FR-2.2, FR-2.3, FR-3.1, FR-8.1, FR-8.2, NFR-3.1, NFR-3.2, NFR-3.10, NFR-3.11.

## Code ↔ spec divergences (tracked for follow-up)

§10 of the spec records every place where current `internal/ws/` behavior differs from target. Each gets a follow-up Linear issue, not a silent fix in this PR:

1. Envelope `seq` not yet emitted (NFR-3.11)
2. Envelope-level `ts` not yet emitted
3. `subscribe`/`unsubscribe` not implemented — `readPump` ignores post-auth frames
4. App-level `ping`/`pong` not yet implemented (relying on RFC 6455 control frames today)
5. Only close codes 1001 and 1008 are emitted; 4001-4005 reserved for follow-up
6. **Nav debounce mismatch:** NFR-3.2 says 200ms, `defaultNavFlushInterval` is 500ms — architect decision needed
7. `Client.vehicleIDs` is a handshake-time snapshot — revoked invites stream until reconnect
8. No `auth_ok` acknowledgement frame on successful auth
9. Fixture JSON files not yet authored (paths reserved in catalog)

## Reviewer notes

- Fixture links in the catalog resolve to not-yet-existing paths under `docs/contracts/fixtures/websocket/*.json`. Intentional — #9 above tracks the fixture authoring.
- `drive_updated` is a logical/SDK-derived event, not on the wire. The wire carries `vehicle_update` with `routeCoordinates` — consistent with `state-machine.md` §4.1 and the broadcaster code.
- Close code matrix in §6.2 is the lowest-confidence section: RFC 6455 ranges + existing `coder/websocket` constants + reserved 4xxx design proposal. Worth a closer read before the PLANNED codes get implemented.
- YAML was hand-validated (structure, `$ref` targets, indentation). No AsyncAPI parser was run against it (`@asyncapi/cli` not in the repo); running `npx @asyncapi/cli@latest validate docs/contracts/specs/websocket.asyncapi.yaml` locally before merge is recommended.
- JSON Schemas parse as JSON; not validated as JSON Schema draft-2020-12 (no `ajv` in repo). Style matches existing `vehicle-state.schema.json`.

## Test plan

- [ ] `contract-guard` CI check passes
- [ ] Markdown renders cleanly on GitHub (section anchors, tables, mermaid diagrams if any)
- [ ] AsyncAPI YAML validates with `@asyncapi/cli` locally (manual, optional)
- [ ] `sdk-architect` contract-adherence review
- [ ] Claude Review warnings + suggestions addressed before merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)