### PR TITLE
MYR-43 Stop fetching navRouteCoordinates JSON on every WS broadcast

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -59,7 +59,13 @@ jobs:
           echo "Linked issue: ${ISSUE_NUM:-none}"
 
       - name: Run Claude review
-        uses: anthropics/claude-code-action@v1
+        # Pinned to v1.0.104. v1.0.105 (Apr 23 23:24) bumped the underlying
+        # Agent SDK to 0.2.119 and broke the action with an internal
+        # "directory mismatch for tsconfig.json" error that aborts Claude's
+        # session before it can post a review. Symptom: workflow exits
+        # successfully but the sticky comment is left at "I'll analyze this
+        # and get back to you." Bump cautiously and re-test on a real PR.
+        uses: anthropics/claude-code-action@0766301cba8671db92e3025984e2fd038ad48ff7 # v1.0.104
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           github_token: ${{ secrets.GH_PAT }}
@@ -145,7 +151,13 @@ jobs:
           fetch-depth: 0
           token: ${{ secrets.GH_PAT }}
 
-      - uses: anthropics/claude-code-action@v1
+      # Pinned to v1.0.104. v1.0.105 (Apr 23 23:24) bumped the underlying
+      # Agent SDK to 0.2.119 and broke the action with an internal
+      # "directory mismatch for tsconfig.json" error that aborts Claude's
+      # session before it can post a review. Symptom: workflow exits
+      # successfully but the sticky comment is left at "I'll analyze this
+      # and get back to you." Bump cautiously and re-test on a real PR.
+      - uses: anthropics/claude-code-action@0766301cba8671db92e3025984e2fd038ad48ff7 # v1.0.104
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           github_token: ${{ secrets.GH_PAT }}

--- a/cmd/telemetry-server/adapters.go
+++ b/cmd/telemetry-server/adapters.go
@@ -62,32 +62,37 @@ func resolveDebugFieldsGate(devMode bool, token string) (debugFieldsGate, error)
 	}
 }
 
-// vinResolverAdapter adapts store.VehicleRepo (returns Vehicle) to the
-// ws.VINResolver interface (returns vehicleID string).
+// vinResolverAdapter adapts store.VINCache to the ws.VINResolver interface
+// (returns vehicleID string). Backing the WS broadcaster path with the cache
+// avoids fetching the full Vehicle row (including the heavy navRouteCoordinates
+// JSON) on every telemetry frame — the slim two-column query runs once per VIN
+// for the lifetime of the process.
 type vinResolverAdapter struct {
-	repo *store.VehicleRepo
+	cache *store.VINCache
 }
 
 func (a *vinResolverAdapter) GetByVIN(ctx context.Context, vin string) (string, error) {
-	v, err := a.repo.GetByVIN(ctx, vin)
+	id, err := a.cache.ResolveID(ctx, vin)
 	if err != nil {
 		return "", fmt.Errorf("resolve VIN: %w", err)
 	}
-	return v.ID, nil
+	return id, nil
 }
 
-// vehicleOwnerAdapter adapts store.VehicleRepo to the
-// telemetry.VehicleOwnerLookup interface (returns owning user ID).
+// vehicleOwnerAdapter adapts store.VINCache to the
+// telemetry.VehicleOwnerLookup interface (returns owning user ID). Shares
+// the same cache instance as vinResolverAdapter, so a single DB lookup per
+// VIN serves both ID and owner resolution for the lifetime of the process.
 type vehicleOwnerAdapter struct {
-	repo *store.VehicleRepo
+	cache *store.VINCache
 }
 
 func (a *vehicleOwnerAdapter) GetVehicleOwner(ctx context.Context, vin string) (string, error) {
-	v, err := a.repo.GetByVIN(ctx, vin)
+	userID, err := a.cache.ResolveOwner(ctx, vin)
 	if err != nil {
 		return "", fmt.Errorf("resolve vehicle owner: %w", err)
 	}
-	return v.UserID, nil
+	return userID, nil
 }
 
 // teslaTokenAdapter adapts store.AccountRepo to the

