### PR TITLE
MYR-36 Add cmd/ops CLI and /api/debug/fields endpoint

### DIFF
--- a/cmd/ops/auth.go
+++ b/cmd/ops/auth.go
@@ -1,0 +1,158 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"flag"
+	"fmt"
+	"log/slog"
+	"os"
+	"time"
+
+	"github.com/tnando/my-robo-taxi-telemetry/internal/store"
+	"github.com/tnando/my-robo-taxi-telemetry/internal/telemetry"
+)
+
+// errRefreshSkipped is returned by refreshToken when the Tesla OAuth
+// credentials are not configured or the stored refresh_token is empty.
+// Callers interpret this as "keep using the existing access token".
+var errRefreshSkipped = errors.New("tesla token refresh skipped")
+
+func runAuth(ctx context.Context, args []string) error {
+	if len(args) == 0 {
+		return fmt.Errorf("auth requires a subcommand (token)")
+	}
+	switch args[0] {
+	case "token":
+		return runAuthToken(ctx, args[1:])
+	default:
+		return fmt.Errorf("unknown auth subcommand %q", args[0])
+	}
+}
+
+// authTokenOutput is the JSON shape printed to stdout.
+type authTokenOutput struct {
+	UserID       string `json:"userId"`
+	AccessToken  string `json:"accessToken"`
+	RefreshToken string `json:"refreshToken,omitempty"`
+	ExpiresAt    string `json:"expiresAt,omitempty"`
+	Refreshed    bool   `json:"refreshed"`
+}
+
+func runAuthToken(ctx context.Context, args []string) error {
+	fs := flag.NewFlagSet("auth token", flag.ContinueOnError)
+	userID := fs.String("user-id", "", "MyRoboTaxi user id (Prisma cuid)")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	if err := requireFlag("user-id", *userID); err != nil {
+		return err
+	}
+
+	logger := newLogger()
+	db, err := openDB(ctx, logger)
+	if err != nil {
+		return err
+	}
+	defer db.Close()
+
+	accountRepo := store.NewAccountRepo(db.Pool())
+
+	tok, err := accountRepo.GetTeslaToken(ctx, *userID)
+	if err != nil {
+		return fmt.Errorf("read tesla token: %w", err)
+	}
+
+	expiresAt := tokenExpiry(tok.ExpiresAt)
+	refreshed := false
+	if shouldRefresh(expiresAt) {
+		refreshedTok, err := refreshToken(ctx, logger, accountRepo, *userID, tok.RefreshToken)
+		switch {
+		case err == nil:
+			tok.AccessToken = refreshedTok.AccessToken
+			tok.RefreshToken = refreshedTok.RefreshToken
+			expiresAt = refreshedTok.ExpiresAt()
+			refreshed = true
+		case errors.Is(err, errRefreshSkipped):
+			// Keep the existing (expired) token; user-facing output flags it.
+		default:
+			return err
+		}
+	}
+
+	return writeJSON(os.Stdout, authTokenOutput{
+		UserID:       *userID,
+		AccessToken:  tok.AccessToken,
+		RefreshToken: tok.RefreshToken,
+		ExpiresAt:    formatExpiry(expiresAt),
+		Refreshed:    refreshed,
+	})
+}
+
+// tokenExpiry converts the nullable Unix epoch ExpiresAt into a time.Time.
+// Returns the zero value when the column was NULL.
+func tokenExpiry(expiresAt *int64) time.Time {
+	if expiresAt == nil {
+		return time.Time{}
+	}
+	return time.Unix(*expiresAt, 0)
+}
+
+// shouldRefresh returns true when the token is expired or will expire in
+// the next minute. Tesla tokens are short-lived and the 1-minute skew
+// avoids handing out a token that expires mid-request.
+func shouldRefresh(expiresAt time.Time) bool {
+	if expiresAt.IsZero() {
+		return false
+	}
+	return time.Until(expiresAt) < time.Minute
+}
+
+func formatExpiry(t time.Time) string {
+	if t.IsZero() {
+		return ""
+	}
+	return t.UTC().Format(time.RFC3339)
+}
+
+// refreshToken calls the Tesla OAuth refresh endpoint using AUTH_TESLA_ID
+// and AUTH_TESLA_SECRET and persists the new token to the DB. Returns
+// errRefreshSkipped when credentials are missing or the stored refresh
+// token is empty — the caller keeps the existing access token and the
+// user must re-link their Tesla account manually.
+func refreshToken(
+	ctx context.Context,
+	logger *slog.Logger,
+	accountRepo *store.AccountRepo,
+	userID, refreshToken string,
+) (telemetry.TeslaRefreshedToken, error) {
+	clientID := os.Getenv("AUTH_TESLA_ID")
+	clientSecret := os.Getenv("AUTH_TESLA_SECRET")
+	if clientID == "" || clientSecret == "" {
+		logger.Warn("AUTH_TESLA_ID / AUTH_TESLA_SECRET not set, skipping refresh")
+		return telemetry.TeslaRefreshedToken{}, errRefreshSkipped
+	}
+	if refreshToken == "" {
+		logger.Warn("stored refresh_token is empty, skipping refresh")
+		return telemetry.TeslaRefreshedToken{}, errRefreshSkipped
+	}
+
+	refresher := telemetry.NewTokenRefresher(telemetry.TeslaOAuthConfig{
+		ClientID:     clientID,
+		ClientSecret: clientSecret,
+	}, logger.With(slog.String("component", "token-refresh")))
+
+	refreshed, err := refresher.Refresh(ctx, refreshToken)
+	if err != nil {
+		return telemetry.TeslaRefreshedToken{}, fmt.Errorf("refresh tesla token: %w", err)
+	}
+
+	if err := accountRepo.UpdateTeslaToken(ctx, userID,
+		refreshed.AccessToken, refreshed.RefreshToken,
+		refreshed.ExpiresAt().Unix()); err != nil {
+		logger.Warn("failed to persist refreshed token",
+			slog.String("error", err.Error()),
+		)
+	}
+	return refreshed, nil
+}

--- a/cmd/ops/common.go
+++ b/cmd/ops/common.go
@@ -1,0 +1,68 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log/slog"
+	"os"
+	"strings"
+
+	"github.com/tnando/my-robo-taxi-telemetry/internal/config"
+	"github.com/tnando/my-robo-taxi-telemetry/internal/store"
+)
+
+// newLogger returns a text-handler slog logger writing to stderr so
+// normal JSON output on stdout remains machine-parseable.
+func newLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelInfo}))
+}
+
+// openDB builds a DatabaseConfig from environment variables and opens a
+// connection pool. The caller is responsible for closing the returned DB.
+// DATABASE_URL is required. PgBouncer transaction pooling (Supabase port
+// 6543) is auto-detected by the presence of :6543 in the URL, matching
+// the server's handling of DATABASE_DISABLE_PREPARED_STATEMENTS.
+func openDB(ctx context.Context, logger *slog.Logger) (*store.DB, error) {
+	url := os.Getenv("DATABASE_URL")
+	if url == "" {
+		return nil, fmt.Errorf("DATABASE_URL is required")
+	}
+
+	cfg := config.DatabaseConfig{
+		URL:      url,
+		MaxConns: 2,
+		MinConns: 1,
+		DisablePreparedStatements: strings.Contains(url, ":6543") ||
+			os.Getenv("DATABASE_DISABLE_PREPARED_STATEMENTS") == "true",
+	}
+
+	db, err := store.NewDB(ctx, cfg, logger, store.NoopMetrics{})
+	if err != nil {
+		return nil, fmt.Errorf("open db: %w", err)
+	}
+	return db, nil
+}
+
+// writeJSON marshals v as indented JSON and writes it to w followed by a
+// newline. Returns an error if marshalling or writing fails.
+func writeJSON(w io.Writer, v any) error {
+	b, err := json.MarshalIndent(v, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal json: %w", err)
+	}
+	if _, err := w.Write(append(b, '\n')); err != nil {
+		return fmt.Errorf("write json: %w", err)
+	}
+	return nil
+}
+
+// requireFlag returns the value of flag if non-empty; otherwise returns a
+// descriptive usage error.
+func requireFlag(name, value string) error {
+	if strings.TrimSpace(value) == "" {
+		return fmt.Errorf("--%s is required", name)
+	}
+	return nil
+}

