### PR TITLE
MYR-25 Add charge field instrumentation for Tesla unit verification

### DIFF
--- a/internal/telemetry/decoder.go
+++ b/internal/telemetry/decoder.go
@@ -2,6 +2,7 @@ package telemetry
 
 import (
 	"fmt"
+	"log/slog"
 	"time"
 
 	"google.golang.org/protobuf/proto"
@@ -122,6 +123,17 @@ func (d *Decoder) DecodePayload(payload *tpb.Payload) (events.VehicleTelemetryEv
 		}
 
 		fields[string(name)] = tv
+
+		// MYR-25/28/29: Temporary debug log for Tesla field unit verification.
+		// Remove after empirical verification is complete.
+		switch name {
+		case FieldTimeToFullCharge, FieldEstimatedHoursToChargeTermination, FieldMilesToArrival:
+			slog.Info("MYR-25/28/29 FIELD VERIFICATION",
+				slog.String("field", string(name)),
+				slog.String("vin_last4", payload.GetVin()[len(payload.GetVin())-4:]),
+				slog.Any("raw_value", tv),
+			)
+		}
 	}
 
 	evt := events.VehicleTelemetryEvent{

--- a/internal/telemetry/decoder.go
+++ b/internal/telemetry/decoder.go
@@ -107,6 +107,26 @@ func (d *Decoder) DecodePayload(payload *tpb.Payload) (events.VehicleTelemetryEv
 			continue
 		}
 
+		// MYR-25/28/29: Temporary debug log for Tesla field unit verification.
+		// These fields are NOT in fieldMap (intentionally excluded from the event
+		// bus to avoid leaking uncontracted fields to WS clients). We intercept
+		// them here for observation only. Remove after empirical verification.
+		switch datum.GetKey() {
+		case tpb.Field_TimeToFullCharge, tpb.Field_EstimatedHoursToChargeTermination:
+			if tv, err := extractValue(datum); err == nil {
+				vin := payload.GetVin()
+				vinSuffix := vin
+				if len(vin) > 4 {
+					vinSuffix = vin[len(vin)-4:]
+				}
+				slog.Info("MYR-25/28/29 FIELD VERIFICATION",
+					slog.String("field", datum.GetKey().String()),
+					slog.String("vin_last4", vinSuffix),
+					slog.Any("raw_value", tv),
+				)
+			}
+		}
+
 		name, ok := InternalFieldName(datum.GetKey())
 		if !ok {
 			continue // untracked field, skip silently
@@ -124,13 +144,17 @@ func (d *Decoder) DecodePayload(payload *tpb.Payload) (events.VehicleTelemetryEv
 
 		fields[string(name)] = tv
 
-		// MYR-25/28/29: Temporary debug log for Tesla field unit verification.
+		// MYR-25/29: Log MilesToArrival (already in fieldMap) for unit verification.
 		// Remove after empirical verification is complete.
-		switch name {
-		case FieldTimeToFullCharge, FieldEstimatedHoursToChargeTermination, FieldMilesToArrival:
+		if name == FieldMilesToArrival {
+			vin := payload.GetVin()
+			vinSuffix := vin
+			if len(vin) > 4 {
+				vinSuffix = vin[len(vin)-4:]
+			}
 			slog.Info("MYR-25/28/29 FIELD VERIFICATION",
 				slog.String("field", string(name)),
-				slog.String("vin_last4", payload.GetVin()[len(payload.GetVin())-4:]),
+				slog.String("vin_last4", vinSuffix),
 				slog.Any("raw_value", tv),
 			)
 		}

--- a/internal/telemetry/fields.go
+++ b/internal/telemetry/fields.go
@@ -13,15 +13,15 @@ type FieldName string
 // detector, WebSocket broadcast, store) reference these constants, not
 // Tesla's proto enum names.
 const (
-	FieldSpeed              FieldName = "speed"
-	FieldLocation           FieldName = "location"
-	FieldHeading            FieldName = "heading"
-	FieldGear               FieldName = "gear"
-	FieldSOC                FieldName = "soc"
-	FieldEstBatteryRange    FieldName = "estimatedRange"
-	FieldChargeState         FieldName = "chargeState"
-	FieldDetailedChargeState FieldName = "detailedChargeState"
-	FieldOdometer           FieldName = "odometer"
+	FieldSpeed                FieldName = "speed"
+	FieldLocation             FieldName = "location"
+	FieldHeading              FieldName = "heading"
+	FieldGear                 FieldName = "gear"
+	FieldSOC                  FieldName = "soc"
+	FieldEstBatteryRange      FieldName = "estimatedRange"
+	FieldChargeState          FieldName = "chargeState"
+	FieldDetailedChargeState  FieldName = "detailedChargeState"
+	FieldOdometer             FieldName = "odometer"
 	FieldInsideTemp           FieldName = "insideTemp"
 	FieldOutsideTemp          FieldName = "outsideTemp"
 	FieldHvacPower            FieldName = "hvacPower"
@@ -33,43 +33,41 @@ const (
 	FieldSeatHeaterRight      FieldName = "seatHeaterRight"
 	FieldClimateKeeperMode    FieldName = "climateKeeperMode"
 	FieldDestinationName      FieldName = "destinationName"
-	FieldRouteLine          FieldName = "routeLine"
-	FieldFSDMiles           FieldName = "fsdMilesSinceReset"
-	FieldBatteryLevel       FieldName = "batteryLevel"
-	FieldIdealBatteryRange  FieldName = "idealBatteryRange"
-	FieldRatedRange         FieldName = "ratedRange"
-	FieldEnergyRemaining    FieldName = "energyRemaining"
-	FieldPackVoltage        FieldName = "packVoltage"
-	FieldPackCurrent        FieldName = "packCurrent"
-	FieldVehicleName        FieldName = "vehicleName"
-	FieldCarType            FieldName = "carType"
-	FieldVersion            FieldName = "version"
-	FieldLocked             FieldName = "locked"
-	FieldSentryMode         FieldName = "sentryMode"
-	FieldOriginLocation     FieldName = "originLocation"
-	FieldDestLocation       FieldName = "destinationLocation"
-	FieldMilesToArrival     FieldName = "milesToArrival"
-	FieldMinutesToArrival   FieldName = "minutesToArrival"
-	FieldLatAccel            FieldName = "lateralAcceleration"
-	FieldLongAccel           FieldName = "longitudinalAcceleration"
-	FieldMilesSinceReset                    FieldName = "milesSinceReset"
-	FieldTimeToFullCharge                   FieldName = "timeToFullCharge"
-	FieldEstimatedHoursToChargeTermination  FieldName = "estimatedHoursToChargeTermination"
+	FieldRouteLine            FieldName = "routeLine"
+	FieldFSDMiles             FieldName = "fsdMilesSinceReset"
+	FieldBatteryLevel         FieldName = "batteryLevel"
+	FieldIdealBatteryRange    FieldName = "idealBatteryRange"
+	FieldRatedRange           FieldName = "ratedRange"
+	FieldEnergyRemaining      FieldName = "energyRemaining"
+	FieldPackVoltage          FieldName = "packVoltage"
+	FieldPackCurrent          FieldName = "packCurrent"
+	FieldVehicleName          FieldName = "vehicleName"
+	FieldCarType              FieldName = "carType"
+	FieldVersion              FieldName = "version"
+	FieldLocked               FieldName = "locked"
+	FieldSentryMode           FieldName = "sentryMode"
+	FieldOriginLocation       FieldName = "originLocation"
+	FieldDestLocation         FieldName = "destinationLocation"
+	FieldMilesToArrival       FieldName = "milesToArrival"
+	FieldMinutesToArrival     FieldName = "minutesToArrival"
+	FieldLatAccel             FieldName = "lateralAcceleration"
+	FieldLongAccel            FieldName = "longitudinalAcceleration"
+	FieldMilesSinceReset      FieldName = "milesSinceReset"
 )
 
 // fieldMap maps Tesla's proto Field enum values to our internal field names.
 // Only fields that MyRoboTaxi cares about are included. Unlisted fields are
 // silently skipped during decoding.
 var fieldMap = map[tpb.Field]FieldName{
-	tpb.Field_VehicleSpeed:             FieldSpeed,
-	tpb.Field_Location:                 FieldLocation,
-	tpb.Field_GpsHeading:               FieldHeading,
-	tpb.Field_Gear:                     FieldGear,
-	tpb.Field_Soc:                      FieldSOC,
-	tpb.Field_EstBatteryRange:          FieldEstBatteryRange,
-	tpb.Field_ChargeState:              FieldChargeState,
-	tpb.Field_DetailedChargeState:      FieldDetailedChargeState,
-	tpb.Field_Odometer:                 FieldOdometer,
+	tpb.Field_VehicleSpeed:                FieldSpeed,
+	tpb.Field_Location:                    FieldLocation,
+	tpb.Field_GpsHeading:                  FieldHeading,
+	tpb.Field_Gear:                        FieldGear,
+	tpb.Field_Soc:                         FieldSOC,
+	tpb.Field_EstBatteryRange:             FieldEstBatteryRange,
+	tpb.Field_ChargeState:                 FieldChargeState,
+	tpb.Field_DetailedChargeState:         FieldDetailedChargeState,
+	tpb.Field_Odometer:                    FieldOdometer,
 	tpb.Field_InsideTemp:                  FieldInsideTemp,
 	tpb.Field_OutsideTemp:                 FieldOutsideTemp,
 	tpb.Field_HvacPower:                   FieldHvacPower,
@@ -81,28 +79,30 @@ var fieldMap = map[tpb.Field]FieldName{
 	tpb.Field_SeatHeaterRight:             FieldSeatHeaterRight,
 	tpb.Field_ClimateKeeperMode:           FieldClimateKeeperMode,
 	tpb.Field_DestinationName:             FieldDestinationName,
-	tpb.Field_RouteLine:                FieldRouteLine,
-	tpb.Field_SelfDrivingMilesSinceReset: FieldFSDMiles,
-	tpb.Field_BatteryLevel:             FieldBatteryLevel,
-	tpb.Field_IdealBatteryRange:        FieldIdealBatteryRange,
-	tpb.Field_RatedRange:               FieldRatedRange,
-	tpb.Field_EnergyRemaining:          FieldEnergyRemaining,
-	tpb.Field_PackVoltage:              FieldPackVoltage,
-	tpb.Field_PackCurrent:              FieldPackCurrent,
-	tpb.Field_VehicleName:              FieldVehicleName,
-	tpb.Field_CarType:                  FieldCarType,
-	tpb.Field_Version:                  FieldVersion,
-	tpb.Field_Locked:                   FieldLocked,
-	tpb.Field_SentryMode:               FieldSentryMode,
-	tpb.Field_OriginLocation:           FieldOriginLocation,
-	tpb.Field_DestinationLocation:      FieldDestLocation,
-	tpb.Field_MilesToArrival:           FieldMilesToArrival,
-	tpb.Field_MinutesToArrival:         FieldMinutesToArrival,
-	tpb.Field_LateralAcceleration:      FieldLatAccel,
-	tpb.Field_LongitudinalAcceleration: FieldLongAccel,
-	tpb.Field_MilesSinceReset:                    FieldMilesSinceReset,
-	tpb.Field_TimeToFullCharge:                   FieldTimeToFullCharge,
-	tpb.Field_EstimatedHoursToChargeTermination:  FieldEstimatedHoursToChargeTermination,
+	tpb.Field_RouteLine:                   FieldRouteLine,
+	tpb.Field_SelfDrivingMilesSinceReset:  FieldFSDMiles,
+	tpb.Field_BatteryLevel:                FieldBatteryLevel,
+	tpb.Field_IdealBatteryRange:           FieldIdealBatteryRange,
+	tpb.Field_RatedRange:                  FieldRatedRange,
+	tpb.Field_EnergyRemaining:             FieldEnergyRemaining,
+	tpb.Field_PackVoltage:                 FieldPackVoltage,
+	tpb.Field_PackCurrent:                 FieldPackCurrent,
+	tpb.Field_VehicleName:                 FieldVehicleName,
+	tpb.Field_CarType:                     FieldCarType,
+	tpb.Field_Version:                     FieldVersion,
+	tpb.Field_Locked:                      FieldLocked,
+	tpb.Field_SentryMode:                  FieldSentryMode,
+	tpb.Field_OriginLocation:              FieldOriginLocation,
+	tpb.Field_DestinationLocation:         FieldDestLocation,
+	tpb.Field_MilesToArrival:              FieldMilesToArrival,
+	tpb.Field_MinutesToArrival:            FieldMinutesToArrival,
+	tpb.Field_LateralAcceleration:         FieldLatAccel,
+	tpb.Field_LongitudinalAcceleration:    FieldLongAccel,
+	tpb.Field_MilesSinceReset:             FieldMilesSinceReset,
+	// Field_TimeToFullCharge (43) and Field_EstimatedHoursToChargeTermination (190)
+	// are intentionally NOT in fieldMap — they are observation-only via the MYR-25
+	// debug log in decoder.go. Adding them here would leak uncontracted fields to
+	// WS clients via the event bus. They will be added after empirical verification.
 	// Field_RouteLastUpdated omitted — Tesla docs state this field is broken.
 }
 

--- a/internal/telemetry/fields.go
+++ b/internal/telemetry/fields.go
@@ -52,7 +52,9 @@ const (
 	FieldMinutesToArrival   FieldName = "minutesToArrival"
 	FieldLatAccel            FieldName = "lateralAcceleration"
 	FieldLongAccel           FieldName = "longitudinalAcceleration"
-	FieldMilesSinceReset    FieldName = "milesSinceReset"
+	FieldMilesSinceReset                    FieldName = "milesSinceReset"
+	FieldTimeToFullCharge                   FieldName = "timeToFullCharge"
+	FieldEstimatedHoursToChargeTermination  FieldName = "estimatedHoursToChargeTermination"
 )
 
 // fieldMap maps Tesla's proto Field enum values to our internal field names.
@@ -98,7 +100,9 @@ var fieldMap = map[tpb.Field]FieldName{
 	tpb.Field_MinutesToArrival:         FieldMinutesToArrival,
 	tpb.Field_LateralAcceleration:      FieldLatAccel,
 	tpb.Field_LongitudinalAcceleration: FieldLongAccel,
-	tpb.Field_MilesSinceReset:          FieldMilesSinceReset,
+	tpb.Field_MilesSinceReset:                    FieldMilesSinceReset,
+	tpb.Field_TimeToFullCharge:                   FieldTimeToFullCharge,
+	tpb.Field_EstimatedHoursToChargeTermination:  FieldEstimatedHoursToChargeTermination,
 	// Field_RouteLastUpdated omitted — Tesla docs state this field is broken.
 }
 

--- a/internal/telemetry/fleet_api_fields.go
+++ b/internal/telemetry/fleet_api_fields.go
@@ -21,30 +21,30 @@ const (
 // --- Location / Navigation ---
 
 const (
-	FleetFieldLocation           = "Location"
-	FleetFieldGpsHeading         = "GpsHeading"
-	FleetFieldOriginLocation     = "OriginLocation"
-	FleetFieldDestLocation       = "DestinationLocation"
-	FleetFieldDestinationName    = "DestinationName"
-	FleetFieldRouteLine          = "RouteLine"
+	FleetFieldLocation        = "Location"
+	FleetFieldGpsHeading      = "GpsHeading"
+	FleetFieldOriginLocation  = "OriginLocation"
+	FleetFieldDestLocation    = "DestinationLocation"
+	FleetFieldDestinationName = "DestinationName"
+	FleetFieldRouteLine       = "RouteLine"
 	// RouteLastUpdated omitted — Tesla docs state this field is broken and never returns data.
-	FleetFieldMilesToArrival     = "MilesToArrival"
-	FleetFieldMinutesToArrival   = "MinutesToArrival"
+	FleetFieldMilesToArrival   = "MilesToArrival"
+	FleetFieldMinutesToArrival = "MinutesToArrival"
 )
 
 // --- Battery / Charging ---
 
 const (
-	FleetFieldSOC                  = "Soc"
-	FleetFieldBatteryLevel         = "BatteryLevel"
-	FleetFieldEstBatteryRange      = "EstBatteryRange"
-	FleetFieldIdealBatteryRange    = "IdealBatteryRange"
-	FleetFieldRatedRange           = "RatedRange"
-	FleetFieldEnergyRemaining      = "EnergyRemaining"
-	FleetFieldPackVoltage          = "PackVoltage"
-	FleetFieldPackCurrent          = "PackCurrent"
-	FleetFieldDetailedChargeState              = "DetailedChargeState"
-	FleetFieldTimeToFullCharge                 = "TimeToFullCharge"
+	FleetFieldSOC                               = "Soc"
+	FleetFieldBatteryLevel                      = "BatteryLevel"
+	FleetFieldEstBatteryRange                   = "EstBatteryRange"
+	FleetFieldIdealBatteryRange                 = "IdealBatteryRange"
+	FleetFieldRatedRange                        = "RatedRange"
+	FleetFieldEnergyRemaining                   = "EnergyRemaining"
+	FleetFieldPackVoltage                       = "PackVoltage"
+	FleetFieldPackCurrent                       = "PackCurrent"
+	FleetFieldDetailedChargeState               = "DetailedChargeState"
+	FleetFieldTimeToFullCharge                  = "TimeToFullCharge"
 	FleetFieldEstimatedHoursToChargeTermination = "EstimatedHoursToChargeTermination"
 )
 
@@ -109,27 +109,27 @@ func DefaultFieldConfig() map[string]FieldConfig {
 		FleetFieldLongAccel:    {IntervalSeconds: 2},
 
 		// Location / Navigation — high frequency with delta filter
-		FleetFieldLocation:         {IntervalSeconds: 2, MinimumDelta: &locationDelta},
-		FleetFieldGpsHeading:       {IntervalSeconds: 5},
-		FleetFieldOriginLocation:   {IntervalSeconds: 1, ResendIntervalSeconds: intPtr(30)},
-		FleetFieldDestLocation:     {IntervalSeconds: 1, ResendIntervalSeconds: intPtr(30)},
-		FleetFieldDestinationName:  {IntervalSeconds: 1, ResendIntervalSeconds: intPtr(30)},
-		FleetFieldRouteLine:        {IntervalSeconds: 1, ResendIntervalSeconds: intPtr(30)},
+		FleetFieldLocation:        {IntervalSeconds: 2, MinimumDelta: &locationDelta},
+		FleetFieldGpsHeading:      {IntervalSeconds: 5},
+		FleetFieldOriginLocation:  {IntervalSeconds: 1, ResendIntervalSeconds: intPtr(30)},
+		FleetFieldDestLocation:    {IntervalSeconds: 1, ResendIntervalSeconds: intPtr(30)},
+		FleetFieldDestinationName: {IntervalSeconds: 1, ResendIntervalSeconds: intPtr(30)},
+		FleetFieldRouteLine:       {IntervalSeconds: 1, ResendIntervalSeconds: intPtr(30)},
 		// RouteLastUpdated omitted — broken per Tesla docs, wastes buffer.
 		FleetFieldMilesToArrival:   {IntervalSeconds: 1, ResendIntervalSeconds: intPtr(30)},
 		FleetFieldMinutesToArrival: {IntervalSeconds: 1, ResendIntervalSeconds: intPtr(30)},
 
 		// Battery / Charging — medium frequency
-		FleetFieldSOC:                 {IntervalSeconds: 30},
-		FleetFieldBatteryLevel:        {IntervalSeconds: 30},
-		FleetFieldEstBatteryRange:     {IntervalSeconds: 30},
-		FleetFieldIdealBatteryRange:   {IntervalSeconds: 30},
-		FleetFieldRatedRange:          {IntervalSeconds: 30},
-		FleetFieldEnergyRemaining:     {IntervalSeconds: 30},
-		FleetFieldPackVoltage:         {IntervalSeconds: 30},
-		FleetFieldPackCurrent:         {IntervalSeconds: 30},
-		FleetFieldDetailedChargeState:              {IntervalSeconds: 30}, // maps to FieldDetailedChargeState (proto 179)
-		FleetFieldTimeToFullCharge:                 {IntervalSeconds: 30}, // MYR-25: proto 43, unit verification (hours vs seconds)
+		FleetFieldSOC:                               {IntervalSeconds: 30},
+		FleetFieldBatteryLevel:                      {IntervalSeconds: 30},
+		FleetFieldEstBatteryRange:                   {IntervalSeconds: 30},
+		FleetFieldIdealBatteryRange:                 {IntervalSeconds: 30},
+		FleetFieldRatedRange:                        {IntervalSeconds: 30},
+		FleetFieldEnergyRemaining:                   {IntervalSeconds: 30},
+		FleetFieldPackVoltage:                       {IntervalSeconds: 30},
+		FleetFieldPackCurrent:                       {IntervalSeconds: 30},
+		FleetFieldDetailedChargeState:               {IntervalSeconds: 30}, // maps to FieldDetailedChargeState (proto 179)
+		FleetFieldTimeToFullCharge:                  {IntervalSeconds: 30}, // MYR-25: proto 43, unit verification (hours vs seconds)
 		FleetFieldEstimatedHoursToChargeTermination: {IntervalSeconds: 30}, // MYR-28: proto 190, delineation vs TimeToFullCharge
 
 		// Climate — medium/low frequency

--- a/internal/telemetry/fleet_api_fields.go
+++ b/internal/telemetry/fleet_api_fields.go
@@ -43,7 +43,9 @@ const (
 	FleetFieldEnergyRemaining      = "EnergyRemaining"
 	FleetFieldPackVoltage          = "PackVoltage"
 	FleetFieldPackCurrent          = "PackCurrent"
-	FleetFieldDetailedChargeState  = "DetailedChargeState"
+	FleetFieldDetailedChargeState              = "DetailedChargeState"
+	FleetFieldTimeToFullCharge                 = "TimeToFullCharge"
+	FleetFieldEstimatedHoursToChargeTermination = "EstimatedHoursToChargeTermination"
 )
 
 // --- Climate ---
@@ -126,7 +128,9 @@ func DefaultFieldConfig() map[string]FieldConfig {
 		FleetFieldEnergyRemaining:     {IntervalSeconds: 30},
 		FleetFieldPackVoltage:         {IntervalSeconds: 30},
 		FleetFieldPackCurrent:         {IntervalSeconds: 30},
-		FleetFieldDetailedChargeState: {IntervalSeconds: 30}, // maps to FieldDetailedChargeState (proto 179)
+		FleetFieldDetailedChargeState:              {IntervalSeconds: 30}, // maps to FieldDetailedChargeState (proto 179)
+		FleetFieldTimeToFullCharge:                 {IntervalSeconds: 30}, // MYR-25: proto 43, unit verification (hours vs seconds)
+		FleetFieldEstimatedHoursToChargeTermination: {IntervalSeconds: 30}, // MYR-28: proto 190, delineation vs TimeToFullCharge
 
 		// Climate — medium/low frequency
 		FleetFieldInsideTemp:           {IntervalSeconds: 60, ResendIntervalSeconds: intPtr(120)},


### PR DESCRIPTION
## Summary

- Adds `TimeToFullCharge` (proto 43) and `EstimatedHoursToChargeTermination` (proto 190) to field map + fleet config at 30s intervals
- Adds temporary debug logging in the decoder for the 3 fields under verification (MYR-25/28/29)
- No wire mapping, DB columns, or broadcaster changes — observation only

## Why

The v1 contract assumes `TimeToFullCharge` is in **hours** (decimal) based on secondary sources, but no empirical protobuf capture has confirmed this. This PR instruments the decoder so we can compare raw values against the Tesla touchscreen display while charging and navigating.

## What to do after merge

1. Deploy to Fly.io
2. Push updated fleet config: `./scripts/push-fleet-config.sh --vin <VIN> --token <TOKEN>`
3. Plug in Tesla to charge + set a nav destination
4. Read `fly logs` — look for `MYR-25/28/29 FIELD VERIFICATION` lines
5. Compare raw values against Tesla touchscreen → ground truth for units

## Cleanup

The debug logging is temporary. After verification, a follow-up commit removes the `switch` block in `decoder.go` and records the findings in the contract docs.

## Test plan

- [x] `go test ./...` — all pass
- [x] `go vet ./...` — clean
- [x] `go build ./cmd/...` — builds
- [x] `TestDefaultFieldConfig_CoversAllTrackedFields` — passes (new fields have config entries)
- [ ] CI checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)