--- a/cmd/telemetry-server/main.go
+++ b/cmd/telemetry-server/main.go
@@ -160,7 +160,15 @@ func run() error { //nolint:funlen // composition root — sequential dependency
 	hub := ws.NewHub(logger.With(slog.String("component", "ws")), ws.NoopHubMetrics{})
 	defer hub.Stop()
 
-	vinResolver := &vinResolverAdapter{repo: vehicleRepo}
+	// Shared VIN → (vehicleID, userID) cache backing the broadcaster and
+	// the HTTP handlers below. Both identifiers are immutable for the
+	// lifetime of a vehicle row, so the cache lives forever and a single
+	// slim two-column query runs per VIN for the lifetime of the process.
+	// This replaces ~660k full-row fetches per billing cycle that were
+	// pulling the heavy navRouteCoordinates JSON on every telemetry frame.
+	vinCache := store.NewVINCache(vehicleRepo, logger.With(slog.String("component", "vin-cache")))
+
+	vinResolver := &vinResolverAdapter{cache: vinCache}
 	broadcaster := ws.NewBroadcaster(hub, bus, vinResolver, logger.With(slog.String("component", "broadcaster")))
 	if err := broadcaster.Start(ctx); err != nil {
 		return fmt.Errorf("starting broadcaster: %w", err)
@@ -199,14 +207,14 @@ func run() error { //nolint:funlen // composition root — sequential dependency
 	// --- Vehicle status endpoint (always available) ---
 	statusHandler := telemetry.NewVehicleStatusHandler(
 		authenticator,
-		&vehicleOwnerAdapter{repo: vehicleRepo},
+		&vehicleOwnerAdapter{cache: vinCache},
 		recv,
 		logger.With(slog.String("component", "vehicle-status")),
 	)
 	srv.HandleFunc("GET /api/vehicle-status/{vin}", statusHandler.ServeHTTP)
 
 	// --- Fleet config push endpoint (optional — requires proxy config) ---
-	setupFleetConfigEndpoint(cfg, srv, authenticator, vehicleRepo, accountRepo, logger)
+	setupFleetConfigEndpoint(cfg, srv, authenticator, vinCache, accountRepo, logger)
 
 	// --- Debug fields endpoint ---
 	// Mounted when resolveDebugFieldsGate says so — either because the
@@ -267,7 +275,7 @@ func setupFleetConfigEndpoint(
 	cfg *config.Config,
 	srv *server.Server,
 	authenticator ws.Authenticator,
-	vehicleRepo *store.VehicleRepo,
+	vinCache *store.VINCache,
 	accountRepo *store.AccountRepo,
 	logger *slog.Logger,
 ) {
@@ -301,7 +309,7 @@ func setupFleetConfigEndpoint(
 
 	fleetHandler := telemetry.NewFleetConfigHandler(
 		authenticator,
-		&vehicleOwnerAdapter{repo: vehicleRepo},
+		&vehicleOwnerAdapter{cache: vinCache},
 		&teslaTokenAdapter{repo: accountRepo},
 		fleetClient,
 		telemetry.EndpointConfig{

--- a/internal/store/queries.go
+++ b/internal/store/queries.go
@@ -30,6 +30,12 @@ FROM "Vehicle"
 WHERE "userId" = $1
 ORDER BY "name", "vin"`
 
+// queryVehicleIDsByVIN is the slim companion of queryVehicleByVIN. It
+// returns only the immutable identifiers (id, userId) so hot paths that
+// need to map VIN → vehicleID/userID don't pull the heavy navRouteCoordinates
+// JSON and other telemetry columns on every call.
+const queryVehicleIDsByVIN = `SELECT "id", "userId" FROM "Vehicle" WHERE "vin" = $1`
+
 const queryUpdateVehicleStatus = `UPDATE "Vehicle"
 SET "status" = $1::"VehicleStatus", "lastUpdated" = NOW()
 WHERE "vin" = $2`

--- a/internal/store/vehicle_repo.go
+++ b/internal/store/vehicle_repo.go
@@ -36,6 +36,27 @@ func (r *VehicleRepo) GetByVIN(ctx context.Context, vin string) (Vehicle, error)
 	return v, nil
 }
 
+// GetIDsByVIN returns just the (vehicleID, userID) pair for the given VIN.
+// Both values are immutable for the lifetime of a vehicle row, which makes
+// this safe to cache indefinitely. Use this in hot paths that only need
+// to map a VIN to its identifiers — it avoids pulling the heavy
+// navRouteCoordinates JSON and other telemetry columns that GetByVIN reads.
+// Returns ErrVehicleNotFound if no vehicle has that VIN.
+func (r *VehicleRepo) GetIDsByVIN(ctx context.Context, vin string) (id, userID string, err error) {
+	start := time.Now()
+	row := r.pool.QueryRow(ctx, queryVehicleIDsByVIN, vin)
+	scanErr := row.Scan(&id, &userID)
+	r.metrics.ObserveQueryDuration("vehicle.get_ids_by_vin", time.Since(start).Seconds())
+	if errors.Is(scanErr, pgx.ErrNoRows) {
+		return "", "", fmt.Errorf("VehicleRepo.GetIDsByVIN(%s): %w", redactVIN(vin), ErrVehicleNotFound)
+	}
+	if scanErr != nil {
+		r.metrics.IncQueryError("vehicle.get_ids_by_vin")
+		return "", "", fmt.Errorf("VehicleRepo.GetIDsByVIN(%s): %w", redactVIN(vin), scanErr)
+	}
+	return id, userID, nil
+}
+
 // ListByUser returns every vehicle owned by the given user, ordered by
 // name and VIN. Returns an empty slice (and nil error) when the user has
 // no linked vehicles.

--- a/internal/store/vehicle_repo_test.go
+++ b/internal/store/vehicle_repo_test.go
@@ -103,6 +103,55 @@ func TestVehicleRepo_GetByID(t *testing.T) {
 	}
 }
 
+func TestVehicleRepo_GetIDsByVIN(t *testing.T) {
+	cleanTables(t, testPool)
+	seedVehicle(t, testPool, "veh_ids_001", "5YJ3E1EA1NF000IDS")
+
+	repo := store.NewVehicleRepo(testPool, store.NoopMetrics{})
+	ctx := context.Background()
+
+	tests := []struct {
+		name       string
+		vin        string
+		wantID     string
+		wantUserID string
+		wantErr    error
+	}{
+		{
+			name:       "existing vehicle returns id and userId",
+			vin:        "5YJ3E1EA1NF000IDS",
+			wantID:     "veh_ids_001",
+			wantUserID: "user_001", // seedVehicle hardcodes this owner
+		},
+		{
+			name:    "missing vehicle returns ErrVehicleNotFound",
+			vin:     "NONEXISTENT",
+			wantErr: store.ErrVehicleNotFound,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			id, userID, err := repo.GetIDsByVIN(ctx, tt.vin)
+			if tt.wantErr != nil {
+				if !errors.Is(err, tt.wantErr) {
+					t.Fatalf("expected %v, got %v", tt.wantErr, err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if id != tt.wantID {
+				t.Errorf("id = %q, want %q", id, tt.wantID)
+			}
+			if userID != tt.wantUserID {
+				t.Errorf("userID = %q, want %q", userID, tt.wantUserID)
+			}
+		})
+	}
+}
+
 func TestVehicleRepo_UpdateTelemetry(t *testing.T) {
 	cleanTables(t, testPool)
 	seedVehicle(t, testPool, "veh_003", "5YJ3E1EA1NF000003")

--- a/internal/store/vin_cache.go
+++ b/internal/store/vin_cache.go
@@ -8,63 +8,100 @@ import (
 	"sync"
 )
 
-// vinLookup is the consumer-site interface for looking up a vehicle by VIN.
-// VehicleRepo satisfies this interface.
-type vinLookup interface {
-	GetByVIN(ctx context.Context, vin string) (Vehicle, error)
+// vinIDLookup is the consumer-site interface for fetching the immutable
+// (vehicleID, userID) pair for a VIN. VehicleRepo satisfies this via
+// GetIDsByVIN, which uses a two-column SELECT instead of pulling the
+// full vehicle row.
+type vinIDLookup interface {
+	GetIDsByVIN(ctx context.Context, vin string) (id, userID string, err error)
 }
 
-// sentinel value stored in the cache when a VIN is not found in the DB,
-// preventing repeated lookups for unknown vehicles.
-const vinMiss = ""
+// vinIDs holds the immutable identifier pair cached per VIN.
+type vinIDs struct {
+	vehicleID string
+	userID    string
+}
 
-// vinCache maps VIN strings to vehicle IDs (cuid), backed by a sync.Map
-// for lock-free concurrent reads. Cache entries never expire because
-// vehicle IDs are immutable.
-type vinCache struct {
-	lookup vinLookup
-	cache  sync.Map // VIN → string (vehicleID or vinMiss)
+// vinMissSentinel is the cached value for VINs that returned
+// ErrVehicleNotFound, so subsequent lookups for the same VIN don't
+// re-hit the database. Both fields are empty.
+var vinMissSentinel = vinIDs{}
+
+// VINCache maps VIN strings to (vehicleID, userID) pairs, backed by a
+// sync.Map for lock-free concurrent reads. Cache entries never expire
+// because both identifiers are immutable for the lifetime of a vehicle
+// row in the Prisma-owned "Vehicle" table.
+//
+// Use ResolveID when only the vehicle ID is needed and ResolveOwner when
+// only the owning userID is needed; the same cache entry serves both.
+type VINCache struct {
+	lookup vinIDLookup
+	cache  sync.Map // VIN → vinIDs (zero value = cached miss)
 	logger *slog.Logger
 }
 
-// newVINCache creates a vinCache that resolves cache misses against the
-// given vinLookup.
-func newVINCache(lookup vinLookup, logger *slog.Logger) *vinCache {
-	return &vinCache{
+// NewVINCache creates a VINCache that resolves cache misses against the
+// given vinIDLookup.
+func NewVINCache(lookup vinIDLookup, logger *slog.Logger) *VINCache {
+	return &VINCache{
 		lookup: lookup,
 		logger: logger,
 	}
 }
 
-// resolve returns the vehicleID for the given VIN. It checks the cache
-// first, then falls back to the database. Returns ErrVehicleNotFound if
-// the VIN has no matching vehicle in the DB (this result is cached).
-func (c *vinCache) resolve(ctx context.Context, vin string) (string, error) {
+// ResolveID returns the vehicleID for the given VIN, using the cache to
+// avoid repeated database lookups. Returns ErrVehicleNotFound when the
+// VIN has no matching vehicle (this result is cached).
+func (c *VINCache) ResolveID(ctx context.Context, vin string) (string, error) {
+	ids, err := c.resolve(ctx, vin)
+	if err != nil {
+		return "", err
+	}
+	return ids.vehicleID, nil
+}
+
+// ResolveOwner returns the owning userID for the given VIN, using the
+// cache to avoid repeated database lookups. Returns ErrVehicleNotFound
+// when the VIN has no matching vehicle (this result is cached).
+func (c *VINCache) ResolveOwner(ctx context.Context, vin string) (string, error) {
+	ids, err := c.resolve(ctx, vin)
+	if err != nil {
+		return "", err
+	}
+	return ids.userID, nil
+}
+
+// resolve is the shared cache-and-fetch path used by ResolveID and
+// ResolveOwner. The first call for a given VIN hits the database via
+// the slim two-column query; subsequent calls return the cached pair.
+func (c *VINCache) resolve(ctx context.Context, vin string) (vinIDs, error) {
 	if v, ok := c.cache.Load(vin); ok {
-		id := v.(string) //nolint:forcetypeassert // cache only stores strings
-		if id == vinMiss {
-			return "", fmt.Errorf("vinCache.resolve(%s): %w", redactVIN(vin), ErrVehicleNotFound)
+		ids := v.(vinIDs) //nolint:forcetypeassert // cache only stores vinIDs
+		if ids == vinMissSentinel {
+			return vinIDs{}, fmt.Errorf("VINCache.resolve(%s): %w", redactVIN(vin), ErrVehicleNotFound)
 		}
-		return id, nil
+		return ids, nil
 	}
 
-	vehicle, err := c.lookup.GetByVIN(ctx, vin)
+	id, userID, err := c.lookup.GetIDsByVIN(ctx, vin)
 	if errors.Is(err, ErrVehicleNotFound) {
-		c.cache.Store(vin, vinMiss)
+		c.cache.Store(vin, vinMissSentinel)
 		c.logger.Warn("vehicle not found for VIN, caching miss",
 			slog.String("vin", redactVIN(vin)),
 		)
-		return "", fmt.Errorf("vinCache.resolve(%s): %w", redactVIN(vin), ErrVehicleNotFound)
+		return vinIDs{}, fmt.Errorf("VINCache.resolve(%s): %w", redactVIN(vin), ErrVehicleNotFound)
 	}
 	if err != nil {
 		// Don't cache transient errors — let the next call retry.
-		return "", fmt.Errorf("vinCache.resolve(%s): %w", redactVIN(vin), err)
+		return vinIDs{}, fmt.Errorf("VINCache.resolve(%s): %w", redactVIN(vin), err)
 	}
 
-	c.cache.Store(vin, vehicle.ID)
-	c.logger.Debug("cached VIN → vehicleID mapping",
+	ids := vinIDs{vehicleID: id, userID: userID}
+	c.cache.Store(vin, ids)
+	c.logger.Debug("cached VIN → (vehicleID, userID) mapping",
 		slog.String("vin", redactVIN(vin)),
-		slog.String("vehicle_id", vehicle.ID),
+		slog.String("vehicle_id", id),
+		slog.String("user_id", userID),
 	)
-	return vehicle.ID, nil
+	return ids, nil
 }

--- a/internal/store/vin_cache_test.go
+++ b/internal/store/vin_cache_test.go
@@ -8,32 +8,32 @@ import (
 	"testing"
 )
 
-// stubVINLookup is a test double for vinLookup that returns configurable
-// results and counts calls.
-type stubVINLookup struct {
-	vehicles map[string]Vehicle // VIN → Vehicle
-	err      error              // returned for all lookups if set
-	calls    atomic.Int64
+// stubIDLookup is a test double for vinIDLookup that returns configurable
+// (id, userID) pairs and counts calls.
+type stubIDLookup struct {
+	pairs map[string]struct{ id, userID string }
+	err   error
+	calls atomic.Int64
 }
 
-func (s *stubVINLookup) GetByVIN(_ context.Context, vin string) (Vehicle, error) {
+func (s *stubIDLookup) GetIDsByVIN(_ context.Context, vin string) (string, string, error) {
 	s.calls.Add(1)
 	if s.err != nil {
-		return Vehicle{}, s.err
+		return "", "", s.err
 	}
-	v, ok := s.vehicles[vin]
+	p, ok := s.pairs[vin]
 	if !ok {
-		return Vehicle{}, ErrVehicleNotFound
+		return "", "", ErrVehicleNotFound
 	}
-	return v, nil
+	return p.id, p.userID, nil
 }
 
-func TestVINCache_Resolve(t *testing.T) {
+func TestVINCache_ResolveID(t *testing.T) {
 	logger := slog.Default()
 
 	tests := []struct {
 		name      string
-		vehicles  map[string]Vehicle
+		pairs     map[string]struct{ id, userID string }
 		lookupErr error
 		vin       string
 		wantID    string
@@ -41,21 +41,21 @@ func TestVINCache_Resolve(t *testing.T) {
 	}{
 		{
 			name: "cache miss then hit",
-			vehicles: map[string]Vehicle{
-				"5YJ3E1EA1NF000001": {ID: "veh_001", VIN: "5YJ3E1EA1NF000001"},
+			pairs: map[string]struct{ id, userID string }{
+				"5YJ3E1EA1NF000001": {id: "veh_001", userID: "user_001"},
 			},
 			vin:    "5YJ3E1EA1NF000001",
 			wantID: "veh_001",
 		},
 		{
-			name:     "vehicle not found cached",
-			vehicles: map[string]Vehicle{},
-			vin:      "UNKNOWN",
-			wantErr:  ErrVehicleNotFound,
+			name:    "vehicle not found cached",
+			pairs:   map[string]struct{ id, userID string }{},
+			vin:     "UNKNOWN",
+			wantErr: ErrVehicleNotFound,
 		},
 		{
 			name:      "transient error not cached",
-			vehicles:  map[string]Vehicle{},
+			pairs:     map[string]struct{ id, userID string }{},
 			lookupErr: errors.New("connection refused"),
 			vin:       "5YJ3E1EA1NF000001",
 			wantErr:   errors.New("connection refused"),
@@ -64,11 +64,11 @@ func TestVINCache_Resolve(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			lookup := &stubVINLookup{vehicles: tt.vehicles, err: tt.lookupErr}
-			cache := newVINCache(lookup, logger)
+			lookup := &stubIDLookup{pairs: tt.pairs, err: tt.lookupErr}
+			cache := NewVINCache(lookup, logger)
 			ctx := context.Background()
 
-			id, err := cache.resolve(ctx, tt.vin)
+			id, err := cache.ResolveID(ctx, tt.vin)
 			if tt.wantErr != nil {
 				if err == nil {
 					t.Fatalf("expected error, got nil")
@@ -88,23 +88,53 @@ func TestVINCache_Resolve(t *testing.T) {
 	}
 }
 
-func TestVINCache_CacheHitAvoidsDuplicateLookup(t *testing.T) {
-	lookup := &stubVINLookup{
-		vehicles: map[string]Vehicle{
-			"5YJ3E1EA1NF000001": {ID: "veh_001", VIN: "5YJ3E1EA1NF000001"},
+func TestVINCache_ResolveOwnerReusesSameEntry(t *testing.T) {
+	lookup := &stubIDLookup{
+		pairs: map[string]struct{ id, userID string }{
+			"5YJ3E1EA1NF000001": {id: "veh_001", userID: "user_owner"},
 		},
 	}
-	cache := newVINCache(lookup, slog.Default())
+	cache := NewVINCache(lookup, slog.Default())
 	ctx := context.Background()
 
-	// First call: cache miss → DB lookup.
-	id1, err := cache.resolve(ctx, "5YJ3E1EA1NF000001")
+	// Resolve the ID first (one DB lookup).
+	id, err := cache.ResolveID(ctx, "5YJ3E1EA1NF000001")
+	if err != nil {
+		t.Fatalf("ResolveID: %v", err)
+	}
+	if id != "veh_001" {
+		t.Errorf("id = %q, want veh_001", id)
+	}
+
+	// Then resolve the owner — should hit the same cached entry, no new DB call.
+	owner, err := cache.ResolveOwner(ctx, "5YJ3E1EA1NF000001")
+	if err != nil {
+		t.Fatalf("ResolveOwner: %v", err)
+	}
+	if owner != "user_owner" {
+		t.Errorf("owner = %q, want user_owner", owner)
+	}
+
+	if calls := lookup.calls.Load(); calls != 1 {
+		t.Errorf("DB lookups = %d, want 1 (single cache entry serves both methods)", calls)
+	}
+}
+
+func TestVINCache_CacheHitAvoidsDuplicateLookup(t *testing.T) {
+	lookup := &stubIDLookup{
+		pairs: map[string]struct{ id, userID string }{
+			"5YJ3E1EA1NF000001": {id: "veh_001", userID: "user_001"},
+		},
+	}
+	cache := NewVINCache(lookup, slog.Default())
+	ctx := context.Background()
+
+	id1, err := cache.ResolveID(ctx, "5YJ3E1EA1NF000001")
 	if err != nil {
 		t.Fatalf("first resolve: %v", err)
 	}
 
-	// Second call: cache hit → no DB lookup.
-	id2, err := cache.resolve(ctx, "5YJ3E1EA1NF000001")
+	id2, err := cache.ResolveID(ctx, "5YJ3E1EA1NF000001")
 	if err != nil {
 		t.Fatalf("second resolve: %v", err)
 	}
@@ -118,37 +148,36 @@ func TestVINCache_CacheHitAvoidsDuplicateLookup(t *testing.T) {
 }
 
 func TestVINCache_MissCachedPreventsRepeatedLookup(t *testing.T) {
-	lookup := &stubVINLookup{vehicles: map[string]Vehicle{}}
-	cache := newVINCache(lookup, slog.Default())
+	lookup := &stubIDLookup{pairs: map[string]struct{ id, userID string }{}}
+	cache := NewVINCache(lookup, slog.Default())
 	ctx := context.Background()
 
-	// First call: miss → DB lookup → ErrVehicleNotFound → cached.
-	_, err := cache.resolve(ctx, "UNKNOWN")
+	_, err := cache.ResolveID(ctx, "UNKNOWN")
 	if !errors.Is(err, ErrVehicleNotFound) {
 		t.Fatalf("expected ErrVehicleNotFound, got: %v", err)
 	}
 
-	// Second call: cached miss → no DB lookup.
-	_, err = cache.resolve(ctx, "UNKNOWN")
+	// Owner lookup should also see the cached miss without a DB hit.
+	_, err = cache.ResolveOwner(ctx, "UNKNOWN")
 	if !errors.Is(err, ErrVehicleNotFound) {
 		t.Fatalf("expected ErrVehicleNotFound, got: %v", err)
 	}
 
 	if calls := lookup.calls.Load(); calls != 1 {
-		t.Errorf("DB lookups = %d, want 1 (miss should be cached)", calls)
+		t.Errorf("DB lookups = %d, want 1 (miss should be cached and shared across methods)", calls)
 	}
 }
 
 func TestVINCache_TransientErrorNotCached(t *testing.T) {
-	lookup := &stubVINLookup{
-		vehicles: map[string]Vehicle{},
-		err:      errors.New("connection refused"),
+	lookup := &stubIDLookup{
+		pairs: map[string]struct{ id, userID string }{},
+		err:   errors.New("connection refused"),
 	}
-	cache := newVINCache(lookup, slog.Default())
+	cache := NewVINCache(lookup, slog.Default())
 	ctx := context.Background()
 
-	_, _ = cache.resolve(ctx, "5YJ3E1EA1NF000001")
-	_, _ = cache.resolve(ctx, "5YJ3E1EA1NF000001")
+	_, _ = cache.ResolveID(ctx, "5YJ3E1EA1NF000001")
+	_, _ = cache.ResolveID(ctx, "5YJ3E1EA1NF000001")
 
 	if calls := lookup.calls.Load(); calls != 2 {
 		t.Errorf("DB lookups = %d, want 2 (transient errors should not be cached)", calls)

--- a/internal/store/writer.go
+++ b/internal/store/writer.go
@@ -49,7 +49,7 @@ type Writer struct {
 	vehicles vehicleUpdater
 	drives   drivePersister
 	bus      events.Bus
-	vinCache *vinCache
+	vinCache *VINCache
 	geocoder geocode.Geocoder
 	logger   *slog.Logger
 	cfg      WriterConfig
@@ -73,7 +73,7 @@ type Writer struct {
 func NewWriter(
 	vehicles vehicleUpdater,
 	drives drivePersister,
-	vinLookup vinLookup,
+	vinLookup vinIDLookup,
 	bus events.Bus,
 	geocoder geocode.Geocoder,
 	logger *slog.Logger,
@@ -89,7 +89,7 @@ func NewWriter(
 		vehicles:  vehicles,
 		drives:    drives,
 		bus:       bus,
-		vinCache:  newVINCache(vinLookup, logger),
+		vinCache:  NewVINCache(vinLookup, logger),
 		geocoder:  geocoder,
 		logger:    logger,
 		cfg:       cfg,

--- a/internal/store/writer_drives.go
+++ b/internal/store/writer_drives.go
@@ -28,7 +28,7 @@ func (w *Writer) handleDriveStarted() events.Handler {
 		opCtx, cancel := context.WithTimeout(context.Background(), driveOpTimeout)
 		defer cancel()
 
-		vehicleID, err := w.vinCache.resolve(opCtx, evt.VIN)
+		vehicleID, err := w.vinCache.ResolveID(opCtx, evt.VIN)
 		if err != nil {
 			w.logger.Warn("cannot persist drive start: VIN lookup failed",
 				slog.String("vin", redactVIN(evt.VIN)),

--- a/internal/store/writer_test.go
+++ b/internal/store/writer_test.go
@@ -140,7 +140,7 @@ func newTestBus(t *testing.T) *events.ChannelBus {
 	return bus
 }
 
-func newTestWriter(t *testing.T, bus events.Bus, vehicles vehicleUpdater, drives drivePersister, lookup vinLookup) *Writer {
+func newTestWriter(t *testing.T, bus events.Bus, vehicles vehicleUpdater, drives drivePersister, lookup vinIDLookup) *Writer {
 	t.Helper()
 	w := NewWriter(vehicles, drives, lookup, bus, geocode.NoopGeocoder{}, slog.Default(), WriterConfig{
 		FlushInterval: 50 * time.Millisecond,
@@ -185,7 +185,7 @@ func TestWriter_TelemetryFlush(t *testing.T) {
 	bus := newTestBus(t)
 	vehicles := &mockVehicleUpdater{}
 	drives := &mockDrivePersister{}
-	lookup := &stubVINLookup{vehicles: map[string]Vehicle{}}
+	lookup := &stubIDLookup{pairs: map[string]struct{ id, userID string }{}}
 
 	w := newTestWriter(t, bus, vehicles, drives, lookup)
 	if err := w.Start(context.Background()); err != nil {
@@ -216,7 +216,7 @@ func TestWriter_Coalescing(t *testing.T) {
 	bus := newTestBus(t)
 	vehicles := &mockVehicleUpdater{}
 	drives := &mockDrivePersister{}
-	lookup := &stubVINLookup{vehicles: map[string]Vehicle{}}
+	lookup := &stubIDLookup{pairs: map[string]struct{ id, userID string }{}}
 
 	w := newTestWriter(t, bus, vehicles, drives, lookup)
 	if err := w.Start(context.Background()); err != nil {
@@ -262,7 +262,7 @@ func TestWriter_MultipleVehicles(t *testing.T) {
 	bus := newTestBus(t)
 	vehicles := &mockVehicleUpdater{}
 	drives := &mockDrivePersister{}
-	lookup := &stubVINLookup{vehicles: map[string]Vehicle{}}
+	lookup := &stubIDLookup{pairs: map[string]struct{ id, userID string }{}}
 
 	w := newTestWriter(t, bus, vehicles, drives, lookup)
 	if err := w.Start(context.Background()); err != nil {
@@ -298,9 +298,9 @@ func TestWriter_DriveStarted(t *testing.T) {
 	bus := newTestBus(t)
 	vehicles := &mockVehicleUpdater{}
 	drives := &mockDrivePersister{}
-	lookup := &stubVINLookup{
-		vehicles: map[string]Vehicle{
-			"5YJ3E1EA1NF000001": {ID: "veh_001", VIN: "5YJ3E1EA1NF000001"},
+	lookup := &stubIDLookup{
+		pairs: map[string]struct{ id, userID string }{
+			"5YJ3E1EA1NF000001": {id: "veh_001", userID: "user_001"},
 		},
 	}
 
@@ -340,7 +340,7 @@ func TestWriter_DriveEnded(t *testing.T) {
 	bus := newTestBus(t)
 	vehicles := &mockVehicleUpdater{}
 	drives := &mockDrivePersister{}
-	lookup := &stubVINLookup{vehicles: map[string]Vehicle{}}
+	lookup := &stubIDLookup{pairs: map[string]struct{ id, userID string }{}}
 
 	w := newTestWriter(t, bus, vehicles, drives, lookup)
 	if err := w.Start(context.Background()); err != nil {
@@ -429,7 +429,7 @@ func TestWriter_BatchSizeTriggersFlush(t *testing.T) {
 	bus := newTestBus(t)
 	vehicles := &mockVehicleUpdater{}
 	drives := &mockDrivePersister{}
-	lookup := &stubVINLookup{vehicles: map[string]Vehicle{}}
+	lookup := &stubIDLookup{pairs: map[string]struct{ id, userID string }{}}
 
 	// Set batch size very low so it triggers before the timer.
 	w := NewWriter(vehicles, drives, lookup, bus, geocode.NoopGeocoder{}, slog.Default(), WriterConfig{
@@ -460,7 +460,7 @@ func TestWriter_DriveUpdated_FlushOnSize(t *testing.T) {
 	bus := newTestBus(t)
 	vehicles := &mockVehicleUpdater{}
 	drives := &mockDrivePersister{}
-	lookup := &stubVINLookup{vehicles: map[string]Vehicle{}}
+	lookup := &stubIDLookup{pairs: map[string]struct{ id, userID string }{}}
 
 	w := NewWriter(vehicles, drives, lookup, bus, geocode.NoopGeocoder{}, slog.Default(), WriterConfig{
 		FlushInterval: 50 * time.Millisecond,
@@ -510,7 +510,7 @@ func TestWriter_DriveUpdated_FlushOnTimer(t *testing.T) {
 	bus := newTestBus(t)
 	vehicles := &mockVehicleUpdater{}
 	drives := &mockDrivePersister{}
-	lookup := &stubVINLookup{vehicles: map[string]Vehicle{}}
+	lookup := &stubIDLookup{pairs: map[string]struct{ id, userID string }{}}
 
 	w := NewWriter(vehicles, drives, lookup, bus, geocode.NoopGeocoder{}, slog.Default(), WriterConfig{
 		FlushInterval: 50 * time.Millisecond,
@@ -558,7 +558,7 @@ func TestWriter_DriveEnded_FlushesRemainingBufferedPoints(t *testing.T) {
 	bus := newTestBus(t)
 	vehicles := &mockVehicleUpdater{}
 	drives := &mockDrivePersister{}
-	lookup := &stubVINLookup{vehicles: map[string]Vehicle{}}
+	lookup := &stubIDLookup{pairs: map[string]struct{ id, userID string }{}}
 
 	w := NewWriter(vehicles, drives, lookup, bus, geocode.NoopGeocoder{}, slog.Default(), WriterConfig{
 		FlushInterval: 50 * time.Millisecond,
@@ -644,7 +644,7 @@ func TestWriter_DriveUpdated_MultipleDrivers(t *testing.T) {
 	bus := newTestBus(t)
 	vehicles := &mockVehicleUpdater{}
 	drives := &mockDrivePersister{}
-	lookup := &stubVINLookup{vehicles: map[string]Vehicle{}}
+	lookup := &stubIDLookup{pairs: map[string]struct{ id, userID string }{}}
 
 	w := NewWriter(vehicles, drives, lookup, bus, geocode.NoopGeocoder{}, slog.Default(), WriterConfig{
 		FlushInterval: 50 * time.Millisecond,


### PR DESCRIPTION
## Summary

Fixes a Supabase egress regression where the WS broadcaster's VIN→ID lookup was selecting the full `Vehicle` row — including the heavy `navRouteCoordinates` JSON — on every Tesla telemetry frame, just to read `id` or `userId`. Over the 2026-04-01 → 2026-04-25 cycle this drove **6.87 GB / 5 GB** egress (137% of free tier) and put the org in grace until 2026-05-23.

## Root cause

`pg_stat_statements` showed one query at 663,851 calls (≈18/min, 24/7):

```sql
SELECT "id", "userId", "vin", "name", ..., "navRouteCoordinates", "lastUpdated"
FROM "Vehicle" WHERE "vin" = $1
```

Source: `vinResolverAdapter.GetByVIN` and `vehicleOwnerAdapter.GetVehicleOwner` in `cmd/telemetry-server/adapters.go` called `repo.GetByVIN` (24 columns) and read only `.ID` / `.UserID`. The existing `vinCache` in `internal/store/` was wired into the persistence writer but not the broadcaster.

## Fix

1. **Slim query**: `queryVehicleIDsByVIN` selects only `id, userId` (~50 B/row vs ~1-5 KB).
2. **Slim repo method**: `VehicleRepo.GetIDsByVIN(ctx, vin) (id, userID, err)`.
3. **Refactor `VINCache`**: now backed by `GetIDsByVIN`, stores `(vehicleID, userID)` per VIN, exposes `ResolveID` and `ResolveOwner` — both share the same cache entry. Type is exported so `cmd/telemetry-server` can construct one shared instance.
4. **Wire shared cache** into `vinResolverAdapter`, `vehicleOwnerAdapter` (used by `/api/vehicle-status/{vin}` and `/api/fleet-config/{vin}`), and the WS broadcaster path.

Both identifiers are immutable for the lifetime of a vehicle row, so cache entries live forever. `ErrVehicleNotFound` is also cached to prevent repeat lookups for unknown VINs; transient errors are not cached.

## Expected impact

- Per-call payload: ~1-5 KB → ~50 B (50× reduction) on cache miss.
- After warmup: zero egress for VIN→ID and VIN→owner resolution (sync.Map hit).
- Eliminates effectively all 6 GB of recurring egress traced to this query in `pg_stat_statements`.

## Contract impact

None. No WebSocket messages, REST shapes, DB columns, or public SDK API change. Pure backend perf fix touching `internal/store/`, `internal/ws/`-adjacent (`cmd/telemetry-server/adapters.go`), and `cmd/telemetry-server/main.go`.

## Test plan

- [x] `go vet ./...`
- [x] `golangci-lint run ./...` — 0 issues
- [x] `go test ./... -short` — all packages pass (one pre-existing flake `TestReceiver_GracefulShutdown` passed 3/3 on retry, unrelated to this PR)
- [x] New unit tests in `internal/store/vin_cache_test.go` cover: cache hit/miss, owner-resolution reuses ID-cache entry, miss is cached, transient errors not cached
- [x] New integration test `TestVehicleRepo_GetIDsByVIN` covers existing-vehicle and missing-vehicle paths against the test pool
- [ ] After merge + deploy: confirm in `pg_stat_statements` that the 24-column `Vehicle WHERE vin = $1` query stops growing call count

## Out of scope

- Reducing `Drive.routePoints` writes (separate concern; current size is fine).
- Schema changes to the `Vehicle` table (Prisma-owned, write-only restricted).

🤖 Generated with [Claude Code](https://claude.com/claude-code)