### PR TITLE
MYR-37 Add ops auth link (Tesla OAuth authorization_code + PKCE)

### DIFF
--- a/cmd/ops/auth.go
+++ b/cmd/ops/auth.go
@@ -20,11 +20,13 @@ var errRefreshSkipped = errors.New("tesla token refresh skipped")
 
 func runAuth(ctx context.Context, args []string) error {
 	if len(args) == 0 {
-		return fmt.Errorf("auth requires a subcommand (token)")
+		return fmt.Errorf("auth requires a subcommand (token | link)")
 	}
 	switch args[0] {
 	case "token":
 		return runAuthToken(ctx, args[1:])
+	case "link":
+		return runAuthLink(ctx, args[1:])
 	default:
 		return fmt.Errorf("unknown auth subcommand %q", args[0])
 	}

--- a/cmd/ops/auth_link.go
+++ b/cmd/ops/auth_link.go
@@ -2,23 +2,16 @@ package main
 
 import (
 	"context"
-	"crypto/rand"
-	"crypto/sha256"
-	"encoding/base64"
-	"encoding/json"
 	"errors"
 	"flag"
 	"fmt"
 	"html"
-	"io"
 	"log/slog"
 	"net"
 	"net/http"
-	"net/url"
 	"os"
 	"os/exec"
 	"runtime"
-	"strings"
 	"time"
 
 	"github.com/tnando/my-robo-taxi-telemetry/internal/store"
@@ -118,53 +111,9 @@ func runAuthLink(ctx context.Context, args []string) error {
 
 	return writeJSON(os.Stdout, authLinkOutput{
 		UserID:    *userID,
-		ExpiresAt: expiresAt.UTC().Format(time.RFC3339),
+		ExpiresAt: formatExpiry(expiresAt),
 		Message:   "Tesla account linked — run `ops auth token` to verify",
 	})
-}
-
-// pkcePair holds a PKCE verifier/challenge pair for a single OAuth flow.
-type pkcePair struct {
-	verifier  string
-	challenge string
-}
-
-// newPKCE generates a fresh PKCE verifier + S256 challenge per RFC 7636.
-// The verifier is a URL-safe random string; the challenge is
-// base64url(sha256(verifier)) without padding.
-func newPKCE() (pkcePair, error) {
-	verifier, err := randomURLSafeString(32)
-	if err != nil {
-		return pkcePair{}, err
-	}
-	sum := sha256.Sum256([]byte(verifier))
-	challenge := base64.RawURLEncoding.EncodeToString(sum[:])
-	return pkcePair{verifier: verifier, challenge: challenge}, nil
-}
-
-// randomURLSafeString returns n bytes of cryptographic randomness encoded
-// with unpadded base64url, producing a string safe to use in URLs and
-// query parameters.
-func randomURLSafeString(n int) (string, error) {
-	b := make([]byte, n)
-	if _, err := rand.Read(b); err != nil {
-		return "", fmt.Errorf("rand.Read: %w", err)
-	}
-	return base64.RawURLEncoding.EncodeToString(b), nil
-}
-
-// buildAuthorizeURL constructs the Tesla /oauth2/v3/authorize URL that
-// starts the authorization_code + PKCE flow.
-func buildAuthorizeURL(clientID, redirectURI, scopes, state, codeChallenge string) string {
-	q := url.Values{}
-	q.Set("response_type", "code")
-	q.Set("client_id", clientID)
-	q.Set("redirect_uri", redirectURI)
-	q.Set("scope", scopes)
-	q.Set("state", state)
-	q.Set("code_challenge", codeChallenge)
-	q.Set("code_challenge_method", "S256")
-	return teslaOAuthAuthorizeURL + "?" + q.Encode()
 }
 
 // runCallbackServer starts a one-shot HTTP server on 127.0.0.1:<port>,
@@ -234,6 +183,8 @@ type callbackResult struct {
 // callbackHandler returns an http.HandlerFunc that validates the state
 // parameter, surfaces Tesla-reported errors, and forwards the auth code
 // through the result channel. The page the user sees reflects the outcome.
+// Non-blocking sends protect against duplicate callbacks (double-click,
+// refresh) holding handler goroutines open forever.
 func callbackHandler(expectedState string, result chan<- callbackResult) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		q := r.URL.Query()
@@ -241,25 +192,35 @@ func callbackHandler(expectedState string, result chan<- callbackResult) http.Ha
 		if errCode := q.Get("error"); errCode != "" {
 			msg := fmt.Sprintf("Tesla rejected the authorization: %s — %s", errCode, q.Get("error_description"))
 			respondCallback(w, http.StatusBadRequest, "OAuth failed", msg)
-			result <- callbackResult{err: fmt.Errorf("tesla oauth error: %s: %s", errCode, q.Get("error_description"))}
+			trySendResult(result, callbackResult{err: fmt.Errorf("tesla oauth error: %s: %s", errCode, q.Get("error_description"))})
 			return
 		}
 
 		if gotState := q.Get("state"); gotState != expectedState {
 			respondCallback(w, http.StatusBadRequest, "State mismatch", "The OAuth state parameter did not match. Possible CSRF — retry the command.")
-			result <- callbackResult{err: errors.New("oauth state mismatch")}
+			trySendResult(result, callbackResult{err: errors.New("oauth state mismatch")})
 			return
 		}
 
 		code := q.Get("code")
 		if code == "" {
 			respondCallback(w, http.StatusBadRequest, "Missing code", "Tesla did not return an authorization code.")
-			result <- callbackResult{err: errors.New("tesla returned no authorization code")}
+			trySendResult(result, callbackResult{err: errors.New("tesla returned no authorization code")})
 			return
 		}
 
 		respondCallback(w, http.StatusOK, "Tesla account linked", "You can close this tab and return to the terminal.")
-		result <- callbackResult{code: code}
+		trySendResult(result, callbackResult{code: code})
+	}
+}
+
+// trySendResult forwards r to the buffered channel without blocking. A
+// second concurrent callback (e.g. browser retry) is silently dropped
+// rather than holding its handler goroutine open.
+func trySendResult(ch chan<- callbackResult, r callbackResult) {
+	select {
+	case ch <- r:
+	default:
 	}
 }
 
@@ -279,15 +240,20 @@ func respondCallback(w http.ResponseWriter, status int, title, body string) {
 // openBrowser tries to open browserURL in the user's default browser using
 // the platform-appropriate command. On failure it logs a warning; the
 // user is already told to open the URL manually in the stderr banner.
+//
+// The URL passed here is the authorize URL built by buildAuthorizeURL
+// from static constants plus CLI flags and env vars — not arbitrary
+// user input — so gosec G204 (subprocess launched with variable) is
+// suppressed on each exec call.
 func openBrowser(ctx context.Context, logger *slog.Logger, browserURL string) {
 	var cmd *exec.Cmd
 	switch runtime.GOOS {
 	case "darwin":
-		cmd = exec.CommandContext(ctx, "open", browserURL)
+		cmd = exec.CommandContext(ctx, "open", browserURL) //#nosec G204 -- browserURL is the CLI-built Tesla authorize URL
 	case "linux":
-		cmd = exec.CommandContext(ctx, "xdg-open", browserURL)
+		cmd = exec.CommandContext(ctx, "xdg-open", browserURL) //#nosec G204 -- browserURL is the CLI-built Tesla authorize URL
 	case "windows":
-		cmd = exec.CommandContext(ctx, "rundll32", "url.dll,FileProtocolHandler", browserURL)
+		cmd = exec.CommandContext(ctx, "rundll32", "url.dll,FileProtocolHandler", browserURL) //#nosec G204 -- browserURL is the CLI-built Tesla authorize URL
 	default:
 		logger.Warn("unsupported platform for auto-open — open the URL manually",
 			slog.String("platform", runtime.GOOS),
@@ -297,61 +263,4 @@ func openBrowser(ctx context.Context, logger *slog.Logger, browserURL string) {
 	if err := cmd.Start(); err != nil {
 		logger.Warn("failed to auto-open browser", slog.Any("error", err))
 	}
-}
-
-// tokenResponse mirrors Tesla's /oauth2/v3/token response body.
-type tokenResponse struct {
-	AccessToken  string `json:"access_token"`
-	RefreshToken string `json:"refresh_token"`
-	ExpiresIn    int64  `json:"expires_in"`
-	TokenType    string `json:"token_type"`
-}
-
-// exchangeCodeForToken swaps the one-time authorization code (plus PKCE
-// verifier) for an access_token / refresh_token pair.
-func exchangeCodeForToken(
-	ctx context.Context,
-	logger *slog.Logger,
-	clientID, clientSecret, redirectURI, code, codeVerifier string,
-) (*tokenResponse, error) {
-	form := url.Values{}
-	form.Set("grant_type", "authorization_code")
-	form.Set("client_id", clientID)
-	form.Set("client_secret", clientSecret)
-	form.Set("code", code)
-	form.Set("redirect_uri", redirectURI)
-	form.Set("code_verifier", codeVerifier)
-
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, teslaOAuthTokenURL, strings.NewReader(form.Encode()))
-	if err != nil {
-		return nil, fmt.Errorf("build token request: %w", err)
-	}
-	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
-
-	resp, err := http.DefaultClient.Do(req)
-	if err != nil {
-		return nil, fmt.Errorf("post to token endpoint: %w", err)
-	}
-	defer resp.Body.Close()
-
-	body, err := io.ReadAll(io.LimitReader(resp.Body, 1<<16))
-	if err != nil {
-		return nil, fmt.Errorf("read token response: %w", err)
-	}
-	if resp.StatusCode != http.StatusOK {
-		logger.Warn("tesla token exchange failed",
-			slog.Int("status", resp.StatusCode),
-			slog.String("body", string(body)),
-		)
-		return nil, fmt.Errorf("tesla returned %d: %s", resp.StatusCode, string(body))
-	}
-
-	var tok tokenResponse
-	if err := json.Unmarshal(body, &tok); err != nil {
-		return nil, fmt.Errorf("decode token response: %w", err)
-	}
-	if tok.AccessToken == "" || tok.RefreshToken == "" {
-		return nil, errors.New("tesla response missing access_token or refresh_token")
-	}
-	return &tok, nil
 }

--- a/cmd/ops/auth_link.go
+++ b/cmd/ops/auth_link.go
@@ -1,0 +1,357 @@
+package main
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"html"
+	"io"
+	"log/slog"
+	"net"
+	"net/http"
+	"net/url"
+	"os"
+	"os/exec"
+	"runtime"
+	"strings"
+	"time"
+
+	"github.com/tnando/my-robo-taxi-telemetry/internal/store"
+)
+
+const (
+	// defaultCallbackPort is the local HTTP port the CLI listens on for the
+	// Tesla OAuth redirect. This port must be registered as an allowed
+	// redirect URI on the Tesla Fleet API app: http://localhost:<port>/callback.
+	defaultCallbackPort = 8765
+
+	// defaultOAuthTimeout bounds how long the CLI waits for the user to
+	// complete the browser flow before giving up.
+	defaultOAuthTimeout = 2 * time.Minute
+
+	// teslaOAuthAuthorizeURL is Tesla's OAuth2 authorize endpoint.
+	teslaOAuthAuthorizeURL = "https://auth.tesla.com/oauth2/v3/authorize"
+
+	// teslaOAuthTokenURL is Tesla's OAuth2 token endpoint (same one used
+	// by refresh_token grant).
+	teslaOAuthTokenURL = "https://auth.tesla.com/oauth2/v3/token" //#nosec G101 -- public OAuth endpoint URL, not a credential
+
+	// defaultTeslaOAuthScopes is the Fleet API scope set needed by the
+	// ops CLI (read telemetry + push fleet config commands).
+	defaultTeslaOAuthScopes = "openid offline_access vehicle_device_data vehicle_cmds vehicle_charging_cmds"
+)
+
+// authLinkOutput is the JSON shape printed on success.
+type authLinkOutput struct {
+	UserID    string `json:"userId"`
+	ExpiresAt string `json:"expiresAt"`
+	Message   string `json:"message"`
+}
+
+// runAuthLink drives the full Tesla OAuth2 authorization_code + PKCE flow:
+// spins up a localhost callback server, opens the Tesla authorize URL in
+// the developer's browser, exchanges the returned code for fresh tokens,
+// and persists them to the Account row.
+func runAuthLink(ctx context.Context, args []string) error {
+	fs := flag.NewFlagSet("auth link", flag.ContinueOnError)
+	userID := fs.String("user-id", "", "MyRoboTaxi user id (Prisma cuid)")
+	port := fs.Int("port", defaultCallbackPort, "local HTTP port for the OAuth callback (must match the redirect URI registered on the Tesla Fleet API app)")
+	scopes := fs.String("scopes", defaultTeslaOAuthScopes, "space-separated OAuth scopes to request")
+	timeout := fs.Duration("timeout", defaultOAuthTimeout, "how long to wait for the browser flow to complete")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	if err := requireFlag("user-id", *userID); err != nil {
+		return err
+	}
+
+	clientID := os.Getenv("AUTH_TESLA_ID")
+	clientSecret := os.Getenv("AUTH_TESLA_SECRET")
+	if clientID == "" || clientSecret == "" {
+		return fmt.Errorf("AUTH_TESLA_ID and AUTH_TESLA_SECRET must be set to link a Tesla account")
+	}
+
+	logger := newLogger()
+	db, err := openDB(ctx, logger)
+	if err != nil {
+		return err
+	}
+	defer db.Close()
+
+	pkce, err := newPKCE()
+	if err != nil {
+		return fmt.Errorf("generate pkce: %w", err)
+	}
+	state, err := randomURLSafeString(24)
+	if err != nil {
+		return fmt.Errorf("generate state: %w", err)
+	}
+
+	redirectURI := fmt.Sprintf("http://localhost:%d/callback", *port)
+	authorizeURL := buildAuthorizeURL(clientID, redirectURI, *scopes, state, pkce.challenge)
+
+	code, err := runCallbackServer(ctx, logger, *port, state, authorizeURL, *timeout)
+	if err != nil {
+		return err
+	}
+
+	tok, err := exchangeCodeForToken(ctx, logger, clientID, clientSecret, redirectURI, code, pkce.verifier)
+	if err != nil {
+		return fmt.Errorf("exchange code for token: %w", err)
+	}
+
+	accountRepo := store.NewAccountRepo(db.Pool())
+	expiresAt := time.Now().Add(time.Duration(tok.ExpiresIn) * time.Second)
+	if err := accountRepo.UpdateTeslaToken(ctx, *userID, tok.AccessToken, tok.RefreshToken, expiresAt.Unix()); err != nil {
+		return fmt.Errorf("persist tesla token: %w", err)
+	}
+
+	logger.Info("tesla account linked",
+		slog.String("user_id", *userID),
+		slog.Time("expires_at", expiresAt),
+	)
+
+	return writeJSON(os.Stdout, authLinkOutput{
+		UserID:    *userID,
+		ExpiresAt: expiresAt.UTC().Format(time.RFC3339),
+		Message:   "Tesla account linked — run `ops auth token` to verify",
+	})
+}
+
+// pkcePair holds a PKCE verifier/challenge pair for a single OAuth flow.
+type pkcePair struct {
+	verifier  string
+	challenge string
+}
+
+// newPKCE generates a fresh PKCE verifier + S256 challenge per RFC 7636.
+// The verifier is a URL-safe random string; the challenge is
+// base64url(sha256(verifier)) without padding.
+func newPKCE() (pkcePair, error) {
+	verifier, err := randomURLSafeString(32)
+	if err != nil {
+		return pkcePair{}, err
+	}
+	sum := sha256.Sum256([]byte(verifier))
+	challenge := base64.RawURLEncoding.EncodeToString(sum[:])
+	return pkcePair{verifier: verifier, challenge: challenge}, nil
+}
+
+// randomURLSafeString returns n bytes of cryptographic randomness encoded
+// with unpadded base64url, producing a string safe to use in URLs and
+// query parameters.
+func randomURLSafeString(n int) (string, error) {
+	b := make([]byte, n)
+	if _, err := rand.Read(b); err != nil {
+		return "", fmt.Errorf("rand.Read: %w", err)
+	}
+	return base64.RawURLEncoding.EncodeToString(b), nil
+}
+
+// buildAuthorizeURL constructs the Tesla /oauth2/v3/authorize URL that
+// starts the authorization_code + PKCE flow.
+func buildAuthorizeURL(clientID, redirectURI, scopes, state, codeChallenge string) string {
+	q := url.Values{}
+	q.Set("response_type", "code")
+	q.Set("client_id", clientID)
+	q.Set("redirect_uri", redirectURI)
+	q.Set("scope", scopes)
+	q.Set("state", state)
+	q.Set("code_challenge", codeChallenge)
+	q.Set("code_challenge_method", "S256")
+	return teslaOAuthAuthorizeURL + "?" + q.Encode()
+}
+
+// runCallbackServer starts a one-shot HTTP server on 127.0.0.1:<port>,
+// opens the authorize URL in the user's browser, and blocks until either
+// the callback fires with a matching state+code, the context is cancelled,
+// or the timeout elapses. Returns the authorization code on success.
+func runCallbackServer(
+	ctx context.Context,
+	logger *slog.Logger,
+	port int,
+	expectedState, authorizeURL string,
+	timeout time.Duration,
+) (string, error) {
+	var lc net.ListenConfig
+	listener, err := lc.Listen(ctx, "tcp", fmt.Sprintf("127.0.0.1:%d", port))
+	if err != nil {
+		return "", fmt.Errorf("listen on port %d (is it registered as a redirect URI on Tesla?): %w", port, err)
+	}
+
+	result := make(chan callbackResult, 1)
+	mux := http.NewServeMux()
+	mux.HandleFunc("/callback", callbackHandler(expectedState, result))
+	mux.HandleFunc("/", func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, "ops: waiting on /callback", http.StatusNotFound)
+	})
+
+	server := &http.Server{Handler: mux, ReadHeaderTimeout: 5 * time.Second}
+	go func() {
+		if err := server.Serve(listener); err != nil && !errors.Is(err, http.ErrServerClosed) {
+			logger.Warn("callback server error", slog.Any("error", err))
+		}
+	}()
+
+	fmt.Fprintf(os.Stderr, "\nOpening Tesla login in your browser…\nIf nothing opens, visit this URL manually:\n\n  %s\n\nWaiting for callback on %s …\n\n", authorizeURL, listener.Addr())
+	openBrowser(ctx, logger, authorizeURL)
+
+	waitCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	defer func() {
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		defer cancel()
+		_ = server.Shutdown(shutdownCtx)
+	}()
+
+	select {
+	case <-waitCtx.Done():
+		if errors.Is(waitCtx.Err(), context.DeadlineExceeded) {
+			return "", fmt.Errorf("timed out after %s waiting for Tesla OAuth callback", timeout)
+		}
+		return "", fmt.Errorf("oauth flow cancelled: %w", waitCtx.Err())
+	case r := <-result:
+		if r.err != nil {
+			return "", r.err
+		}
+		return r.code, nil
+	}
+}
+
+// callbackResult carries the outcome of a single callback request back to
+// the waiting runCallbackServer goroutine.
+type callbackResult struct {
+	code string
+	err  error
+}
+
+// callbackHandler returns an http.HandlerFunc that validates the state
+// parameter, surfaces Tesla-reported errors, and forwards the auth code
+// through the result channel. The page the user sees reflects the outcome.
+func callbackHandler(expectedState string, result chan<- callbackResult) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		q := r.URL.Query()
+
+		if errCode := q.Get("error"); errCode != "" {
+			msg := fmt.Sprintf("Tesla rejected the authorization: %s — %s", errCode, q.Get("error_description"))
+			respondCallback(w, http.StatusBadRequest, "OAuth failed", msg)
+			result <- callbackResult{err: fmt.Errorf("tesla oauth error: %s: %s", errCode, q.Get("error_description"))}
+			return
+		}
+
+		if gotState := q.Get("state"); gotState != expectedState {
+			respondCallback(w, http.StatusBadRequest, "State mismatch", "The OAuth state parameter did not match. Possible CSRF — retry the command.")
+			result <- callbackResult{err: errors.New("oauth state mismatch")}
+			return
+		}
+
+		code := q.Get("code")
+		if code == "" {
+			respondCallback(w, http.StatusBadRequest, "Missing code", "Tesla did not return an authorization code.")
+			result <- callbackResult{err: errors.New("tesla returned no authorization code")}
+			return
+		}
+
+		respondCallback(w, http.StatusOK, "Tesla account linked", "You can close this tab and return to the terminal.")
+		result <- callbackResult{code: code}
+	}
+}
+
+// respondCallback writes a tiny HTML page confirming the outcome to the
+// user's browser. title/body are HTML-escaped before interpolation.
+func respondCallback(w http.ResponseWriter, status int, title, body string) {
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	w.WriteHeader(status)
+	safeTitle := html.EscapeString(title)
+	safeBody := html.EscapeString(body)
+	fmt.Fprintf(w,
+		`<!doctype html><html><head><title>%[1]s</title><meta charset="utf-8"><style>body{font:16px/1.4 system-ui,sans-serif;max-width:480px;margin:48px auto;padding:0 16px;color:#111}h1{font-size:20px}</style></head><body><h1>%[1]s</h1><p>%[2]s</p></body></html>`,
+		safeTitle, safeBody,
+	)
+}
+
+// openBrowser tries to open browserURL in the user's default browser using
+// the platform-appropriate command. On failure it logs a warning; the
+// user is already told to open the URL manually in the stderr banner.
+func openBrowser(ctx context.Context, logger *slog.Logger, browserURL string) {
+	var cmd *exec.Cmd
+	switch runtime.GOOS {
+	case "darwin":
+		cmd = exec.CommandContext(ctx, "open", browserURL)
+	case "linux":
+		cmd = exec.CommandContext(ctx, "xdg-open", browserURL)
+	case "windows":
+		cmd = exec.CommandContext(ctx, "rundll32", "url.dll,FileProtocolHandler", browserURL)
+	default:
+		logger.Warn("unsupported platform for auto-open — open the URL manually",
+			slog.String("platform", runtime.GOOS),
+		)
+		return
+	}
+	if err := cmd.Start(); err != nil {
+		logger.Warn("failed to auto-open browser", slog.Any("error", err))
+	}
+}
+
+// tokenResponse mirrors Tesla's /oauth2/v3/token response body.
+type tokenResponse struct {
+	AccessToken  string `json:"access_token"`
+	RefreshToken string `json:"refresh_token"`
+	ExpiresIn    int64  `json:"expires_in"`
+	TokenType    string `json:"token_type"`
+}
+
+// exchangeCodeForToken swaps the one-time authorization code (plus PKCE
+// verifier) for an access_token / refresh_token pair.
+func exchangeCodeForToken(
+	ctx context.Context,
+	logger *slog.Logger,
+	clientID, clientSecret, redirectURI, code, codeVerifier string,
+) (*tokenResponse, error) {
+	form := url.Values{}
+	form.Set("grant_type", "authorization_code")
+	form.Set("client_id", clientID)
+	form.Set("client_secret", clientSecret)
+	form.Set("code", code)
+	form.Set("redirect_uri", redirectURI)
+	form.Set("code_verifier", codeVerifier)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, teslaOAuthTokenURL, strings.NewReader(form.Encode()))
+	if err != nil {
+		return nil, fmt.Errorf("build token request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("post to token endpoint: %w", err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 1<<16))
+	if err != nil {
+		return nil, fmt.Errorf("read token response: %w", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		logger.Warn("tesla token exchange failed",
+			slog.Int("status", resp.StatusCode),
+			slog.String("body", string(body)),
+		)
+		return nil, fmt.Errorf("tesla returned %d: %s", resp.StatusCode, string(body))
+	}
+
+	var tok tokenResponse
+	if err := json.Unmarshal(body, &tok); err != nil {
+		return nil, fmt.Errorf("decode token response: %w", err)
+	}
+	if tok.AccessToken == "" || tok.RefreshToken == "" {
+		return nil, errors.New("tesla response missing access_token or refresh_token")
+	}
+	return &tok, nil
+}

--- a/cmd/ops/auth_link_test.go
+++ b/cmd/ops/auth_link_test.go
@@ -4,13 +4,14 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/base64"
-	"encoding/json"
 	"io"
+	"log/slog"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
 	"strings"
 	"testing"
+	"time"
 )
 
 func TestNewPKCE_ChallengeIsSha256OfVerifier(t *testing.T) {
@@ -68,6 +69,24 @@ func TestBuildAuthorizeURL_ContainsAllRequiredParams(t *testing.T) {
 	for k, want := range checks {
 		if got := q.Get(k); got != want {
 			t.Errorf("param %s: got %q, want %q", k, got, want)
+		}
+	}
+}
+
+func TestBuildTokenExchangeForm_AssemblesAllFields(t *testing.T) {
+	form := buildTokenExchangeForm("cid", "csec", "http://localhost:8765/callback", "the-code", "pkce-verifier")
+
+	want := map[string]string{
+		"grant_type":    "authorization_code",
+		"client_id":     "cid",
+		"client_secret": "csec",
+		"code":          "the-code",
+		"redirect_uri":  "http://localhost:8765/callback",
+		"code_verifier": "pkce-verifier",
+	}
+	for k, v := range want {
+		if got := form.Get(k); got != v {
+			t.Errorf("form[%s]: got %q, want %q", k, got, v)
 		}
 	}
 }
@@ -133,7 +152,31 @@ func TestCallbackHandler_TeslaErrorSurfaced(t *testing.T) {
 	}
 }
 
-func TestExchangeCodeForToken_SendsExpectedFormAndParsesResponse(t *testing.T) {
+func TestCallbackHandler_DuplicateSendDoesNotBlock(t *testing.T) {
+	// Buffered capacity 1 — if the handler blocked on a second send, this
+	// test would deadlock.
+	result := make(chan callbackResult, 1)
+	handler := callbackHandler("s", result)
+
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/callback?state=s&code=c1", nil)
+	handler(httptest.NewRecorder(), req)
+
+	req2 := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/callback?state=s&code=c2", nil)
+	// Must not block even though the channel is full. Use a timeout guard
+	// so a regression surfaces as a test failure instead of a hang.
+	done := make(chan struct{})
+	go func() {
+		handler(httptest.NewRecorder(), req2)
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(1 * time.Second):
+		t.Fatal("duplicate callback blocked on full channel")
+	}
+}
+
+func TestExchangeCodeForToken_SuccessParses200Response(t *testing.T) {
 	var gotForm url.Values
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		body, _ := io.ReadAll(r.Body)
@@ -141,57 +184,76 @@ func TestExchangeCodeForToken_SendsExpectedFormAndParsesResponse(t *testing.T) {
 		if ct := r.Header.Get("Content-Type"); ct != "application/x-www-form-urlencoded" {
 			t.Errorf("content-type: got %q", ct)
 		}
-		// Write the JSON manually to avoid the gosec G117 literal-struct
-		// scanner flagging the fake token values as "marshaled secrets".
+		// Literal JSON avoids the gosec G117 literal-struct credential scanner.
 		_, _ = w.Write([]byte(`{"access_token":"fake-access","refresh_token":"fake-refresh","expires_in":3600,"token_type":"Bearer"}`))
 	}))
 	defer srv.Close()
+	withTokenEndpoint(t, srv.URL)
 
-	// Swap the package-level constant by temporarily overriding via a thin
-	// indirection: the function uses teslaOAuthTokenURL, so we can't mock it
-	// without touching the constant. Use t.Run to document the expected
-	// form fields against a locally-built request instead.
-	form := url.Values{}
-	form.Set("grant_type", "authorization_code")
-	form.Set("client_id", "cid")
-	form.Set("client_secret", "csec")
-	form.Set("code", "the-code")
-	form.Set("redirect_uri", "http://localhost:8765/callback")
-	form.Set("code_verifier", "pkce-verifier")
-
-	req, err := http.NewRequestWithContext(context.Background(), http.MethodPost, srv.URL, strings.NewReader(form.Encode()))
+	tok, err := exchangeCodeForToken(
+		context.Background(),
+		slog.Default(),
+		"cid", "csec", "http://localhost:8765/callback", "the-code", "pkce-verifier",
+	)
 	if err != nil {
-		t.Fatalf("build request: %v", err)
-	}
-	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
-	resp, err := srv.Client().Do(req)
-	if err != nil {
-		t.Fatalf("post: %v", err)
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode != http.StatusOK {
-		t.Fatalf("status: %d", resp.StatusCode)
-	}
-	var tok tokenResponse
-	if err := json.NewDecoder(resp.Body).Decode(&tok); err != nil {
-		t.Fatalf("decode: %v", err)
+		t.Fatalf("exchangeCodeForToken: %v", err)
 	}
 	if tok.AccessToken != "fake-access" || tok.RefreshToken != "fake-refresh" {
 		t.Errorf("token decode: %+v", tok)
 	}
-
-	wantForm := map[string]string{
+	if tok.ExpiresIn != 3600 {
+		t.Errorf("expires_in: %d", tok.ExpiresIn)
+	}
+	// Confirm the real function built the expected form body.
+	for k, want := range map[string]string{
 		"grant_type":    "authorization_code",
 		"client_id":     "cid",
 		"client_secret": "csec",
 		"code":          "the-code",
 		"redirect_uri":  "http://localhost:8765/callback",
 		"code_verifier": "pkce-verifier",
-	}
-	for k, want := range wantForm {
+	} {
 		if got := gotForm.Get(k); got != want {
 			t.Errorf("form[%s]: got %q, want %q", k, got, want)
 		}
 	}
+}
+
+func TestExchangeCodeForToken_Non200ReturnsError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+		_, _ = w.Write([]byte(`{"error":"invalid_grant"}`))
+	}))
+	defer srv.Close()
+	withTokenEndpoint(t, srv.URL)
+
+	_, err := exchangeCodeForToken(context.Background(), slog.Default(), "c", "s", "r", "c", "v")
+	if err == nil {
+		t.Fatal("expected error on 401")
+	}
+	if !strings.Contains(err.Error(), "401") || !strings.Contains(err.Error(), "invalid_grant") {
+		t.Errorf("error should include status + body, got: %v", err)
+	}
+}
+
+func TestExchangeCodeForToken_MissingTokenFieldsRejected(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"access_token":"","refresh_token":"","expires_in":0}`))
+	}))
+	defer srv.Close()
+	withTokenEndpoint(t, srv.URL)
+
+	_, err := exchangeCodeForToken(context.Background(), slog.Default(), "c", "s", "r", "c", "v")
+	if err == nil || !strings.Contains(err.Error(), "missing access_token") {
+		t.Errorf("expected missing-token error, got: %v", err)
+	}
+}
+
+// withTokenEndpoint points the Tesla token endpoint at a test server for
+// the duration of a single test and restores the production URL at the end.
+func withTokenEndpoint(t *testing.T, endpoint string) {
+	t.Helper()
+	prev := teslaOAuthTokenEndpoint
+	teslaOAuthTokenEndpoint = endpoint
+	t.Cleanup(func() { teslaOAuthTokenEndpoint = prev })
 }

--- a/cmd/ops/auth_link_test.go
+++ b/cmd/ops/auth_link_test.go
@@ -1,0 +1,197 @@
+package main
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+)
+
+func TestNewPKCE_ChallengeIsSha256OfVerifier(t *testing.T) {
+	pkce, err := newPKCE()
+	if err != nil {
+		t.Fatalf("newPKCE: %v", err)
+	}
+	if pkce.verifier == "" || pkce.challenge == "" {
+		t.Fatalf("empty pkce pair: %+v", pkce)
+	}
+
+	// challenge must be base64url(sha256(verifier)) with no padding.
+	sum := sha256.Sum256([]byte(pkce.verifier))
+	want := base64.RawURLEncoding.EncodeToString(sum[:])
+	if pkce.challenge != want {
+		t.Errorf("challenge mismatch: got %q, want %q", pkce.challenge, want)
+	}
+
+	// Two consecutive pkce pairs must differ.
+	other, err := newPKCE()
+	if err != nil {
+		t.Fatalf("second newPKCE: %v", err)
+	}
+	if other.verifier == pkce.verifier {
+		t.Error("expected distinct verifiers across pkce pairs")
+	}
+}
+
+func TestBuildAuthorizeURL_ContainsAllRequiredParams(t *testing.T) {
+	urlStr := buildAuthorizeURL(
+		"client-123",
+		"http://localhost:8765/callback",
+		"openid offline_access",
+		"state-xyz",
+		"challenge-abc",
+	)
+
+	u, err := url.Parse(urlStr)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if got := u.Scheme + "://" + u.Host + u.Path; got != teslaOAuthAuthorizeURL {
+		t.Errorf("endpoint: got %q, want %q", got, teslaOAuthAuthorizeURL)
+	}
+	q := u.Query()
+	checks := map[string]string{
+		"response_type":         "code",
+		"client_id":             "client-123",
+		"redirect_uri":          "http://localhost:8765/callback",
+		"scope":                 "openid offline_access",
+		"state":                 "state-xyz",
+		"code_challenge":        "challenge-abc",
+		"code_challenge_method": "S256",
+	}
+	for k, want := range checks {
+		if got := q.Get(k); got != want {
+			t.Errorf("param %s: got %q, want %q", k, got, want)
+		}
+	}
+}
+
+func TestCallbackHandler_SuccessPath(t *testing.T) {
+	result := make(chan callbackResult, 1)
+	handler := callbackHandler("expected-state", result)
+
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet,
+		"/callback?state=expected-state&code=code-xyz", nil)
+	rec := httptest.NewRecorder()
+	handler(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Errorf("status: got %d, want 200", rec.Code)
+	}
+	select {
+	case r := <-result:
+		if r.err != nil {
+			t.Errorf("unexpected err: %v", r.err)
+		}
+		if r.code != "code-xyz" {
+			t.Errorf("code: got %q, want code-xyz", r.code)
+		}
+	default:
+		t.Fatal("handler did not write to result channel")
+	}
+}
+
+func TestCallbackHandler_StateMismatchRejected(t *testing.T) {
+	result := make(chan callbackResult, 1)
+	handler := callbackHandler("expected-state", result)
+
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet,
+		"/callback?state=wrong&code=code-xyz", nil)
+	rec := httptest.NewRecorder()
+	handler(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("status: got %d, want 400", rec.Code)
+	}
+	r := <-result
+	if r.err == nil || !strings.Contains(r.err.Error(), "state mismatch") {
+		t.Errorf("expected state mismatch error, got %v", r.err)
+	}
+}
+
+func TestCallbackHandler_TeslaErrorSurfaced(t *testing.T) {
+	result := make(chan callbackResult, 1)
+	handler := callbackHandler("expected-state", result)
+
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet,
+		"/callback?error=access_denied&error_description=user+declined", nil)
+	rec := httptest.NewRecorder()
+	handler(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("status: got %d, want 400", rec.Code)
+	}
+	r := <-result
+	if r.err == nil || !strings.Contains(r.err.Error(), "access_denied") {
+		t.Errorf("expected access_denied error, got %v", r.err)
+	}
+}
+
+func TestExchangeCodeForToken_SendsExpectedFormAndParsesResponse(t *testing.T) {
+	var gotForm url.Values
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		gotForm, _ = url.ParseQuery(string(body))
+		if ct := r.Header.Get("Content-Type"); ct != "application/x-www-form-urlencoded" {
+			t.Errorf("content-type: got %q", ct)
+		}
+		// Write the JSON manually to avoid the gosec G117 literal-struct
+		// scanner flagging the fake token values as "marshaled secrets".
+		_, _ = w.Write([]byte(`{"access_token":"fake-access","refresh_token":"fake-refresh","expires_in":3600,"token_type":"Bearer"}`))
+	}))
+	defer srv.Close()
+
+	// Swap the package-level constant by temporarily overriding via a thin
+	// indirection: the function uses teslaOAuthTokenURL, so we can't mock it
+	// without touching the constant. Use t.Run to document the expected
+	// form fields against a locally-built request instead.
+	form := url.Values{}
+	form.Set("grant_type", "authorization_code")
+	form.Set("client_id", "cid")
+	form.Set("client_secret", "csec")
+	form.Set("code", "the-code")
+	form.Set("redirect_uri", "http://localhost:8765/callback")
+	form.Set("code_verifier", "pkce-verifier")
+
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodPost, srv.URL, strings.NewReader(form.Encode()))
+	if err != nil {
+		t.Fatalf("build request: %v", err)
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	resp, err := srv.Client().Do(req)
+	if err != nil {
+		t.Fatalf("post: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status: %d", resp.StatusCode)
+	}
+	var tok tokenResponse
+	if err := json.NewDecoder(resp.Body).Decode(&tok); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if tok.AccessToken != "fake-access" || tok.RefreshToken != "fake-refresh" {
+		t.Errorf("token decode: %+v", tok)
+	}
+
+	wantForm := map[string]string{
+		"grant_type":    "authorization_code",
+		"client_id":     "cid",
+		"client_secret": "csec",
+		"code":          "the-code",
+		"redirect_uri":  "http://localhost:8765/callback",
+		"code_verifier": "pkce-verifier",
+	}
+	for k, want := range wantForm {
+		if got := gotForm.Get(k); got != want {
+			t.Errorf("form[%s]: got %q, want %q", k, got, want)
+		}
+	}
+}

--- a/cmd/ops/auth_oauth.go
+++ b/cmd/ops/auth_oauth.go
@@ -1,0 +1,137 @@
+package main
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+)
+
+// tokenExchangeTimeout bounds the code → token HTTP roundtrip. The parent
+// context also cancels the request, but this floor protects against a
+// hung TCP connection to auth.tesla.com.
+const tokenExchangeTimeout = 15 * time.Second
+
+// teslaOAuthTokenEndpoint holds the Tesla /oauth2/v3/token URL in a
+// package-level var (rather than const) so tests can redirect it to an
+// httptest.Server. Production code reads it unchanged.
+var teslaOAuthTokenEndpoint = teslaOAuthTokenURL
+
+// pkcePair holds a PKCE verifier/challenge pair for a single OAuth flow.
+type pkcePair struct {
+	verifier  string
+	challenge string
+}
+
+// newPKCE generates a fresh PKCE verifier + S256 challenge per RFC 7636.
+// The verifier is a URL-safe random string; the challenge is
+// base64url(sha256(verifier)) without padding.
+func newPKCE() (pkcePair, error) {
+	verifier, err := randomURLSafeString(32)
+	if err != nil {
+		return pkcePair{}, err
+	}
+	sum := sha256.Sum256([]byte(verifier))
+	challenge := base64.RawURLEncoding.EncodeToString(sum[:])
+	return pkcePair{verifier: verifier, challenge: challenge}, nil
+}
+
+// randomURLSafeString returns n bytes of cryptographic randomness encoded
+// with unpadded base64url, producing a string safe to use in URLs and
+// query parameters.
+func randomURLSafeString(n int) (string, error) {
+	b := make([]byte, n)
+	if _, err := rand.Read(b); err != nil {
+		return "", fmt.Errorf("rand.Read: %w", err)
+	}
+	return base64.RawURLEncoding.EncodeToString(b), nil
+}
+
+// buildAuthorizeURL constructs the Tesla /oauth2/v3/authorize URL that
+// starts the authorization_code + PKCE flow.
+func buildAuthorizeURL(clientID, redirectURI, scopes, state, codeChallenge string) string {
+	q := url.Values{}
+	q.Set("response_type", "code")
+	q.Set("client_id", clientID)
+	q.Set("redirect_uri", redirectURI)
+	q.Set("scope", scopes)
+	q.Set("state", state)
+	q.Set("code_challenge", codeChallenge)
+	q.Set("code_challenge_method", "S256")
+	return teslaOAuthAuthorizeURL + "?" + q.Encode()
+}
+
+// tokenResponse mirrors Tesla's /oauth2/v3/token response body.
+type tokenResponse struct {
+	AccessToken  string `json:"access_token"`
+	RefreshToken string `json:"refresh_token"`
+	ExpiresIn    int64  `json:"expires_in"`
+	TokenType    string `json:"token_type"`
+}
+
+// exchangeCodeForToken swaps the one-time authorization code (plus PKCE
+// verifier) for an access_token / refresh_token pair from Tesla.
+func exchangeCodeForToken(
+	ctx context.Context,
+	logger *slog.Logger,
+	clientID, clientSecret, redirectURI, code, codeVerifier string,
+) (*tokenResponse, error) {
+	form := buildTokenExchangeForm(clientID, clientSecret, redirectURI, code, codeVerifier)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, teslaOAuthTokenEndpoint, strings.NewReader(form.Encode()))
+	if err != nil {
+		return nil, fmt.Errorf("build token request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+	client := &http.Client{Timeout: tokenExchangeTimeout}
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("post to token endpoint: %w", err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 1<<16))
+	if err != nil {
+		return nil, fmt.Errorf("read token response: %w", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		logger.Warn("tesla token exchange failed",
+			slog.Int("status", resp.StatusCode),
+			slog.String("body", string(body)),
+		)
+		return nil, fmt.Errorf("tesla returned %d: %s", resp.StatusCode, string(body))
+	}
+
+	var tok tokenResponse
+	if err := json.Unmarshal(body, &tok); err != nil {
+		return nil, fmt.Errorf("decode token response: %w", err)
+	}
+	if tok.AccessToken == "" || tok.RefreshToken == "" {
+		return nil, errors.New("tesla response missing access_token or refresh_token")
+	}
+	return &tok, nil
+}
+
+// buildTokenExchangeForm assembles the x-www-form-urlencoded body for the
+// Tesla code → token POST. Exposed separately so the exact parameter set
+// is testable without spinning up an HTTP server.
+func buildTokenExchangeForm(clientID, clientSecret, redirectURI, code, codeVerifier string) url.Values {
+	form := url.Values{}
+	form.Set("grant_type", "authorization_code")
+	form.Set("client_id", clientID)
+	form.Set("client_secret", clientSecret)
+	form.Set("code", code)
+	form.Set("redirect_uri", redirectURI)
+	form.Set("code_verifier", codeVerifier)
+	return form
+}

--- a/cmd/ops/main.go
+++ b/cmd/ops/main.go
@@ -72,6 +72,7 @@ Usage:
 
 Commands:
   auth token          --user-id <id>                 Print the user's Tesla token (auto-refreshes if expired)
+  auth link           --user-id <id> [--port N]      Run the Tesla OAuth browser flow and store fresh tokens
   vehicles list       --user-id <id>                 List vehicles owned by the user
   fleet-config show                                  Print DefaultFieldConfig as JSON
   fleet-config push   --vin <vin> --user-id <id>     Push DefaultFieldConfig to Tesla for this VIN

--- a/docs/ops-cli.md
+++ b/docs/ops-cli.md
@@ -17,7 +17,7 @@ go build -o ./bin/ops ./cmd/ops
 | Variable | Required for | Notes |
 |---|---|---|
 | `DATABASE_URL` | every subcommand | Supabase Postgres connection string. PgBouncer mode (`:6543`) is auto-detected. |
-| `AUTH_TESLA_ID` | `auth token`, `fleet-config push` (when refresh needed) | Tesla OAuth client id. |
+| `AUTH_TESLA_ID` | `auth token`, `auth link`, `fleet-config push` | Tesla OAuth client id. |
 | `AUTH_TESLA_SECRET` | same as above | Tesla OAuth client secret. |
 | `TESLA_PROXY_URL` | `fleet-config push` | Base URL of the running `tesla-http-proxy` sidecar (e.g. `https://localhost:4443`). |
 | `FLEET_TELEMETRY_HOSTNAME` | `fleet-config push` | Hostname vehicles connect to after config (e.g. `telemetry.myrobotaxi.app`). |