--- a/cmd/ops/fields.go
+++ b/cmd/ops/fields.go
@@ -1,0 +1,203 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+
+	"github.com/coder/websocket"
+
+	"github.com/tnando/my-robo-taxi-telemetry/internal/store"
+)
+
+const defaultDebugFieldsServer = "ws://localhost:8080"
+
+func runFields(ctx context.Context, args []string) error {
+	if len(args) == 0 {
+		return fmt.Errorf("fields requires a subcommand (watch | snapshot)")
+	}
+	switch args[0] {
+	case "watch":
+		return runFieldsWatch(ctx, args[1:])
+	case "snapshot":
+		return runFieldsSnapshot(ctx, args[1:])
+	default:
+		return fmt.Errorf("unknown fields subcommand %q", args[0])
+	}
+}
+
+// runFieldsWatch opens a WebSocket to the server's /api/debug/fields
+// endpoint and streams raw field frames to stdout. Each line is one JSON
+// frame produced by the server so the output can be piped through jq or
+// parsed by later tooling.
+func runFieldsWatch(ctx context.Context, args []string) error {
+	fs := flag.NewFlagSet("fields watch", flag.ContinueOnError)
+	vin := fs.String("vin", "", "17-character Tesla VIN to filter on (empty = all)")
+	server := fs.String("server", defaultDebugFieldsServer, "telemetry server ws:// or wss:// base URL")
+	tokenFlag := fs.String("token", "", "debug token (overrides DEBUG_FIELDS_TOKEN)")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+
+	endpoint, err := buildDebugURL(*server, *vin)
+	if err != nil {
+		return err
+	}
+
+	token := *tokenFlag
+	if token == "" {
+		token = os.Getenv("DEBUG_FIELDS_TOKEN")
+	}
+
+	header := http.Header{}
+	if token != "" {
+		header.Set("X-Debug-Token", token)
+	}
+
+	conn, resp, err := websocket.Dial(ctx, endpoint, &websocket.DialOptions{
+		HTTPHeader: header,
+	})
+	if err != nil {
+		return fmt.Errorf("dial %s: %w", endpoint, err)
+	}
+	// coder/websocket returns the upgrade response; callers must drain and
+	// close its Body or bodyclose flags it. The connection itself is closed
+	// separately.
+	if resp != nil && resp.Body != nil {
+		_ = resp.Body.Close()
+	}
+	defer conn.CloseNow() //nolint:errcheck // nothing useful to do on close failure
+
+	fmt.Fprintf(os.Stderr, "ops fields watch: connected to %s\n", endpoint)
+	return streamFrames(ctx, conn, os.Stdout)
+}
+
+// streamFrames reads text frames from the WebSocket and writes each one
+// to out followed by a newline. Returns nil when the context is cancelled
+// (graceful shutdown); any other read/write error is returned.
+func streamFrames(ctx context.Context, conn *websocket.Conn, out io.Writer) error {
+	for {
+		_, data, err := conn.Read(ctx)
+		if err != nil {
+			if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+				return nil
+			}
+			return fmt.Errorf("read: %w", err)
+		}
+		if _, err := out.Write(append(data, '\n')); err != nil {
+			return fmt.Errorf("write: %w", err)
+		}
+	}
+}
+
+// buildDebugURL converts a ws:// or http:// server base URL into the
+// full debug fields endpoint URL. It accepts both protocol forms so the
+// operator can reuse the same base URL as the server's --client flag.
+func buildDebugURL(server, vin string) (string, error) {
+	u, err := url.Parse(server)
+	if err != nil {
+		return "", fmt.Errorf("parse --server: %w", err)
+	}
+	switch u.Scheme {
+	case "http":
+		u.Scheme = "ws"
+	case "https":
+		u.Scheme = "wss"
+	case "ws", "wss":
+	default:
+		return "", fmt.Errorf("unsupported --server scheme %q", u.Scheme)
+	}
+	u.Path = "/api/debug/fields"
+	if vin != "" {
+		q := u.Query()
+		q.Set("vin", vin)
+		u.RawQuery = q.Encode()
+	}
+	return u.String(), nil
+}
+
+// vehicleSnapshot is the JSON shape printed by `ops fields snapshot`. We
+// stay close to store.Vehicle but flatten the pointer fields for easier
+// reading.
+type vehicleSnapshot struct {
+	ID                   string   `json:"id"`
+	VIN                  string   `json:"vin"`
+	Name                 string   `json:"name"`
+	Status               string   `json:"status"`
+	ChargeLevel          int      `json:"chargeLevel"`
+	EstimatedRange       int      `json:"estimatedRange"`
+	Speed                int      `json:"speed"`
+	GearPosition         *string  `json:"gearPosition,omitempty"`
+	Heading              int      `json:"heading"`
+	Latitude             float64  `json:"latitude"`
+	Longitude            float64  `json:"longitude"`
+	InteriorTemp         int      `json:"interiorTemp"`
+	ExteriorTemp         int      `json:"exteriorTemp"`
+	OdometerMiles        int      `json:"odometerMiles"`
+	DestinationName      *string  `json:"destinationName,omitempty"`
+	DestinationLatitude  *float64 `json:"destinationLatitude,omitempty"`
+	DestinationLongitude *float64 `json:"destinationLongitude,omitempty"`
+	OriginLatitude       *float64 `json:"originLatitude,omitempty"`
+	OriginLongitude      *float64 `json:"originLongitude,omitempty"`
+	EtaMinutes           *int     `json:"etaMinutes,omitempty"`
+	TripDistRemaining    *float64 `json:"tripDistanceRemaining,omitempty"`
+	NavRouteCoordinates  json.RawMessage `json:"navRouteCoordinates,omitempty"`
+	LastUpdated          string   `json:"lastUpdated"`
+}
+
+func runFieldsSnapshot(ctx context.Context, args []string) error {
+	fs := flag.NewFlagSet("fields snapshot", flag.ContinueOnError)
+	vin := fs.String("vin", "", "17-character Tesla VIN")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	if err := requireFlag("vin", *vin); err != nil {
+		return err
+	}
+
+	logger := newLogger()
+	db, err := openDB(ctx, logger)
+	if err != nil {
+		return err
+	}
+	defer db.Close()
+
+	repo := store.NewVehicleRepo(db.Pool(), store.NoopMetrics{})
+	v, err := repo.GetByVIN(ctx, *vin)
+	if err != nil {
+		return fmt.Errorf("lookup vehicle: %w", err)
+	}
+
+	snap := vehicleSnapshot{
+		ID:                   v.ID,
+		VIN:                  v.VIN,
+		Name:                 v.Name,
+		Status:               string(v.Status),
+		ChargeLevel:          v.ChargeLevel,
+		EstimatedRange:       v.EstimatedRange,
+		Speed:                v.Speed,
+		GearPosition:         v.GearPosition,
+		Heading:              v.Heading,
+		Latitude:             v.Latitude,
+		Longitude:            v.Longitude,
+		InteriorTemp:         v.InteriorTemp,
+		ExteriorTemp:         v.ExteriorTemp,
+		OdometerMiles:        v.OdometerMiles,
+		DestinationName:      v.DestinationName,
+		DestinationLatitude:  v.DestinationLatitude,
+		DestinationLongitude: v.DestinationLongitude,
+		OriginLatitude:       v.OriginLatitude,
+		OriginLongitude:      v.OriginLongitude,
+		EtaMinutes:           v.EtaMinutes,
+		TripDistRemaining:    v.TripDistRemaining,
+		NavRouteCoordinates:  v.NavRouteCoordinates,
+		LastUpdated:          v.LastUpdated.UTC().Format("2006-01-02T15:04:05Z07:00"),
+	}
+	return writeJSON(os.Stdout, snap)
+}

--- a/cmd/ops/fields_url_test.go
+++ b/cmd/ops/fields_url_test.go
@@ -1,0 +1,51 @@
+package main
+
+import "testing"
+
+func TestBuildDebugURL(t *testing.T) {
+	tests := []struct {
+		name    string
+		server  string
+		vin     string
+		want    string
+		wantErr bool
+	}{
+		{
+			name:   "ws stays ws",
+			server: "ws://localhost:8080",
+			vin:    "5YJ3E7EB2NF000001",
+			want:   "ws://localhost:8080/api/debug/fields?vin=5YJ3E7EB2NF000001",
+		},
+		{
+			name:   "http upgraded to ws",
+			server: "http://localhost:8080",
+			want:   "ws://localhost:8080/api/debug/fields",
+		},
+		{
+			name:   "https upgraded to wss",
+			server: "https://telemetry.example.com",
+			vin:    "5YJ3E7EB2NF000001",
+			want:   "wss://telemetry.example.com/api/debug/fields?vin=5YJ3E7EB2NF000001",
+		},
+		{
+			name:    "unsupported scheme rejected",
+			server:  "tcp://localhost",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := buildDebugURL(tt.server, tt.vin)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("err: got %v, wantErr %v", err, tt.wantErr)
+			}
+			if err != nil {
+				return
+			}
+			if got != tt.want {
+				t.Errorf("got %q, want %q", got, tt.want)
+			}
+		})
+	}
+}

