### PR TITLE
MYR-38 Let DEBUG_FIELDS_TOKEN gate /api/debug/fields in prod

### DIFF
--- a/cmd/telemetry-server/adapters.go
+++ b/cmd/telemetry-server/adapters.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"crypto/tls"
+	"errors"
 	"fmt"
 	"log/slog"
 	"net"
@@ -13,6 +14,53 @@ import (
 	"github.com/tnando/my-robo-taxi-telemetry/internal/store"
 	"github.com/tnando/my-robo-taxi-telemetry/internal/telemetry"
 )
+
+// debugFieldsMinTokenLen is the minimum length required for
+// DEBUG_FIELDS_TOKEN when the endpoint is enabled in non-dev mode.
+// 32 chars ≈ 192 bits of entropy for a base64-encoded random token;
+// anything shorter is likely a typo or a test fixture and should be
+// rejected at startup rather than shipped to prod.
+const debugFieldsMinTokenLen = 32
+
+// debugFieldsGate describes how /api/debug/fields should be mounted at
+// startup. It is derived from the --dev flag and the DEBUG_FIELDS_TOKEN
+// env var by resolveDebugFieldsGate.
+type debugFieldsGate struct {
+	// Enabled is true when the endpoint should be mounted.
+	Enabled bool
+	// Token is the shared secret the client must present; empty means
+	// auth is skipped (only valid under --dev).
+	Token string
+	// Reason is a short human string ("dev mode" or "token set") used
+	// in the startup log to tell operators which gate is active.
+	Reason string
+}
+
+// errDebugFieldsTokenTooShort is returned when a non-dev operator sets
+// DEBUG_FIELDS_TOKEN to a value shorter than debugFieldsMinTokenLen.
+var errDebugFieldsTokenTooShort = errors.New("DEBUG_FIELDS_TOKEN must be at least 32 chars in non-dev mode")
+
+// resolveDebugFieldsGate folds the --dev flag and DEBUG_FIELDS_TOKEN
+// value into a single decision about whether to mount the debug-fields
+// endpoint and how to authenticate clients. Rules:
+//
+//   - --dev:              endpoint mounted, token optional
+//   - no --dev + no token: endpoint NOT mounted
+//   - no --dev + token:   endpoint mounted, token required; fails if token < 32 chars
+func resolveDebugFieldsGate(devMode bool, token string) (debugFieldsGate, error) {
+	switch {
+	case devMode && token != "":
+		return debugFieldsGate{Enabled: true, Token: token, Reason: "dev mode + DEBUG_FIELDS_TOKEN"}, nil
+	case devMode:
+		return debugFieldsGate{Enabled: true, Reason: "dev mode (no token required)"}, nil
+	case token == "":
+		return debugFieldsGate{}, nil
+	case len(token) < debugFieldsMinTokenLen:
+		return debugFieldsGate{}, fmt.Errorf("%w (got %d chars)", errDebugFieldsTokenTooShort, len(token))
+	default:
+		return debugFieldsGate{Enabled: true, Token: token, Reason: "DEBUG_FIELDS_TOKEN set"}, nil
+	}
+}
 
 // vinResolverAdapter adapts store.VehicleRepo (returns Vehicle) to the
 // ws.VINResolver interface (returns vehicleID string).

--- a/cmd/telemetry-server/adapters_test.go
+++ b/cmd/telemetry-server/adapters_test.go
@@ -1,9 +1,11 @@
 package main
 
 import (
+	"errors"
 	"io"
 	"log/slog"
 	"net/http"
+	"strings"
 	"testing"
 )
 