@@ -34,6 +34,30 @@ set -a && source ../my-robo-taxi/.env.local && set +a
 ## Subcommands
 
 Run `ops help` any time for the flag summary. Every subcommand prints JSON to stdout; progress/warning logs go to stderr so you can pipe through `jq`.
+
+### `ops auth link --user-id <id> [--port 8765]`
+
+Runs the full Tesla OAuth browser flow and writes fresh `access_token` + `refresh_token` to the DB. Use this when `ops auth token` fails with `401 login_required` (meaning the stored refresh_token has been revoked or expired — Tesla rotates aggressively).
+
+**One-time setup on Tesla Developer portal:** add `http://localhost:8765/callback` to your Fleet API app's allowed redirect URIs. Tesla apps support multiple redirect URIs, so this sits next to your production web redirect with no conflict.
+
+```bash
+ops auth link --user-id clxy...
+```
+
+The CLI opens Tesla's login page in your browser, you approve the scopes, Tesla redirects back to `localhost:8765/callback`, the CLI swaps the code for tokens and persists them. Then:
+
+```bash
+ops auth token --user-id clxy...   # should now succeed
+```
+
+Flags:
+
+- `--port` — local HTTP port the CLI listens on. Default `8765`. Must match the redirect URI registered on the Tesla app.
+- `--scopes` — space-separated OAuth scopes. Default includes `openid`, `offline_access`, `vehicle_device_data`, `vehicle_cmds`, `vehicle_charging_cmds`.
+- `--timeout` — how long to wait for the browser flow. Default `2m`.
+
+PKCE (S256) is implemented per RFC 7636 — no client secret is sent in the authorize URL, and the code exchange is bound to a fresh verifier per flow.
 
 ### `ops auth token --user-id <id>`
 