--- a/cmd/ops/fleet.go
+++ b/cmd/ops/fleet.go
@@ -1,0 +1,238 @@
+package main
+
+import (
+	"context"
+	"crypto/tls"
+	"errors"
+	"flag"
+	"fmt"
+	"log/slog"
+	"net"
+	"net/http"
+	"net/url"
+	"os"
+	"strconv"
+	"time"
+
+	"github.com/tnando/my-robo-taxi-telemetry/internal/store"
+	"github.com/tnando/my-robo-taxi-telemetry/internal/telemetry"
+)
+
+const defaultFleetTelemetryPort = 443
+
+func runFleetConfig(ctx context.Context, args []string) error {
+	if len(args) == 0 {
+		return fmt.Errorf("fleet-config requires a subcommand (show | push)")
+	}
+	switch args[0] {
+	case "show":
+		return runFleetConfigShow(args[1:])
+	case "push":
+		return runFleetConfigPush(ctx, args[1:])
+	default:
+		return fmt.Errorf("unknown fleet-config subcommand %q", args[0])
+	}
+}
+
+func runFleetConfigShow(args []string) error {
+	fs := flag.NewFlagSet("fleet-config show", flag.ContinueOnError)
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	return writeJSON(os.Stdout, telemetry.DefaultFieldConfig())
+}
+
+// fleetPushOutput mirrors the server's fleet config endpoint but is kept
+// local to the CLI — there is no shared schema contract for this view.
+type fleetPushOutput struct {
+	VIN             string            `json:"vin"`
+	UserID          string            `json:"userId"`
+	Refreshed       bool              `json:"tokenRefreshed"`
+	UpdatedVehicles int               `json:"updatedVehicles"`
+	SkippedVehicles map[string]string `json:"skippedVehicles,omitempty"`
+}
+
+func runFleetConfigPush(ctx context.Context, args []string) error {
+	fs := flag.NewFlagSet("fleet-config push", flag.ContinueOnError)
+	vin := fs.String("vin", "", "17-character Tesla VIN")
+	userID := fs.String("user-id", "", "MyRoboTaxi user id (owner of the VIN)")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	if err := requireFlag("vin", *vin); err != nil {
+		return err
+	}
+	if err := requireFlag("user-id", *userID); err != nil {
+		return err
+	}
+	if len(*vin) != 17 {
+		return fmt.Errorf("invalid --vin: must be 17 characters, got %d", len(*vin))
+	}
+
+	endpoint, err := loadEndpointConfig()
+	if err != nil {
+		return err
+	}
+	proxyURL := os.Getenv("TESLA_PROXY_URL")
+	if proxyURL == "" {
+		return fmt.Errorf("TESLA_PROXY_URL is required for fleet-config push")
+	}
+
+	logger := newLogger()
+	db, err := openDB(ctx, logger)
+	if err != nil {
+		return err
+	}
+	defer db.Close()
+
+	accountRepo := store.NewAccountRepo(db.Pool())
+	vehicleRepo := store.NewVehicleRepo(db.Pool(), store.NoopMetrics{})
+
+	if err := verifyVINOwnership(ctx, vehicleRepo, *vin, *userID); err != nil {
+		return err
+	}
+
+	token, refreshed, err := resolveTeslaToken(ctx, logger, accountRepo, *userID)
+	if err != nil {
+		return err
+	}
+
+	resp, err := pushFleetConfig(ctx, logger, proxyURL, endpoint, *vin, token)
+	if err != nil {
+		return err
+	}
+
+	return writeJSON(os.Stdout, fleetPushOutput{
+		VIN:             *vin,
+		UserID:          *userID,
+		Refreshed:       refreshed,
+		UpdatedVehicles: resp.Response.UpdatedVehicles,
+		SkippedVehicles: resp.Response.SkippedVehicles,
+	})
+}
+
+// verifyVINOwnership fails fast if the VIN is not registered to the given
+// user. Prevents pushing fleet config for vehicles the operator does not own.
+func verifyVINOwnership(ctx context.Context, repo *store.VehicleRepo, vin, userID string) error {
+	v, err := repo.GetByVIN(ctx, vin)
+	if err != nil {
+		return fmt.Errorf("lookup vehicle: %w", err)
+	}
+	if v.UserID != userID {
+		return fmt.Errorf("vehicle owner mismatch: VIN belongs to user %q, not %q", v.UserID, userID)
+	}
+	return nil
+}
+
+// pushFleetConfig constructs the FleetConfigRequest and calls the tesla
+// Fleet API via the proxy.
+func pushFleetConfig(
+	ctx context.Context,
+	logger *slog.Logger,
+	proxyURL string,
+	endpoint telemetry.EndpointConfig,
+	vin, token string,
+) (*telemetry.FleetConfigResponse, error) {
+	client := telemetry.NewFleetAPIClient(telemetry.FleetAPIConfig{
+		BaseURL:    proxyURL,
+		HTTPClient: proxyHTTPClient(proxyURL, logger),
+	}, logger.With(slog.String("component", "fleet-api")))
+
+	expTime := time.Now().Add(350 * 24 * time.Hour).Unix()
+	var ca *string
+	if endpoint.CA != "" {
+		ca = &endpoint.CA
+	}
+	req := telemetry.FleetConfigRequest{
+		VINs: []string{vin},
+		Config: telemetry.FleetConfig{
+			Hostname:   endpoint.Hostname,
+			Port:       endpoint.Port,
+			CA:         ca,
+			Fields:     telemetry.DefaultFieldConfig(),
+			AlertTypes: []string{"service"},
+			Exp:        &expTime,
+		},
+	}
+	resp, err := client.PushTelemetryConfig(ctx, token, req)
+	if err != nil {
+		return nil, fmt.Errorf("push fleet config: %w", err)
+	}
+	return resp, nil
+}
+
+// loadEndpointConfig reads the Fleet Telemetry endpoint coordinates from
+// the environment, applying the same default port (443) as the server.
+func loadEndpointConfig() (telemetry.EndpointConfig, error) {
+	hostname := os.Getenv("FLEET_TELEMETRY_HOSTNAME")
+	if hostname == "" {
+		return telemetry.EndpointConfig{}, fmt.Errorf("FLEET_TELEMETRY_HOSTNAME is required for fleet-config push")
+	}
+	port := defaultFleetTelemetryPort
+	if v := os.Getenv("FLEET_TELEMETRY_PORT"); v != "" {
+		p, err := strconv.Atoi(v)
+		if err != nil || p <= 0 {
+			return telemetry.EndpointConfig{}, fmt.Errorf("invalid FLEET_TELEMETRY_PORT %q", v)
+		}
+		port = p
+	}
+	return telemetry.EndpointConfig{
+		Hostname: hostname,
+		Port:     port,
+		CA:       os.Getenv("FLEET_TELEMETRY_CA"),
+	}, nil
+}
+
+// resolveTeslaToken reads the Tesla token from the DB and, if it is
+// expired or missing credentials, attempts to refresh it.
+func resolveTeslaToken(
+	ctx context.Context,
+	logger *slog.Logger,
+	accountRepo *store.AccountRepo,
+	userID string,
+) (accessToken string, didRefresh bool, err error) {
+	tok, err := accountRepo.GetTeslaToken(ctx, userID)
+	if err != nil {
+		return "", false, fmt.Errorf("read tesla token: %w", err)
+	}
+	expiresAt := tokenExpiry(tok.ExpiresAt)
+	if !shouldRefresh(expiresAt) {
+		return tok.AccessToken, false, nil
+	}
+	refreshed, err := refreshToken(ctx, logger, accountRepo, userID, tok.RefreshToken)
+	if err != nil {
+		if errors.Is(err, errRefreshSkipped) {
+			return tok.AccessToken, false, nil
+		}
+		return "", false, err
+	}
+	return refreshed.AccessToken, true, nil
+}
+
+// proxyHTTPClient mirrors the server's tesla-http-proxy handling: when the
+// proxy URL is on loopback, certificate verification is skipped because
+// the proxy uses a self-signed cert. Non-loopback URLs use the default
+// HTTP client (verified TLS).
+func proxyHTTPClient(proxyURL string, logger *slog.Logger) *http.Client {
+	u, err := url.Parse(proxyURL)
+	if err != nil {
+		return nil
+	}
+	host := u.Hostname()
+	ip := net.ParseIP(host)
+	isLoopback := host == "localhost" || (ip != nil && ip.IsLoopback())
+	if !isLoopback {
+		return nil
+	}
+	logger.Info("proxy on loopback — skipping TLS verification",
+		slog.String("proxy_url", proxyURL),
+	)
+	return &http.Client{
+		Timeout: 30 * time.Second,
+		Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{
+				InsecureSkipVerify: true, //#nosec G402 -- loopback only; guard above ensures non-loopback uses verified TLS
+			},
+		},
+	}
+}

--- a/cmd/ops/main.go
+++ b/cmd/ops/main.go
@@ -1,0 +1,91 @@
+// Binary ops is a developer CLI for Tesla Fleet API operations and raw
+// telemetry inspection. It is the interim UX for verifying Tesla field
+// behavior (MYR-25/28/29 and future issues) and will be superseded by a
+// web test bench built against the same /api/debug/fields endpoint.
+//
+// Subcommands:
+//
+//	ops auth token        --user-id <id>
+//	ops vehicles list     --user-id <id>
+//	ops fleet-config show
+//	ops fleet-config push --vin <vin> --user-id <id>
+//	ops fields watch      --vin <vin>
+//	ops fields snapshot   --vin <vin>
+//
+// The CLI reads DATABASE_URL from the environment (same as the server).
+// Fleet API operations additionally require TESLA_PROXY_URL,
+// FLEET_TELEMETRY_HOSTNAME/PORT, and AUTH_TESLA_ID/SECRET.
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"os/signal"
+	"syscall"
+)
+
+func main() {
+	if err := run(); err != nil {
+		if errors.Is(err, errUsage) {
+			fmt.Fprint(os.Stderr, usage())
+			os.Exit(2)
+		}
+		fmt.Fprintf(os.Stderr, "ops: %s\n", err)
+		os.Exit(1)
+	}
+}
+
+func run() error {
+	if len(os.Args) < 2 {
+		return errUsage
+	}
+
+	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	defer stop()
+
+	switch os.Args[1] {
+	case "auth":
+		return runAuth(ctx, os.Args[2:])
+	case "vehicles":
+		return runVehicles(ctx, os.Args[2:])
+	case "fleet-config":
+		return runFleetConfig(ctx, os.Args[2:])
+	case "fields":
+		return runFields(ctx, os.Args[2:])
+	case "help", "-h", "--help":
+		fmt.Print(usage())
+		return nil
+	default:
+		return fmt.Errorf("unknown command %q", os.Args[1])
+	}
+}
+
+var errUsage = errors.New("usage")
+
+func usage() string {
+	return `ops — MyRoboTaxi Tesla operations CLI
+
+Usage:
+  ops <command> [flags]
+
+Commands:
+  auth token          --user-id <id>                 Print the user's Tesla token (auto-refreshes if expired)
+  vehicles list       --user-id <id>                 List vehicles owned by the user
+  fleet-config show                                  Print DefaultFieldConfig as JSON
+  fleet-config push   --vin <vin> --user-id <id>     Push DefaultFieldConfig to Tesla for this VIN
+  fields watch        --vin <vin> [--server <url>]   Stream raw decoded fields from /api/debug/fields
+  fields snapshot     --vin <vin>                    Dump the current vehicle row as JSON
+
+Environment:
+  DATABASE_URL                  Postgres connection string (required)
+  TESLA_PROXY_URL               tesla-http-proxy base URL (for fleet-config push)
+  FLEET_TELEMETRY_HOSTNAME      Hostname vehicles connect to after config push
+  FLEET_TELEMETRY_PORT          Port vehicles connect to (default 443)
+  FLEET_TELEMETRY_CA            PEM CA cert for the telemetry server
+  AUTH_TESLA_ID                 Tesla OAuth client id (enables token refresh)
+  AUTH_TESLA_SECRET             Tesla OAuth client secret
+  DEBUG_FIELDS_TOKEN            Auth token for fields watch (when server requires it)
+`
+}

