### PR TITLE
MYR-34 Raise Claude Review max-turns from 25 to 50

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -67,7 +67,7 @@ jobs:
           track_progress: true
           claude_args: >-
             --agent pr-reviewer
-            --max-turns 25
+            --max-turns 50
           prompt: |
             Review this pull request.
 


### PR DESCRIPTION
Closes MYR-34.

## Summary

One-line change in `.github/workflows/claude-review.yml`: bumps the `pr-reviewer` agent's `--max-turns` budget from 25 to 50 so Claude Review can complete reviews on PRs with more than ~2,000 diff lines.

## Root cause

Combined with `track_progress: true` and `use_sticky_comment: true` (lines 66-67), each checklist progress update costs one turn via `mcp__github_comment__update_claude_comment`. On large diffs the agent exhausts the 25-turn budget during the read-and-absorb phase before reaching the verdict step.

## Evidence

| PR | Diff lines | Outcome |
|---|---|---|
| #167 (MYR-11 contract docs) | 1,575 (websocket-protocol.md 1,027 + asyncapi.yaml 548) | Claude Review **succeeded** in 2m54s |
| #168 (MYR-12 contract docs) | 2,470 (rest-api.md 1,053 + rest.openapi.yaml 1,414 + README delta) | Claude Review **failed** deterministically on both the initial run and a rerun, hitting `error_max_turns` at turn 26. Sticky comment showed 6 checklist items set up, **zero completed**. |

The tipping point sits between ~1,575 and ~2,470 diff lines. Every remaining P1 contract PR is expected to exceed this threshold. Doubling the budget gives comfortable headroom without over-allocating.

## What this does NOT change

Per MYR-34 non-goals, this PR does not touch:
- `track_progress: true` or `use_sticky_comment: true` — UX features worth keeping.
- The `pr-reviewer.md` review checklist — the checklist is fine; the agent just needs more turns.
- The `interactive` job's `--max-turns 10` — scoped to short follow-up responses.

## Test plan

- [x] YAML still parses (`python3 -c "import yaml; yaml.safe_load(...)"`)
- [x] Diff is a one-character numeric change on line 70 (`25` → `50`)
- [ ] CI: Lint / Test / Security / Build must remain green (unchanged by this workflow edit)
- [ ] Next contract PR (or a reopen of #168 for verification) exercises the new budget end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)