@@ -183,3 +207,5 @@ Watch a few frames, compare against the in-car display, and you can conclude whe
 - **Empty output from `fields watch`** — the vehicle isn't connected. Check the server logs for a `vehicle connected` line, or confirm with `ops fields snapshot --vin <vin>` that `lastUpdated` is recent.
 - **`unexpected client frame` debug logs on the server** — safe to ignore. The debug endpoint is server→client only; any frame the client sends is logged and discarded.
 - **`unauthorized` on `fields watch`** — `DEBUG_FIELDS_TOKEN` on the server does not match `--token`/the env var. Both sides must agree (or both be empty).
+- **`401 login_required` on `ops auth token`** — the stored `refresh_token` is dead. Run `ops auth link --user-id <id>` to refresh via the browser OAuth flow, then retry.
+- **`listen on port 8765 ... address already in use` on `ops auth link`** — another process holds the port. Close it or pass `--port <free-port>` (and make sure that port is registered on the Tesla app's redirect URIs).


### PR DESCRIPTION
## Summary
Adds `ops auth link --user-id <id>` — a full Tesla OAuth2 authorization_code + PKCE flow directly in the CLI. Closes the recovery gap when the stored `refresh_token` is revoked/expired and `ops auth token` fails with `401 login_required`.

## Flow

1. Generate PKCE verifier/challenge (S256) per run
2. Spin up ephemeral `127.0.0.1:<port>/callback` HTTP server
3. Open Tesla's `/oauth2/v3/authorize` URL in the default browser
4. Validate returned `state`; surface Tesla-reported errors
5. Exchange code for tokens via `/oauth2/v3/token`
6. Persist fresh `access_token`/`refresh_token`/`expires_at` via `AccountRepo.UpdateTeslaToken`

## One-time developer setup
Register `http://localhost:8765/callback` (or `--port` override) on the Tesla Fleet API app's allowed redirect URIs. Documented in `docs/ops-cli.md`.

## Test plan
- [x] `go vet ./...`
- [x] `go test ./...`
- [x] `golangci-lint run ./...` (0 issues)
- [x] Unit tests cover PKCE generation (verifier/challenge SHA-256 relation), authorize URL param shape, callback handler (success + state mismatch + Tesla-reported error), and token exchange form body
- [ ] Manual: `ops auth link --user-id <id>` against a real Tesla account, confirm `ops auth token` succeeds after
- [ ] Manual: confirm port collision error message is clear if port not registered on Tesla app

Closes MYR-37.