### PR TITLE
MYR-39 Fix openssl cert recipe + commit dev-notls config

### DIFF
--- a/configs/dev-notls.json
+++ b/configs/dev-notls.json
@@ -1,0 +1,38 @@
+{
+  "server": {
+    "tesla_port": 8443,
+    "client_port": 8080,
+    "metrics_port": 9090
+  },
+  "tls": {
+    "cert_file": "",
+    "key_file": "",
+    "ca_file": ""
+  },
+  "database": {
+    "max_conns": 10,
+    "min_conns": 2
+  },
+  "telemetry": {
+    "max_vehicles": 100,
+    "event_buffer_size": 1000,
+    "batch_write_interval": "5s",
+    "batch_write_size": 100
+  },
+  "drives": {
+    "min_duration": "2m",
+    "min_distance_miles": 0.1,
+    "end_debounce": "30s",
+    "geocode_timeout": "5s"
+  },
+  "websocket": {
+    "heartbeat_interval": "15s",
+    "write_timeout": "10s",
+    "max_connections_per_user": 5,
+    "read_limit": 4096
+  },
+  "auth": {
+    "token_issuer": "myrobotaxi",
+    "token_audience": "telemetry"
+  }
+}

--- a/docs/simulator.md
+++ b/docs/simulator.md
@@ -11,6 +11,13 @@ The simulator requires mTLS certificates. Generate them once:
 ```bash
 mkdir -p certs
 
+# Homebrew openssl@3 ≥ 3.6 ships without /opt/homebrew/etc/openssl@3/openssl.cnf
+# and every `openssl req` call fails looking for it. Pointing OPENSSL_CONF at
+# /dev/null tells openssl to use compiled-in defaults, which is all this
+# recipe needs. macOS LibreSSL at /usr/bin/openssl isn't a drop-in
+# replacement because it lacks `-copy_extensions`.
+export OPENSSL_CONF=/dev/null
+
 # CA
 openssl ecparam -name prime256v1 -genkey -noout -out certs/ca.key
 openssl req -new -x509 -key certs/ca.key -out certs/ca.crt -days 365 -subj "/CN=MyRoboTaxi Dev CA"
@@ -31,6 +38,7 @@ openssl x509 -req -in certs/client.csr -CA certs/ca.crt -CAkey certs/ca.key \
 # Cleanup
 chmod 600 certs/*.key
 rm -f certs/*.csr certs/*.srl
+unset OPENSSL_CONF
 ```
 
 The client certificate's Common Name (CN) is the VIN that the server will extract via mTLS — this is how Tesla vehicles identify themselves.


### PR DESCRIPTION
## Summary
Two small onboarding unblocks bundled into one docs+config PR:

1. **`docs/simulator.md` cert recipe** was broken on Homebrew openssl@3 ≥3.6 (it looks for `/opt/homebrew/etc/openssl@3/openssl.cnf` which is no longer shipped). Fix: wrap the block in `OPENSSL_CONF=/dev/null` so openssl falls back to compiled-in defaults. Verified end-to-end against the real `certs/` directory; server cert carries `subjectAltName: DNS:localhost, IP:127.0.0.1` as expected.
2. **`configs/dev-notls.json`** is referenced by `docs/ops-cli.md` (from #184) but was never actually committed. This PR adds the file so the "local dev server without TLS certs" onboarding path actually works.

## Test plan
- [x] Ran the updated cert block verbatim from a clean shell on macOS + Homebrew openssl@3 3.6.1 — all commands succeed
- [x] Confirmed server cert SAN contains `DNS:localhost, IP:127.0.0.1`
- [x] Confirmed client cert CN is the expected VIN
- [x] `configs/dev-notls.json` matches the structure the composition root in `cmd/telemetry-server/main.go` expects

Docs/config only; no Go touched.

Closes MYR-39.