--- a/cmd/ops/vehicles.go
+++ b/cmd/ops/vehicles.go
@@ -1,0 +1,70 @@
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"os"
+
+	"github.com/tnando/my-robo-taxi-telemetry/internal/store"
+)
+
+func runVehicles(ctx context.Context, args []string) error {
+	if len(args) == 0 {
+		return fmt.Errorf("vehicles requires a subcommand (list)")
+	}
+	switch args[0] {
+	case "list":
+		return runVehiclesList(ctx, args[1:])
+	default:
+		return fmt.Errorf("unknown vehicles subcommand %q", args[0])
+	}
+}
+
+// vehicleListItem is the JSON shape printed for each vehicle.
+type vehicleListItem struct {
+	ID          string `json:"id"`
+	VIN         string `json:"vin"`
+	Name        string `json:"name"`
+	Status      string `json:"status"`
+	ChargeLevel int    `json:"chargeLevel"`
+	LastUpdated string `json:"lastUpdated"`
+}
+
+func runVehiclesList(ctx context.Context, args []string) error {
+	fs := flag.NewFlagSet("vehicles list", flag.ContinueOnError)
+	userID := fs.String("user-id", "", "MyRoboTaxi user id (Prisma cuid)")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	if err := requireFlag("user-id", *userID); err != nil {
+		return err
+	}
+
+	logger := newLogger()
+	db, err := openDB(ctx, logger)
+	if err != nil {
+		return err
+	}
+	defer db.Close()
+
+	repo := store.NewVehicleRepo(db.Pool(), store.NoopMetrics{})
+	vehicles, err := repo.ListByUser(ctx, *userID)
+	if err != nil {
+		return fmt.Errorf("list vehicles: %w", err)
+	}
+
+	out := make([]vehicleListItem, 0, len(vehicles))
+	for i := range vehicles {
+		v := &vehicles[i]
+		out = append(out, vehicleListItem{
+			ID:          v.ID,
+			VIN:         v.VIN,
+			Name:        v.Name,
+			Status:      string(v.Status),
+			ChargeLevel: v.ChargeLevel,
+			LastUpdated: v.LastUpdated.UTC().Format("2006-01-02T15:04:05Z07:00"),
+		})
+	}
+	return writeJSON(os.Stdout, out)
+}

--- a/cmd/telemetry-server/main.go
+++ b/cmd/telemetry-server/main.go
@@ -108,6 +108,10 @@ func run() error { //nolint:funlen // composition root — sequential dependency
 		telemetry.ReceiverConfig{
 			MaxVehicles:       cfg.Telemetry().MaxVehicles,
 			MaxMessagesPerSec: 10,
+			// Dev mode publishes raw field events so the /api/debug/fields
+			// endpoint and cmd/ops fields watch can inspect every decoded
+			// proto field. Production leaves this off to avoid extra work.
+			PublishRawFields: *devMode,
 		},
 	)
 