@@ -51,6 +53,49 @@ func TestProxyHTTPClient(t *testing.T) {
 			}
 			if !tr.TLSClientConfig.InsecureSkipVerify {
 				t.Error("expected InsecureSkipVerify to be true")
+			}
+		})
+	}
+}
+
+func TestResolveDebugFieldsGate(t *testing.T) {
+	longToken := strings.Repeat("a", debugFieldsMinTokenLen)
+
+	tests := []struct {
+		name        string
+		devMode     bool
+		token       string
+		wantEnabled bool
+		wantToken   string
+		wantErr     error
+	}{
+		{name: "off by default", devMode: false, token: "", wantEnabled: false},
+		{name: "dev, no token — open for dev", devMode: true, token: "", wantEnabled: true, wantToken: ""},
+		{name: "dev + token — enforced in dev too", devMode: true, token: "short", wantEnabled: true, wantToken: "short"},
+		{name: "prod + valid token — enabled", devMode: false, token: longToken, wantEnabled: true, wantToken: longToken},
+		{name: "prod + short token — rejected", devMode: false, token: "short", wantErr: errDebugFieldsTokenTooShort},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := resolveDebugFieldsGate(tt.devMode, tt.token)
+			if tt.wantErr != nil {
+				if !errors.Is(err, tt.wantErr) {
+					t.Fatalf("err: got %v, want %v", err, tt.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected err: %v", err)
+			}
+			if got.Enabled != tt.wantEnabled {
+				t.Errorf("enabled: got %v, want %v", got.Enabled, tt.wantEnabled)
+			}
+			if got.Token != tt.wantToken {
+				t.Errorf("token: got %q, want %q", got.Token, tt.wantToken)
+			}
+			if tt.wantEnabled && got.Reason == "" {
+				t.Error("expected Reason to be set when Enabled")
 			}
 		})
 	}

--- a/cmd/telemetry-server/main.go
+++ b/cmd/telemetry-server/main.go
@@ -82,6 +82,17 @@ func run() error { //nolint:funlen // composition root — sequential dependency
 		slog.Int("metrics_port", cfg.Server().MetricsPort),
 	)
 
+	// --- Debug-fields gate ---
+	// Either --dev or a non-empty DEBUG_FIELDS_TOKEN turns on the
+	// RawVehicleTelemetryEvent pipeline and mounts /api/debug/fields.
+	// In non-dev mode the token must be at least 32 chars so `ops fields
+	// watch` can stream real-Tesla data against production behind a
+	// real secret.
+	debugGate, err := resolveDebugFieldsGate(*devMode, os.Getenv("DEBUG_FIELDS_TOKEN"))
+	if err != nil {
+		return fmt.Errorf("invalid debug-fields configuration: %w", err)
+	}
+
 	// --- Prometheus registry ---
 	reg := prometheus.NewRegistry()
 	reg.MustRegister(collectors.NewGoCollector())
@@ -108,10 +119,11 @@ func run() error { //nolint:funlen // composition root — sequential dependency
 		telemetry.ReceiverConfig{
 			MaxVehicles:       cfg.Telemetry().MaxVehicles,
 			MaxMessagesPerSec: 10,
-			// Dev mode publishes raw field events so the /api/debug/fields
-			// endpoint and cmd/ops fields watch can inspect every decoded
-			// proto field. Production leaves this off to avoid extra work.
-			PublishRawFields: *devMode,
+			// Raw field publication feeds /api/debug/fields. Enabled
+			// whenever the debug-fields gate is open (dev mode OR
+			// DEBUG_FIELDS_TOKEN set) so operators can tail real-Tesla
+			// frames against production without extra deploys.
+			PublishRawFields: debugGate.Enabled,
 		},
 	)
 
@@ -196,18 +208,27 @@ func run() error { //nolint:funlen // composition root — sequential dependency
 	// --- Fleet config push endpoint (optional — requires proxy config) ---
 	setupFleetConfigEndpoint(cfg, srv, authenticator, vehicleRepo, accountRepo, logger)
 
-	// --- Dev-only debug fields endpoint (guarded by --dev flag) ---
-	if *devMode {
+	// --- Debug fields endpoint ---
+	// Mounted when resolveDebugFieldsGate says so — either because the
+	// server is running with --dev (token optional) or because an operator
+	// has set DEBUG_FIELDS_TOKEN on a production instance to let
+	// `ops fields watch` stream real-Tesla frames. Auth is enforced by
+	// DebugFieldsHandler via the X-Debug-Token header / ?token= query param
+	// when APIKey is non-empty.
+	if debugGate.Enabled {
 		debugHandler := telemetry.NewDebugFieldsHandler(
 			bus,
 			logger.With(slog.String("component", "debug-fields")),
 			telemetry.DebugFieldsConfig{
-				APIKey:         os.Getenv("DEBUG_FIELDS_TOKEN"),
+				APIKey:         debugGate.Token,
 				OriginPatterns: originPatterns,
 			},
 		)
 		srv.HandleFunc("GET /api/debug/fields", debugHandler.ServeHTTP)
-		logger.Warn("dev mode: /api/debug/fields endpoint enabled — do not run in production")
+		logger.Info("/api/debug/fields endpoint enabled",
+			slog.String("gate", debugGate.Reason),
+			slog.Bool("token_required", debugGate.Token != ""),
+		)
 	}
 
 	// Configure mTLS on Tesla port. TLS is required for vehicle connections —

--- a/docs/ops-cli.md
+++ b/docs/ops-cli.md
@@ -23,7 +23,7 @@ go build -o ./bin/ops ./cmd/ops
 | `FLEET_TELEMETRY_HOSTNAME` | `fleet-config push` | Hostname vehicles connect to after config (e.g. `telemetry.myrobotaxi.app`). |
 | `FLEET_TELEMETRY_PORT` | `fleet-config push` | Default `443`. |
 | `FLEET_TELEMETRY_CA` | `fleet-config push` (prod) | PEM-encoded CA cert served with the telemetry endpoint. |
-| `DEBUG_FIELDS_TOKEN` | `fields watch` (when server requires it) | Shared secret for `/api/debug/fields`. Set identically on the server. |
+| `DEBUG_FIELDS_TOKEN` | `fields watch` | Shared secret for `/api/debug/fields`. Set identically on the server. In non-dev mode the server requires ≥32 chars and clients must present the token; under `--dev` it is optional. |
 
 `.env.local` from the sibling Next.js app (`../my-robo-taxi/.env.local`) contains every secret you need except `DEBUG_FIELDS_TOKEN`. The fastest local setup:
 
@@ -165,46 +165,83 @@ ops fields watch --vin 5YJ3E7EB2NF000001 --server ws://localhost:8080 | jq
 
 - `--server` accepts `ws://`, `wss://`, `http://`, or `https://`. `http*` is auto-upgraded to `ws*`.
 - Omit `--vin` to stream all vehicles (useful when inspecting a fleet).
-- Auth: if `DEBUG_FIELDS_TOKEN` is set on the server, pass it via `--token` or the env var. The CLI always uses the `X-Debug-Token` header (query-param form exists for browsers but shows up in access logs).
+- Auth: if the server has `DEBUG_FIELDS_TOKEN` set, pass the same value via `--token` or the env var. The CLI always uses the `X-Debug-Token` header (query-param form exists for browsers but shows up in access logs).
 
-#### Starting the server so this endpoint exists
+#### How the endpoint gets mounted
 
-`/api/debug/fields` is mounted **only** when the server runs with `--dev`:
+`/api/debug/fields` is mounted under **either** gate:
+
+| Gate | How to enable | Token required from client? | Intended use |
+|---|---|---|---|
+| **`--dev`** | `go run ./cmd/telemetry-server --dev --config configs/dev-notls.json` | No (but honored if set) | Local laptop server + simulator |
+| **`DEBUG_FIELDS_TOKEN`** | Set on the server (any mode). **In non-dev mode the token must be ≥32 chars** or startup fails. | Yes — client must present the same token | Production server, tailing real-Tesla frames |
+
+Startup logs print which gate is active and whether the token is required. If neither gate is satisfied, the endpoint is not mounted and raw field publication is off (zero cost).
+
+#### Streaming against production (the headline workflow)
+
+Real Teslas only dial the production server, so that's where `ops fields watch` has to connect for actual field verification. Enable the endpoint on Fly once:
 
 ```bash
-DEBUG_FIELDS_TOKEN=dev-secret \
-  go run ./cmd/telemetry-server --dev --config configs/dev.json
+flyctl secrets set DEBUG_FIELDS_TOKEN="$(openssl rand -base64 32)" -a myrobotaxi-telemetry
+# Fly redeploys. Save the token locally — you cannot read it back from Fly.
 ```
 
-The server logs a `WARN` at startup confirming the endpoint is enabled — do not run `--dev` in production.
+Then from your laptop:
+
+```bash
+export DEBUG_FIELDS_TOKEN='<the value you just generated>'
+ops fields watch --vin 7SAYGDET7TA613795 --server wss://telemetry.myrobotaxi.app
+```
+
+Drive the car (or wake it up) and frames stream into your terminal in real time. Rotate the secret by re-running `flyctl secrets set` with a new value.
+
+#### Streaming against a local server
+
+For the simulator or local development, use `--dev` so no token dance is needed:
+
+```bash
+go run ./cmd/telemetry-server --dev --config configs/dev-notls.json
+ops fields watch --vin <vin> --server ws://localhost:8080
+```
+
+`configs/dev-notls.json` leaves TLS empty so you don't need to generate local certs just to boot the server.
 
 ## End-to-end recipe: verifying a Tesla field empirically (MYR-25 style)
 
 The workflow that motivated this tool. Example: confirm the units of `TimeToFullCharge`.
 
+One-time setup — set the debug token on the production server:
+
 ```bash
-# Terminal 1 — start the dev server with raw field publication.
-DEBUG_FIELDS_TOKEN=dev-secret \
-  go run ./cmd/telemetry-server --dev --config configs/dev.json
+flyctl secrets set DEBUG_FIELDS_TOKEN="$(openssl rand -base64 32)" -a myrobotaxi-telemetry
+# Copy the value into a secret manager / password manager for reuse.
+```
 
-# Terminal 2 — make sure the fleet is asking Tesla to send the field.
+Then per verification session:
+
+```bash
+# 1. Confirm the fleet is asking Tesla to send the field at a reasonable interval.
 ops fleet-config show | jq '.TimeToFullCharge'
-ops fleet-config push --vin 5YJ3... --user-id clxy...
+ops fleet-config push --vin 5YJ3... --user-id clxy...   # only if the interval changed
 
-# Terminal 3 — connect your real Tesla to a charger, then watch the stream
-# and grep for the field under test. Raw values are pre-conversion.
-DEBUG_FIELDS_TOKEN=dev-secret \
-  ops fields watch --vin 5YJ3... --server ws://localhost:8080 \
+# 2. Tail the live stream from production while the car is awake/driving/charging.
+export DEBUG_FIELDS_TOKEN='<the value from the Fly secret>'
+ops fields watch --vin 5YJ3... --server wss://telemetry.myrobotaxi.app \
   | jq -c 'select(.fields.TimeToFullCharge) | {t: .timestamp, v: .fields.TimeToFullCharge}'
 ```
 
-Watch a few frames, compare against the in-car display, and you can conclude whether the field arrives in hours, minutes, seconds, etc. — without redeploying or tailing Fly logs.
+Watch a few frames, compare against the in-car display, and you can conclude whether the field arrives in hours, minutes, seconds, etc. — no redeploy, no Fly log tail.
+
+> **Why production, not local?** Real Teslas only dial the server hostname pinned in their on-board `fleet_telemetry_config`. That pointer only ever resolves to the Fly-deployed prod server. A local `--dev` server is for the simulator; it will never receive a frame from a real car.
 
 ## Troubleshooting
 
 - **`DATABASE_URL is required`** — source `../my-robo-taxi/.env.local` (or set the var directly).
 - **`vehicle owner mismatch`** on `fleet-config push` — the `userId` you passed does not own the VIN. Run `ops vehicles list --user-id <id>` to confirm.
-- **Empty output from `fields watch`** — the vehicle isn't connected. Check the server logs for a `vehicle connected` line, or confirm with `ops fields snapshot --vin <vin>` that `lastUpdated` is recent.
+- **Empty output from `fields watch`** — the vehicle isn't streaming to the server you connected to. Remember real Teslas only dial production; pointing `--server` at a local `--dev` server with no simulator running will always be silent. Check the server logs for a `vehicle connected` line, or confirm with `ops fields snapshot --vin <vin>` that `lastUpdated` is recent.
+- **`/api/debug/fields` endpoint not found (404)** — the server was started without either gate. Pass `--dev` locally, or set `DEBUG_FIELDS_TOKEN` (≥32 chars) on the deployed server.
+- **Server refuses to start with `DEBUG_FIELDS_TOKEN must be at least 32 chars`** — non-dev mode enforces a length floor so weak tokens can't reach prod. Generate a proper one: `openssl rand -base64 32`.
 - **`unexpected client frame` debug logs on the server** — safe to ignore. The debug endpoint is server→client only; any frame the client sends is logged and discarded.
 - **`unauthorized` on `fields watch`** — `DEBUG_FIELDS_TOKEN` on the server does not match `--token`/the env var. Both sides must agree (or both be empty).
 - **`401 login_required` on `ops auth token`** — the stored `refresh_token` is dead. Run `ops auth link --user-id <id>` to refresh via the browser OAuth flow, then retry.


### PR DESCRIPTION
## Summary
Decouples `/api/debug/fields` and `PublishRawFields` from the `--dev` flag. In MYR-36 I tied three concerns to one flag — only loose-auth belongs under `--dev`. This change lets operators enable the debug endpoint on the production server via `DEBUG_FIELDS_TOKEN`, so `ops fields watch` can finally stream **real-Tesla** frames (the motivating use case of MYR-36, which wasn't deliverable under the original scoping).

## Gate matrix

| `--dev` | `DEBUG_FIELDS_TOKEN` | Endpoint mounted? | Client token required? |
|---|---|---|---|
| false | empty | no | — |
| false | < 32 chars | **startup fails** | — |
| false | ≥ 32 chars | yes | yes |
| true | empty | yes | no |
| true | any | yes | yes (enforced) |

Main-WS JWT auth semantics are **unchanged** — `--dev` still bypasses it and never otherwise.

## Enablement on prod
```bash
flyctl secrets set DEBUG_FIELDS_TOKEN=\"\$(openssl rand -base64 32)\" -a myrobotaxi-telemetry
```
Save the value; you cannot read it back from Fly.

## Test plan
- [x] `go vet ./...`
- [x] `go test ./...`
- [x] `golangci-lint run ./...` (0 issues)
- [x] New `TestResolveDebugFieldsGate` covers all five matrix rows, including the ≥32 char enforcement error path
- [x] `docs/ops-cli.md` rewritten: gate matrix, prod enablement, local-vs-prod streaming, new troubleshooting entries
- [ ] Manual on prod: set the secret, run `ops fields watch --server wss://telemetry.myrobotaxi.app --vin <vin>`, confirm frames appear

Closes MYR-38. Unblocks all future field-verification issues (MYR-25/28/29-style) — they now have a one-command validation tool that hits real data.