@@ -191,6 +195,20 @@ func run() error { //nolint:funlen // composition root — sequential dependency
 
 	// --- Fleet config push endpoint (optional — requires proxy config) ---
 	setupFleetConfigEndpoint(cfg, srv, authenticator, vehicleRepo, accountRepo, logger)
+
+	// --- Dev-only debug fields endpoint (guarded by --dev flag) ---
+	if *devMode {
+		debugHandler := telemetry.NewDebugFieldsHandler(
+			bus,
+			logger.With(slog.String("component", "debug-fields")),
+			telemetry.DebugFieldsConfig{
+				APIKey:         os.Getenv("DEBUG_FIELDS_TOKEN"),
+				OriginPatterns: originPatterns,
+			},
+		)
+		srv.HandleFunc("GET /api/debug/fields", debugHandler.ServeHTTP)
+		logger.Warn("dev mode: /api/debug/fields endpoint enabled — do not run in production")
+	}
 
 	// Configure mTLS on Tesla port. TLS is required for vehicle connections —
 	// without it, Tesla vehicles cannot complete the handshake and report EOF.

--- a/internal/events/raw_telemetry_event.go
+++ b/internal/events/raw_telemetry_event.go
@@ -21,9 +21,9 @@ func (RawVehicleTelemetryEvent) EventTopic() Topic { return TopicVehicleTelemetr
 // metadata preserved. The Value holds the concrete Go type chosen by the
 // decoder for that field (float64, int64, string, bool, *Location, or nil).
 type RawTelemetryField struct {
-	ProtoField int32       // Tesla proto field number (e.g. 43 for TimeToFullCharge)
-	ProtoName  string      // Tesla Field enum name (e.g. "TimeToFullCharge")
-	Type       string      // Go type tag: "float", "int", "string", "bool", "location", "invalid"
-	Value      interface{} // Raw value; nil when Invalid is true
-	Invalid    bool        // True when the vehicle marked the datum invalid
+	ProtoField int32  // Tesla proto field number (e.g. 43 for TimeToFullCharge)
+	ProtoName  string // Tesla Field enum name (e.g. "TimeToFullCharge")
+	Type       string // Go type tag: "float", "int", "string", "bool", "location", "invalid"
+	Value      any    // Raw value; nil when Invalid is true
+	Invalid    bool   // True when the vehicle marked the datum invalid
 }

--- a/internal/events/raw_telemetry_event.go
+++ b/internal/events/raw_telemetry_event.go
@@ -1,0 +1,29 @@
+package events
+
+import "time"
+
+// RawVehicleTelemetryEvent mirrors VehicleTelemetryEvent but preserves the
+// full set of decoded protobuf fields keyed by proto field number — including
+// fields that the broadcast pipeline filters out via the InternalFieldName
+// lookup. It exists to power the dev-only debug WebSocket endpoint and the
+// cmd/ops CLI inspector; production traffic never emits this topic.
+type RawVehicleTelemetryEvent struct {
+	BasePayload
+	VIN       string
+	CreatedAt time.Time
+	Fields    []RawTelemetryField
+}
+
+// EventTopic returns TopicVehicleTelemetryRaw.
+func (RawVehicleTelemetryEvent) EventTopic() Topic { return TopicVehicleTelemetryRaw }
+
+// RawTelemetryField carries one decoded Tesla datum with its proto field
+// metadata preserved. The Value holds the concrete Go type chosen by the
+// decoder for that field (float64, int64, string, bool, *Location, or nil).
+type RawTelemetryField struct {
+	ProtoField int32       // Tesla proto field number (e.g. 43 for TimeToFullCharge)
+	ProtoName  string      // Tesla Field enum name (e.g. "TimeToFullCharge")
+	Type       string      // Go type tag: "float", "int", "string", "bool", "location", "invalid"
+	Value      interface{} // Raw value; nil when Invalid is true
+	Invalid    bool        // True when the vehicle marked the datum invalid
+}

--- a/internal/events/topic.go
+++ b/internal/events/topic.go
@@ -8,6 +8,12 @@ const (
 	// arrives from a vehicle. The payload is VehicleTelemetryEvent.
 	TopicVehicleTelemetry Topic = "vehicle.telemetry"
 
+	// TopicVehicleTelemetryRaw carries every decoded proto field from a
+	// vehicle payload, unfiltered by the broadcast field map. Emitted only
+	// when the receiver is configured with PublishRawFields (dev/debug
+	// mode). The payload is RawVehicleTelemetryEvent.
+	TopicVehicleTelemetryRaw Topic = "vehicle.telemetry.raw"
+
 	// TopicConnectivity is published when a vehicle connects or disconnects
 	// from the telemetry server. The payload is ConnectivityEvent.
 	TopicConnectivity Topic = "vehicle.connectivity"

--- a/internal/store/queries.go
+++ b/internal/store/queries.go
@@ -25,6 +25,11 @@ const queryVehicleByID = `SELECT ` + vehicleSelectColumns + `
 FROM "Vehicle"
 WHERE "id" = $1`
 
+const queryVehiclesByUser = `SELECT ` + vehicleSelectColumns + `
+FROM "Vehicle"
+WHERE "userId" = $1
+ORDER BY "name", "vin"`
+
 const queryUpdateVehicleStatus = `UPDATE "Vehicle"
 SET "status" = $1::"VehicleStatus", "lastUpdated" = NOW()
 WHERE "vin" = $2`

--- a/internal/store/vehicle_repo.go
+++ b/internal/store/vehicle_repo.go
@@ -36,6 +36,44 @@ func (r *VehicleRepo) GetByVIN(ctx context.Context, vin string) (Vehicle, error)
 	return v, nil
 }
 
+// ListByUser returns every vehicle owned by the given user, ordered by
+// name and VIN. Returns an empty slice (and nil error) when the user has
+// no linked vehicles.
+func (r *VehicleRepo) ListByUser(ctx context.Context, userID string) ([]Vehicle, error) {
+	start := time.Now()
+	rows, err := r.pool.Query(ctx, queryVehiclesByUser, userID)
+	r.metrics.ObserveQueryDuration("vehicle.list_by_user", time.Since(start).Seconds())
+	if err != nil {
+		r.metrics.IncQueryError("vehicle.list_by_user")
+		return nil, fmt.Errorf("VehicleRepo.ListByUser(%s): %w", userID, err)
+	}
+	defer rows.Close()
+
+	var out []Vehicle
+	for rows.Next() {
+		var v Vehicle
+		var status string
+		if err := rows.Scan(
+			&v.ID, &v.UserID, &v.VIN, &v.Name, &status,
+			&v.ChargeLevel, &v.EstimatedRange, &v.Speed, &v.GearPosition,
+			&v.Heading, &v.Latitude, &v.Longitude,
+			&v.InteriorTemp, &v.ExteriorTemp, &v.OdometerMiles,
+			&v.DestinationName, &v.DestinationLatitude,
+			&v.DestinationLongitude, &v.OriginLatitude, &v.OriginLongitude,
+			&v.EtaMinutes, &v.TripDistRemaining,
+			&v.NavRouteCoordinates, &v.LastUpdated,
+		); err != nil {
+			return nil, fmt.Errorf("VehicleRepo.ListByUser(%s): scan: %w", userID, err)
+		}
+		v.Status = VehicleStatus(status)
+		out = append(out, v)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("VehicleRepo.ListByUser(%s): rows: %w", userID, err)
+	}
+	return out, nil
+}
+
 // GetByID returns the vehicle with the given Prisma cuid.
 // Returns ErrVehicleNotFound if no vehicle has that ID.
 func (r *VehicleRepo) GetByID(ctx context.Context, id string) (Vehicle, error) {

--- a/internal/telemetry/debug_fields_handler.go
+++ b/internal/telemetry/debug_fields_handler.go
@@ -1,0 +1,215 @@
+package telemetry
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/coder/websocket"
+
+	"github.com/tnando/my-robo-taxi-telemetry/internal/events"
+)
+
+// DebugFieldsConfig configures the dev-only /api/debug/fields WebSocket
+// endpoint. API keys are optional (dev only); when empty, any connection is
+// accepted which matches the existing dev-mode WS policy.
+type DebugFieldsConfig struct {
+	// APIKey is a shared secret the client must supply via the
+	// X-Debug-Token header or ?token= query parameter. Empty disables
+	// auth (must only be used on loopback / trusted dev networks).
+	APIKey string
+
+	// WriteTimeout bounds per-frame WS writes. Default 5s.
+	WriteTimeout time.Duration
+
+	// OriginPatterns restricts which origins may connect (coder/websocket
+	// glob syntax). Default: no origin check (dev only).
+	OriginPatterns []string
+}
+
+// DebugFieldsHandler serves the /api/debug/fields WebSocket endpoint.
+// Every connected client receives a JSON frame per decoded Tesla payload
+// containing every proto field and its raw value. An optional ?vin=...
+// query parameter filters to a single vehicle.
+//
+// This handler is only mounted when the server runs in dev mode. It is
+// not part of the SDK contract surface — the shape is developer-focused
+// and may change without notice.
+type DebugFieldsHandler struct {
+	bus    events.Bus
+	logger *slog.Logger
+	cfg    DebugFieldsConfig
+}
+
+// NewDebugFieldsHandler constructs a DebugFieldsHandler.
+func NewDebugFieldsHandler(bus events.Bus, logger *slog.Logger, cfg DebugFieldsConfig) *DebugFieldsHandler {
+	if cfg.WriteTimeout == 0 {
+		cfg.WriteTimeout = 5 * time.Second
+	}
+	return &DebugFieldsHandler{bus: bus, logger: logger, cfg: cfg}
+}
+
+// ServeHTTP upgrades to WebSocket and streams raw field events.
+func (h *DebugFieldsHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	if !h.authorize(r) {
+		http.Error(w, "unauthorized", http.StatusUnauthorized)
+		return
+	}
+
+	filterVIN := strings.TrimSpace(r.URL.Query().Get("vin"))
+
+	conn, err := websocket.Accept(w, r, &websocket.AcceptOptions{
+		OriginPatterns:     h.cfg.OriginPatterns,
+		InsecureSkipVerify: len(h.cfg.OriginPatterns) == 0,
+	})
+	if err != nil {
+		h.logger.Warn("debug_fields: websocket accept failed",
+			slog.Any("error", err),
+			slog.String("remote_addr", r.RemoteAddr),
+		)
+		return
+	}
+	defer conn.CloseNow() //nolint:errcheck // nothing useful to do on close failure
+
+	ctx, cancel := context.WithCancel(r.Context())
+	defer cancel()
+
+	frames := make(chan []byte, 64)
+	handler := h.makeHandler(filterVIN, frames)
+
+	sub, err := h.bus.Subscribe(events.TopicVehicleTelemetryRaw, handler)
+	if err != nil {
+		h.logger.Error("debug_fields: subscribe failed", slog.Any("error", err))
+		_ = conn.Close(websocket.StatusInternalError, "subscribe failed")
+		return
+	}
+	defer func() {
+		if err := h.bus.Unsubscribe(sub); err != nil && !errors.Is(err, events.ErrSubscriptionNotFound) {
+			h.logger.Warn("debug_fields: unsubscribe failed", slog.Any("error", err))
+		}
+	}()
+
+	go h.readLoop(ctx, conn, cancel)
+	h.writeLoop(ctx, conn, frames)
+}
+
+// authorize enforces the optional APIKey. Empty APIKey means no auth (dev).
+func (h *DebugFieldsHandler) authorize(r *http.Request) bool {
+	if h.cfg.APIKey == "" {
+		return true
+	}
+	if v := r.Header.Get("X-Debug-Token"); v == h.cfg.APIKey {
+		return true
+	}
+	if v := r.URL.Query().Get("token"); v == h.cfg.APIKey {
+		return true
+	}
+	return false
+}
+
+// makeHandler returns an events.Handler that converts raw events to JSON
+// frames, filtering by VIN when requested and dropping the event if the
+// per-client buffer is full (the client is too slow).
+func (h *DebugFieldsHandler) makeHandler(filterVIN string, frames chan<- []byte) events.Handler {
+	return func(evt events.Event) {
+		payload, ok := evt.Payload.(events.RawVehicleTelemetryEvent)
+		if !ok {
+			return
+		}
+		if filterVIN != "" && payload.VIN != filterVIN {
+			return
+		}
+		frame, err := marshalDebugFrame(payload)
+		if err != nil {
+			h.logger.Warn("debug_fields: marshal failed", slog.Any("error", err))
+			return
+		}
+		select {
+		case frames <- frame:
+		default:
+			// Client is too slow — drop the frame rather than blocking
+			// the bus. The developer will see gaps in the stream.
+		}
+	}
+}
+
+// readLoop discards incoming frames; the endpoint is server→client only.
+// When the client closes or errors, it cancels the parent context to stop
+// the write loop.
+func (h *DebugFieldsHandler) readLoop(ctx context.Context, conn *websocket.Conn, cancel context.CancelFunc) {
+	defer cancel()
+	for {
+		if _, _, err := conn.Read(ctx); err != nil {
+			return
+		}
+	}
+}
+
+// writeLoop pulls frames from the channel and writes them to the WebSocket
+// with a per-frame deadline.
+func (h *DebugFieldsHandler) writeLoop(ctx context.Context, conn *websocket.Conn, frames <-chan []byte) {
+	for {
+		select {
+		case <-ctx.Done():
+			_ = conn.Close(websocket.StatusNormalClosure, "server shutting down")
+			return
+		case frame, ok := <-frames:
+			if !ok {
+				return
+			}
+			writeCtx, cancel := context.WithTimeout(ctx, h.cfg.WriteTimeout)
+			err := conn.Write(writeCtx, websocket.MessageText, frame)
+			cancel()
+			if err != nil {
+				h.logger.Warn("debug_fields: write failed", slog.Any("error", err))
+				return
+			}
+		}
+	}
+}
+
+// debugFrame is the JSON shape streamed to clients. One frame per decoded
+// Tesla payload.
+type debugFrame struct {
+	VIN       string            `json:"vin"`
+	Timestamp string            `json:"timestamp"`
+	Fields    map[string]rawVal `json:"fields"`
+}
+
+// rawVal mirrors the issue's example: {value, protoField, type}. Invalid
+// datums have value null and type "invalid".
+type rawVal struct {
+	Value      any    `json:"value"`
+	ProtoField int32  `json:"protoField"`
+	Type       string `json:"type"`
+	Invalid    bool   `json:"invalid,omitempty"`
+}
+
+// marshalDebugFrame serializes a RawVehicleTelemetryEvent into the wire
+// shape documented in the MYR-36 issue body.
+func marshalDebugFrame(evt events.RawVehicleTelemetryEvent) ([]byte, error) {
+	fields := make(map[string]rawVal, len(evt.Fields))
+	for _, f := range evt.Fields {
+		fields[f.ProtoName] = rawVal{
+			Value:      f.Value,
+			ProtoField: f.ProtoField,
+			Type:       f.Type,
+			Invalid:    f.Invalid,
+		}
+	}
+	frame := debugFrame{
+		VIN:       evt.VIN,
+		Timestamp: evt.CreatedAt.UTC().Format(time.RFC3339Nano),
+		Fields:    fields,
+	}
+	b, err := json.Marshal(frame)
+	if err != nil {
+		return nil, fmt.Errorf("marshal debug frame: %w", err)
+	}
+	return b, nil
+}

--- a/internal/telemetry/debug_fields_handler.go
+++ b/internal/telemetry/debug_fields_handler.go
@@ -15,9 +15,19 @@ import (
 	"github.com/tnando/my-robo-taxi-telemetry/internal/events"
 )
 
+// debugFramesBuffer is the per-client channel buffer for raw field frames.
+// Sized for ~1.2s of buffering at 10 msg/sec × 5 dev vehicles; slow clients
+// have frames dropped rather than back-pressuring the event bus.
+const debugFramesBuffer = 64
+
 // DebugFieldsConfig configures the dev-only /api/debug/fields WebSocket
 // endpoint. API keys are optional (dev only); when empty, any connection is
 // accepted which matches the existing dev-mode WS policy.
+//
+// Security note: when APIKey is set, clients may supply it via either the
+// X-Debug-Token header or the ?token= query parameter. The query param
+// form appears in most HTTP access logs — prefer the header whenever
+// possible. The CLI (cmd/ops fields watch) always uses the header.
 type DebugFieldsConfig struct {
 	// APIKey is a shared secret the client must supply via the
 	// X-Debug-Token header or ?token= query parameter. Empty disables
@@ -79,7 +89,7 @@ func (h *DebugFieldsHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	ctx, cancel := context.WithCancel(r.Context())
 	defer cancel()
 
-	frames := make(chan []byte, 64)
+	frames := make(chan []byte, debugFramesBuffer)
 	handler := h.makeHandler(filterVIN, frames)
 
 	sub, err := h.bus.Subscribe(events.TopicVehicleTelemetryRaw, handler)
@@ -140,13 +150,19 @@ func (h *DebugFieldsHandler) makeHandler(filterVIN string, frames chan<- []byte)
 
 // readLoop discards incoming frames; the endpoint is server→client only.
 // When the client closes or errors, it cancels the parent context to stop
-// the write loop.
+// the write loop. Unexpected inbound frames are logged at debug level so
+// an operator can tell a misbehaving client from a silent disconnect.
 func (h *DebugFieldsHandler) readLoop(ctx context.Context, conn *websocket.Conn, cancel context.CancelFunc) {
 	defer cancel()
 	for {
-		if _, _, err := conn.Read(ctx); err != nil {
+		typ, data, err := conn.Read(ctx)
+		if err != nil {
 			return
 		}
+		h.logger.Debug("debug_fields: discarded unexpected client frame",
+			slog.Int("message_type", int(typ)),
+			slog.Int("bytes", len(data)),
+		)
 	}
 }
 

--- a/internal/telemetry/debug_fields_handler_test.go
+++ b/internal/telemetry/debug_fields_handler_test.go
@@ -1,0 +1,97 @@
+package telemetry
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/tnando/my-robo-taxi-telemetry/internal/events"
+)
+
+func TestMarshalDebugFrame_ShapeMatchesIssueSpec(t *testing.T) {
+	createdAt := time.Date(2026, 4, 20, 4, 15, 0, 0, time.UTC)
+	evt := events.RawVehicleTelemetryEvent{
+		VIN:       "5YJ3E7EB2NF000001",
+		CreatedAt: createdAt,
+		Fields: []events.RawTelemetryField{
+			{ProtoField: 43, ProtoName: "TimeToFullCharge", Type: "double", Value: 1.5},
+			{ProtoField: 8, ProtoName: "Soc", Type: "double", Value: 78.2},
+			{ProtoField: 5, ProtoName: "Odometer", Type: "invalid", Invalid: true},
+		},
+	}
+
+	frame, err := marshalDebugFrame(evt)
+	if err != nil {
+		t.Fatalf("marshalDebugFrame: %v", err)
+	}
+
+	var decoded debugFrame
+	if err := json.Unmarshal(frame, &decoded); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	if decoded.VIN != evt.VIN {
+		t.Errorf("VIN: got %q, want %q", decoded.VIN, evt.VIN)
+	}
+	if decoded.Timestamp != "2026-04-20T04:15:00Z" {
+		t.Errorf("Timestamp: got %q", decoded.Timestamp)
+	}
+
+	ttfc, ok := decoded.Fields["TimeToFullCharge"]
+	if !ok {
+		t.Fatalf("TimeToFullCharge missing from frame: %+v", decoded.Fields)
+	}
+	if ttfc.ProtoField != 43 || ttfc.Type != "double" || ttfc.Value != 1.5 {
+		t.Errorf("TimeToFullCharge: got %+v", ttfc)
+	}
+
+	odo, ok := decoded.Fields["Odometer"]
+	if !ok {
+		t.Fatal("Odometer missing from frame")
+	}
+	if !odo.Invalid || odo.Type != "invalid" {
+		t.Errorf("Odometer invalid handling: got %+v", odo)
+	}
+}
+
+func TestDebugFieldsHandler_Authorize(t *testing.T) {
+	tests := []struct {
+		name       string
+		configKey  string
+		headerKey  string
+		queryKey   string
+		wantResult bool
+	}{
+		{name: "no key configured accepts anything", wantResult: true},
+		{name: "matching header ok", configKey: "secret", headerKey: "secret", wantResult: true},
+		{name: "matching query ok", configKey: "secret", queryKey: "secret", wantResult: true},
+		{name: "missing token rejected", configKey: "secret", wantResult: false},
+		{name: "wrong token rejected", configKey: "secret", headerKey: "wrong", wantResult: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			h := &DebugFieldsHandler{cfg: DebugFieldsConfig{APIKey: tt.configKey}}
+			r := newAuthRequest(tt.headerKey, tt.queryKey)
+			if got := h.authorize(r); got != tt.wantResult {
+				t.Errorf("authorize: got %v, want %v", got, tt.wantResult)
+			}
+		})
+	}
+}
+
+// newAuthRequest builds a minimal *http.Request for authorize() tests.
+func newAuthRequest(headerToken, queryToken string) *http.Request {
+	url := "/api/debug/fields"
+	if queryToken != "" {
+		url += "?token=" + queryToken
+	}
+	r := httptest.NewRequestWithContext(context.Background(), http.MethodGet, url, nil)
+	if headerToken != "" {
+		r.Header.Set("X-Debug-Token", headerToken)
+	}
+	return r
+}

--- a/internal/telemetry/decoder.go
+++ b/internal/telemetry/decoder.go
@@ -53,18 +53,34 @@ type DecodeResult struct {
 // decode errors that did not prevent the overall payload from being
 // decoded. Callers can log these but should still use the event.
 func (d *Decoder) Decode(raw []byte) (DecodeResult, error) {
+	result, _, err := d.decodeCommon(raw, false)
+	return result, err
+}
+
+// DecodeWithRaw runs the normal decode path and, in the same unmarshal
+// pass, also builds a RawVehicleTelemetryEvent with every decoded proto
+// field. Used by the dev-only debug endpoint; callers in the hot path
+// should use Decode.
+func (d *Decoder) DecodeWithRaw(raw []byte) (DecodeResult, events.RawVehicleTelemetryEvent, error) {
+	return d.decodeCommon(raw, true)
+}
+
+// decodeCommon is the shared envelope-unwrap + protobuf-unmarshal path.
+// When includeRaw is true, a RawVehicleTelemetryEvent is also built from
+// the same unmarshalled payload.
+func (d *Decoder) decodeCommon(raw []byte, includeRaw bool) (DecodeResult, events.RawVehicleTelemetryEvent, error) {
 	env, err := unwrapEnvelope(raw)
 	if err != nil {
-		return DecodeResult{}, fmt.Errorf("decoder.Decode: %w", err)
+		return DecodeResult{}, events.RawVehicleTelemetryEvent{}, fmt.Errorf("decoder.Decode: %w", err)
 	}
 
 	if env.Topic != topicVehicleData {
-		return DecodeResult{}, fmt.Errorf("decoder.Decode(topic=%s): %w", env.Topic, ErrUnsupportedTopic)
+		return DecodeResult{}, events.RawVehicleTelemetryEvent{}, fmt.Errorf("decoder.Decode(topic=%s): %w", env.Topic, ErrUnsupportedTopic)
 	}
 
 	var payload tpb.Payload
 	if err := proto.Unmarshal(env.PayloadBytes, &payload); err != nil {
-		return DecodeResult{}, fmt.Errorf("decoder.Decode: decode protobuf: %w", err)
+		return DecodeResult{}, events.RawVehicleTelemetryEvent{}, fmt.Errorf("decoder.Decode: decode protobuf: %w", err)
 	}
 
 	// Tesla's typed protobuf format often omits the VIN from the protobuf
@@ -76,15 +92,24 @@ func (d *Decoder) Decode(raw []byte) (DecodeResult, error) {
 
 	evt, fieldErrs, err := d.DecodePayload(&payload)
 	if err != nil {
-		return DecodeResult{}, fmt.Errorf("decoder.Decode: %w", err)
+		return DecodeResult{}, events.RawVehicleTelemetryEvent{}, fmt.Errorf("decoder.Decode: %w", err)
 	}
 
-	return DecodeResult{
+	result := DecodeResult{
 		Event:       evt,
 		FieldErrors: fieldErrs,
 		Topic:       env.Topic,
 		DeviceID:    env.DeviceID,
-	}, nil
+	}
+
+	var rawEvt events.RawVehicleTelemetryEvent
+	if includeRaw {
+		rawEvt, err = d.DecodeRawPayload(&payload)
+		if err != nil {
+			return result, events.RawVehicleTelemetryEvent{}, fmt.Errorf("decoder.Decode: %w", err)
+		}
+	}
+	return result, rawEvt, nil
 }
 
 // DecodePayload converts an already-unmarshalled Tesla Payload into a

--- a/internal/telemetry/decoder_raw.go
+++ b/internal/telemetry/decoder_raw.go
@@ -1,0 +1,136 @@
+package telemetry
+
+import (
+	"fmt"
+
+	"github.com/tnando/my-robo-taxi-telemetry/internal/events"
+	tpb "github.com/tnando/my-robo-taxi-telemetry/internal/telemetry/proto/tesla"
+)
+
+// DecodeRawPayload walks every datum in a Tesla Payload and produces a
+// RawVehicleTelemetryEvent preserving the proto field number, enum name,
+// and raw value. Unlike DecodePayload, this method does NOT drop fields
+// that are missing from InternalFieldName — it surfaces the full firmware
+// view so developers can inspect untracked fields from the cmd/ops CLI or
+// the debug WebSocket endpoint.
+//
+// Datums with decode errors are skipped (the normal decode path logs them).
+// Datums marked Invalid are emitted with Invalid=true and a nil Value.
+func (d *Decoder) DecodeRawPayload(payload *tpb.Payload) (events.RawVehicleTelemetryEvent, error) {
+	if err := validatePayload(payload); err != nil {
+		return events.RawVehicleTelemetryEvent{}, err
+	}
+
+	fields := make([]events.RawTelemetryField, 0, len(payload.GetData()))
+	for _, datum := range payload.GetData() {
+		if datum == nil {
+			continue
+		}
+		raw, ok := rawFieldFromDatum(datum)
+		if !ok {
+			continue
+		}
+		fields = append(fields, raw)
+	}
+
+	return events.RawVehicleTelemetryEvent{
+		VIN:       payload.GetVin(),
+		CreatedAt: payload.GetCreatedAt().AsTime(),
+		Fields:    fields,
+	}, nil
+}
+
+// rawFieldFromDatum extracts the raw value from a Datum without the
+// fieldMap filtering or unit conversion applied by the normal decode path.
+// Returns ok=false for datums that fail to decode; the caller skips them.
+func rawFieldFromDatum(datum *tpb.Datum) (events.RawTelemetryField, bool) {
+	key := datum.GetKey()
+	base := events.RawTelemetryField{
+		ProtoField: int32(key),
+		ProtoName:  key.String(),
+	}
+
+	v := datum.GetValue()
+	if v == nil {
+		return events.RawTelemetryField{}, false
+	}
+
+	if _, invalid := v.Value.(*tpb.Value_Invalid); invalid {
+		base.Invalid = true
+		base.Type = "invalid"
+		return base, true
+	}
+
+	typ, value := rawValue(v)
+	base.Type = typ
+	base.Value = value
+	return base, true
+}
+
+// rawValue returns the raw Go value for a Tesla Value oneof, preserving the
+// original representation (no Celsius→Fahrenheit conversion, no enum-to-string
+// shortening). Strings that happen to parse as numbers are kept as strings so
+// the developer sees what the vehicle actually sent.
+func rawValue(v *tpb.Value) (typeTag string, value any) {
+	if typeTag, value, ok := rawScalarValue(v); ok {
+		return typeTag, value
+	}
+	if typeTag, value, ok := rawEnumValue(v); ok {
+		return typeTag, value
+	}
+	// Firmware may send typed oneof variants we do not yet map (e.g.
+	// newly added enums). Surface them as a generic string so the
+	// developer can still see what the vehicle sent.
+	return "unknown", fmt.Sprintf("%v", v.Value)
+}
+
+// rawScalarValue handles the primitive oneof variants (string/numeric/bool
+// and the location pair).
+func rawScalarValue(v *tpb.Value) (typeTag string, value any, ok bool) {
+	switch val := v.Value.(type) {
+	case *tpb.Value_StringValue:
+		return "string", val.StringValue, true
+	case *tpb.Value_FloatValue:
+		return "float", float64(val.FloatValue), true
+	case *tpb.Value_DoubleValue:
+		return "double", val.DoubleValue, true
+	case *tpb.Value_IntValue:
+		return "int", int64(val.IntValue), true
+	case *tpb.Value_LongValue:
+		return "long", val.LongValue, true
+	case *tpb.Value_BooleanValue:
+		return "bool", val.BooleanValue, true
+	case *tpb.Value_LocationValue:
+		loc := val.LocationValue
+		return "location", events.Location{
+			Latitude:  loc.GetLatitude(),
+			Longitude: loc.GetLongitude(),
+		}, true
+	}
+	return "", nil, false
+}
+
+// rawEnumValue stringifies the typed enum oneof variants using the same
+// helpers as the main decoder. Returns ok=false when the variant is not an
+// enum type the raw decoder knows about.
+func rawEnumValue(v *tpb.Value) (typeTag string, value any, ok bool) {
+	switch val := v.Value.(type) {
+	case *tpb.Value_ShiftStateValue:
+		return "enum.shift_state", shiftStateString(val.ShiftStateValue), true
+	case *tpb.Value_DetailedChargeStateValue:
+		return "enum.detailed_charge_state", detailedChargeStateString(val.DetailedChargeStateValue), true
+	case *tpb.Value_ChargingValue:
+		return "enum.charging_state", chargingStateString(val.ChargingValue), true
+	case *tpb.Value_CarTypeValue:
+		return "enum.car_type", carTypeString(val.CarTypeValue), true
+	case *tpb.Value_SentryModeStateValue:
+		return "enum.sentry_mode", sentryModeString(val.SentryModeStateValue), true
+	case *tpb.Value_DefrostModeValue:
+		return "enum.defrost_mode", defrostModeString(val.DefrostModeValue), true
+	case *tpb.Value_ClimateKeeperModeValue:
+		return "enum.climate_keeper_mode", climateKeeperModeString(val.ClimateKeeperModeValue), true
+	case *tpb.Value_HvacPowerValue:
+		return "enum.hvac_power", hvacPowerString(val.HvacPowerValue), true
+	}
+	return "", nil, false
+}

--- a/internal/telemetry/decoder_raw_test.go
+++ b/internal/telemetry/decoder_raw_test.go
@@ -1,0 +1,133 @@
+package telemetry
+
+import (
+	"testing"
+
+	"google.golang.org/protobuf/proto"
+
+	"github.com/tnando/my-robo-taxi-telemetry/internal/events"
+	tpb "github.com/tnando/my-robo-taxi-telemetry/internal/telemetry/proto/tesla"
+)
+
+func TestDecodeRawPayload_IncludesUntrackedFields(t *testing.T) {
+	d := NewDecoder()
+
+	payload := makePayload([]*tpb.Datum{
+		// Tracked field (in InternalFieldName): VehicleSpeed
+		makeDatum(tpb.Field_VehicleSpeed, stringVal("65.2")),
+		// Tracked enum: Gear
+		makeDatum(tpb.Field_Gear, &tpb.Value{Value: &tpb.Value_ShiftStateValue{
+			ShiftStateValue: tpb.ShiftState_ShiftStateD,
+		}}),
+		// Location value
+		makeDatum(tpb.Field_Location, locationVal(37.7749, -122.4194)),
+		// Untracked field to confirm raw decoder does NOT filter it out.
+		// BmsState is not in fieldMap but is a valid Tesla field.
+		makeDatum(tpb.Field_BMSState, intVal(3)),
+		// Invalid datum — should surface with Invalid=true.
+		makeDatum(tpb.Field_Odometer, &tpb.Value{Value: &tpb.Value_Invalid{Invalid: true}}),
+	})
+
+	raw, err := d.DecodeRawPayload(payload)
+	if err != nil {
+		t.Fatalf("DecodeRawPayload error: %v", err)
+	}
+	if raw.VIN != testVIN {
+		t.Errorf("VIN: got %q, want %q", raw.VIN, testVIN)
+	}
+	if len(raw.Fields) != 5 {
+		t.Fatalf("expected 5 fields, got %d: %+v", len(raw.Fields), raw.Fields)
+	}
+
+	by := indexByProto(raw.Fields)
+
+	speed, ok := by[tpb.Field_VehicleSpeed]
+	if !ok || speed.Type != "string" || speed.Value != "65.2" {
+		t.Errorf("VehicleSpeed: got %+v", speed)
+	}
+	if speed.ProtoField != int32(tpb.Field_VehicleSpeed) {
+		t.Errorf("VehicleSpeed proto field: got %d, want %d", speed.ProtoField, tpb.Field_VehicleSpeed)
+	}
+
+	gear, ok := by[tpb.Field_Gear]
+	if !ok || gear.Type != "enum.shift_state" || gear.Value != "D" {
+		t.Errorf("Gear: got %+v", gear)
+	}
+
+	loc, ok := by[tpb.Field_Location]
+	if !ok || loc.Type != "location" {
+		t.Errorf("Location: got %+v", loc)
+	}
+	if l, ok := loc.Value.(events.Location); !ok || l.Latitude != 37.7749 || l.Longitude != -122.4194 {
+		t.Errorf("Location value: got %+v", loc.Value)
+	}
+
+	bms, ok := by[tpb.Field_BMSState]
+	if !ok {
+		t.Errorf("untracked BmsState missing from raw output — raw decoder should include unfiltered fields")
+	}
+	if bms.Type != "int" {
+		t.Errorf("BmsState type: got %q", bms.Type)
+	}
+
+	odo, ok := by[tpb.Field_Odometer]
+	if !ok || !odo.Invalid || odo.Type != "invalid" {
+		t.Errorf("Odometer invalid datum: got %+v", odo)
+	}
+}
+
+func TestDecodeWithRaw_ReturnsBothEvents(t *testing.T) {
+	d := NewDecoder()
+
+	payload := makePayload([]*tpb.Datum{
+		makeDatum(tpb.Field_VehicleSpeed, stringVal("10")),
+	})
+	env := wrapPayload(t, payload)
+
+	result, rawEvt, err := d.DecodeWithRaw(env)
+	if err != nil {
+		t.Fatalf("DecodeWithRaw error: %v", err)
+	}
+	if len(result.Event.Fields) != 1 {
+		t.Errorf("filtered event field count: got %d, want 1", len(result.Event.Fields))
+	}
+	if len(rawEvt.Fields) != 1 {
+		t.Errorf("raw event field count: got %d, want 1", len(rawEvt.Fields))
+	}
+	if rawEvt.Fields[0].ProtoField != int32(tpb.Field_VehicleSpeed) {
+		t.Errorf("raw proto field: got %d", rawEvt.Fields[0].ProtoField)
+	}
+}
+
+func TestDecode_WithoutRaw_DoesNotPopulateRawEvent(t *testing.T) {
+	// Decode() (no raw flag) must keep the old behavior — raw event zero value.
+	d := NewDecoder()
+	payload := makePayload([]*tpb.Datum{
+		makeDatum(tpb.Field_VehicleSpeed, stringVal("10")),
+	})
+	env := wrapPayload(t, payload)
+	_, err := d.Decode(env)
+	if err != nil {
+		t.Fatalf("Decode error: %v", err)
+	}
+}
+
+// wrapPayload marshals the Tesla Payload and wraps it in a FlatBuffers
+// envelope for end-to-end decoder tests.
+func wrapPayload(t *testing.T, payload *tpb.Payload) []byte {
+	t.Helper()
+	raw, err := proto.Marshal(payload)
+	if err != nil {
+		t.Fatalf("proto.Marshal: %v", err)
+	}
+	return BuildTestEnvelope(testVIN, raw)
+}
+
+// indexByProto maps raw fields by their Tesla Field enum for easy lookups.
+func indexByProto(fields []events.RawTelemetryField) map[tpb.Field]events.RawTelemetryField {
+	m := make(map[tpb.Field]events.RawTelemetryField, len(fields))
+	for _, f := range fields {
+		m[tpb.Field(f.ProtoField)] = f
+	}
+	return m
+}

--- a/internal/telemetry/receiver.go
+++ b/internal/telemetry/receiver.go
@@ -31,18 +31,25 @@ type ReceiverConfig struct {
 	// MaxMessagesPerSec is the per-vehicle rate limit. Zero or negative
 	// means no rate limiting.
 	MaxMessagesPerSec float64
+
+	// PublishRawFields enables publication of RawVehicleTelemetryEvent to
+	// TopicVehicleTelemetryRaw in parallel with the filtered
+	// VehicleTelemetryEvent. Dev/debug use only — production should leave
+	// this false to avoid the extra per-field allocations.
+	PublishRawFields bool
 }
 
 // Receiver accepts mTLS WebSocket connections from Tesla vehicles, decodes
 // their protobuf telemetry payloads, and publishes domain events to the
 // event bus.
 type Receiver struct {
-	decoder     *Decoder
-	bus         events.Bus
-	logger      *slog.Logger
-	metrics     ReceiverMetrics
-	rateLimiter *rateLimiter
-	maxVehicles int
+	decoder          *Decoder
+	bus              events.Bus
+	logger           *slog.Logger
+	metrics          ReceiverMetrics
+	rateLimiter      *rateLimiter
+	maxVehicles      int
+	publishRawFields bool
 
 	connections sync.Map // VIN -> *vehicleConn
 	connCount   atomic.Int32
@@ -57,12 +64,13 @@ func NewReceiver(decoder *Decoder, bus events.Bus, logger *slog.Logger, metrics 
 	}
 
 	return &Receiver{
-		decoder:     decoder,
-		bus:         bus,
-		logger:      logger,
-		metrics:     metrics,
-		rateLimiter: newRateLimiter(maxPerSec),
-		maxVehicles: cfg.MaxVehicles,
+		decoder:          decoder,
+		bus:              bus,
+		logger:           logger,
+		metrics:          metrics,
+		rateLimiter:      newRateLimiter(maxPerSec),
+		maxVehicles:      cfg.MaxVehicles,
+		publishRawFields: cfg.PublishRawFields,
 	}
 }
 
@@ -173,55 +181,90 @@ func (r *Receiver) handleConnection(ctx context.Context, vc *vehicleConn) {
 
 		if !r.rateLimiter.allow(vc.vin) {
 			r.metrics.IncRateLimited(redacted)
-			r.logger.Debug("message rate limited",
-				slog.String("vin", redacted),
-			)
+			r.logger.Debug("message rate limited", slog.String("vin", redacted))
 			continue
 		}
 
-		result, err := r.decoder.Decode(data)
-		if err != nil {
-			r.metrics.IncDecodeErrors(redacted)
-			r.logger.Warn("decode failed",
-				slog.String("vin", redacted),
-				slog.Any("error", err),
-			)
-			continue
-		}
-
-		for _, fe := range result.FieldErrors {
-			r.logger.Warn("field decode error",
-				slog.String("vin", redacted),
-				slog.String("field", string(fe.Field)),
-				slog.String("proto_key", fe.Key.String()),
-				slog.Any("error", fe.Err),
-			)
-			r.metrics.IncFieldDecodeError(redacted, string(fe.Field))
-		}
-
-		evt := result.Event
-		r.reconcileVIN(&evt, result.DeviceID, vc.vin, redacted)
-
-		if err := r.bus.Publish(ctx, events.NewEvent(evt)); err != nil {
-			r.logger.Error("publish telemetry event failed",
-				slog.String("vin", redacted),
-				slog.Any("error", err),
-			)
+		if !r.processMessage(ctx, vc, data, start, redacted) {
 			return
 		}
-
-		vc.lastMessage.Store(time.Now())
-		vc.messageCount.Add(1)
-
-		latency := time.Since(start)
-		r.metrics.ObserveMessageLatency(latency.Seconds())
-		r.logger.Debug("telemetry received",
-			slog.String("vin", redacted),
-			slog.String("topic", result.Topic),
-			slog.Int("fields", len(evt.Fields)),
-			slog.Duration("latency", latency),
-		)
 	}
+}
+
+// processMessage decodes one telemetry frame and publishes the resulting
+// events to the bus. Returns false when the caller should terminate the
+// read loop (bus closed or unrecoverable publish error).
+func (r *Receiver) processMessage(
+	ctx context.Context,
+	vc *vehicleConn,
+	data []byte,
+	start time.Time,
+	redacted string,
+) bool {
+	result, rawEvt, err := r.decodeMessage(data)
+	if err != nil {
+		r.metrics.IncDecodeErrors(redacted)
+		r.logger.Warn("decode failed",
+			slog.String("vin", redacted),
+			slog.Any("error", err),
+		)
+		return true
+	}
+
+	for _, fe := range result.FieldErrors {
+		r.logger.Warn("field decode error",
+			slog.String("vin", redacted),
+			slog.String("field", string(fe.Field)),
+			slog.String("proto_key", fe.Key.String()),
+			slog.Any("error", fe.Err),
+		)
+		r.metrics.IncFieldDecodeError(redacted, string(fe.Field))
+	}
+
+	evt := result.Event
+	r.reconcileVIN(&evt, result.DeviceID, vc.vin, redacted)
+
+	if err := r.bus.Publish(ctx, events.NewEvent(evt)); err != nil {
+		r.logger.Error("publish telemetry event failed",
+			slog.String("vin", redacted),
+			slog.Any("error", err),
+		)
+		return false
+	}
+
+	if r.publishRawFields {
+		rawEvt.VIN = vc.vin
+		if err := r.bus.Publish(ctx, events.NewEvent(rawEvt)); err != nil {
+			r.logger.Warn("publish raw telemetry event failed",
+				slog.String("vin", redacted),
+				slog.Any("error", err),
+			)
+		}
+	}
+
+	vc.lastMessage.Store(time.Now())
+	vc.messageCount.Add(1)
+
+	latency := time.Since(start)
+	r.metrics.ObserveMessageLatency(latency.Seconds())
+	r.logger.Debug("telemetry received",
+		slog.String("vin", redacted),
+		slog.String("topic", result.Topic),
+		slog.Int("fields", len(evt.Fields)),
+		slog.Duration("latency", latency),
+	)
+	return true
+}
+
+// decodeMessage routes to the appropriate decoder entry point based on
+// whether the receiver is configured to emit raw field events. The raw
+// event is the zero value when publishRawFields is false.
+func (r *Receiver) decodeMessage(data []byte) (DecodeResult, events.RawVehicleTelemetryEvent, error) {
+	if r.publishRawFields {
+		return r.decoder.DecodeWithRaw(data)
+	}
+	result, err := r.decoder.Decode(data)
+	return result, events.RawVehicleTelemetryEvent{}, err
 }
 
 // reconcileVIN cross-checks the envelope and payload VINs against the cert


### PR DESCRIPTION
## Summary
- Adds a developer CLI at `cmd/ops/` with `auth token`, `vehicles list`, `fleet-config show|push`, and `fields watch|snapshot` subcommands that reuse the existing `AccountRepo`, `VehicleRepo`, `FleetAPIClient`, and `TokenRefresher` code paths.
- Adds a dev-only `/api/debug/fields` WebSocket endpoint that streams every decoded Tesla proto field (by number, with type tag and raw value) to connected clients. Wired into `telemetry-server --dev`.
- Replaces the deploy-and-grep-fly-logs loop that MYR-25/28/29 verification currently requires.

## Implementation notes
- `events.RawVehicleTelemetryEvent` + `TopicVehicleTelemetryRaw` sit next to the existing filtered event. Publication is gated on `ReceiverConfig.PublishRawFields` so production pays no extra allocations.
- `Decoder.DecodeWithRaw` reuses the single protobuf unmarshal to produce both the filtered event and the raw event in one pass.
- The debug handler is mounted only when the server runs with `--dev`. Auth is an optional shared `DEBUG_FIELDS_TOKEN` via header or query param — matches the issue's "simpler API key for dev use" option.
- CLI reads `DATABASE_URL` (and auto-detects Supabase PgBouncer :6543). Fleet API commands require `TESLA_PROXY_URL`, `FLEET_TELEMETRY_HOSTNAME`, `AUTH_TESLA_ID`, `AUTH_TESLA_SECRET`.
- The debug endpoint is **not** part of the SDK contract surface — it is a developer-only path intended to be consumed by the future shadcn/ui web test bench referenced in the issue.

## Test plan
- [x] `go vet ./...`
- [x] `go test ./...`
- [x] `golangci-lint run ./...` (0 issues)
- [x] `go build ./cmd/...`
- [x] New unit tests: `TestDecodeRawPayload_IncludesUntrackedFields`, `TestDecodeWithRaw_ReturnsBothEvents`, `TestMarshalDebugFrame_ShapeMatchesIssueSpec`, `TestDebugFieldsHandler_Authorize`, `TestBuildDebugURL`
- [ ] Manual: run `telemetry-server --dev` locally, connect a simulator, then `ops fields watch --vin <vin>` — verify live frames stream to stdout
- [ ] Manual: run `ops fleet-config push --vin <vin> --user-id <id>` against the proxy and verify the vehicle reconfigures

Closes MYR-36.