### PR TITLE
MYR-44 Drop React Native from SDK design; formalize Swift Apple-platform lifecycle

### DIFF
--- a/.claude/agents/sdk-swift.md
+++ b/.claude/agents/sdk-swift.md
@@ -6,7 +6,7 @@ model: opus
 memory: project
 ---
 
-You are a **senior Swift engineer** specializing in cross-Apple-platform SDK design. You build the MyRoboTaxi Swift SDK distributed via Swift Package Manager for iOS 26+, iPadOS 26+, macOS (latest), watchOS, and visionOS.
+You are a **senior Swift engineer** specializing in cross-Apple-platform SDK design. You build the MyRoboTaxi Swift SDK distributed via Swift Package Manager for iOS 26+, iPadOS 26+, macOS 26+, watchOS 26+, and visionOS 26+.
 
 ## Your Scope
 
@@ -15,9 +15,9 @@ You own all Swift code in the SDK package. You implement:
 - Auth callback integration (closure-based, matching TS SDK's `getToken`)
 - State merging (DB snapshot + live WebSocket patches)
 - Observable state model (Swift 5.9+ `@Observable`)
-- Reactive subscription API
+- Observation API: `@Observable` macro state (Swift 5.9+ Observation framework) for SwiftUI; `AsyncSequence` / `AsyncStream` event streams for non-SwiftUI consumers (UIKit, AppKit, headless tests). NEVER `@Published` / `ObservableObject` / `Combine.Publisher`.
 - Typed error enums and retry logic
-- Observability hooks (pluggable logger, OSLog + OTel)
+- Pluggable subsystems exposed as `Sendable` protocols (defaults provided, all swappable for testing): `Authenticator { func token() async throws -> String }`, `SDKLogger`, `MetricsRecorder`, `Tracer` (OTel-shaped). Default implementations: `OSLogLogger`, in-memory `MetricsRecorder`, no-op `Tracer`.
 - Debug mode
 - Contract parsing/validation
 
@@ -28,15 +28,21 @@ Refer to `docs/architecture/requirements.md`. Non-negotiable constraints:
 **Platform targets (NFR-3.34 through 3.36):**
 - iOS 26+
 - iPadOS 26+
-- macOS (latest)
-- watchOS (aggressive lifecycle management)
-- visionOS
+- macOS 26+
+- watchOS 26+ (aggressive lifecycle management)
+- visionOS 26+
 
-**Baseline: Swift 6, async/await, Observable state model.**
+**Baseline: Swift 6 with strict concurrency (`-strict-concurrency=complete`), async/await, structured concurrency with parent-child Task hierarchies, actor isolation for shared mutable state, and `@Observable` (Swift 5.9+ Observation framework) for state exposure.**
 
-**No UIKit dependencies** — the SDK is UI-layer-agnostic. SwiftUI consumers compose state themselves.
+**No third-party WebSocket libraries.** Transport is `URLSessionWebSocketTask` ONLY — no SocketRocket, no Starscream, no Apollo. Works across all target platforms (iOS / iPadOS / macOS / watchOS / visionOS).
 
-**WebSocket abstraction:** URLSession WebSocketTask. Works across all target platforms.
+**No Combine for net-new code.** Combine is in maintenance; use `AsyncSequence` / `AsyncStream` instead. The SDK MUST NOT expose `@Published`, `ObservableObject`, or `Combine.Publisher` on its public API. State is observed via `@Observable` (SwiftUI) or `AsyncStream` (UIKit / AppKit / headless tests).
+
+**No `DispatchQueue.sync` or NSLock for shared state.** All shared mutable state lives behind actor isolation. `DispatchQueue` may be used only for transient one-shot scheduling (e.g., backoff timers via `Task.sleep(for:)`), never for state guarding.
+
+**No UIKit / AppKit / SwiftUI dependencies.** The SDK is UI-layer-agnostic — SwiftUI, UIKit, and AppKit consumers all compose state themselves.
+
+**Distribution: Swift Package Manager only.** No CocoaPods, no Carthage. Semantic version git tags (`v1.x.y`, `v1.x.y-canary.N`). Cadence per NFR-3.41-44: weekly stable, hotfix lane, canary on every main merge.
 
 **watchOS lifecycle:** the SDK MUST gracefully handle aggressive suspension, short-lived app launches, incremental state hydration. Design for "app woken for 5 seconds" scenarios.
 
@@ -69,7 +75,7 @@ When Tesla's quirks affect SDK behavior, consult the `tesla-fleet-telemetry-sme`
 1. **Receive scoped task from `sdk-architect`** with FR/NFR IDs and contract references.
 2. **Read contract docs** (WebSocket protocol, state schema, state machine).
 3. **Implement against the contract**, matching the TypeScript SDK's semantic behavior but with Swift-idiomatic API.
-4. **Write XCTest unit tests** for every public API.
+4. **Write Swift Testing unit tests** (`import Testing`, `@Test` macros) for every public API. XCTest is acceptable only for legacy harnesses or APIs Swift Testing does not yet cover (e.g., performance-metric tests on older toolchains). All test fixtures `Sendable`; concurrency-safe by construction.
 5. **Document every public API** with DocC markup for auto-generated reference.
 6. **Tag `sdk-architect` for review** on every PR.
 

--- a/.claude/agents/sdk-typescript.md
+++ b/.claude/agents/sdk-typescript.md
@@ -1,12 +1,14 @@
 ---
 name: sdk-typescript
-description: TypeScript SDK implementer for the MyRoboTaxi @myrobotaxi/sdk package. Builds the isomorphic core client (React/RN/Node/vanilla), reactive hooks layer, WebSocket client, auth/retry logic, and typed error codes. Works under the sdk-architect's contract enforcement.
+description: TypeScript SDK implementer for the MyRoboTaxi @myrobotaxi/sdk package. Builds the web/Next.js core client (browser + Node + React), WebSocket client, auth/retry logic, and typed error codes. Works under the sdk-architect's contract enforcement. Apple platforms (iOS/iPadOS/macOS/watchOS/visionOS) consume the Swift SDK directly — there is no React Native adapter in v1.
 tools: Read, Grep, Glob, Bash, Edit, Write
 model: opus
 memory: project
 ---
 
-You are a **senior TypeScript engineer** specializing in SDK/client library design. You build the MyRoboTaxi TypeScript SDK that consumers install from npm and use in React apps, React Native apps, Node servers, and vanilla TS.
+You are a **senior TypeScript engineer** specializing in SDK/client library design. You build the MyRoboTaxi TypeScript SDK that consumers install from npm and use in browser apps (with or without React), Next.js apps, and Node servers.
+
+**Platform scope (non-negotiable):** the TypeScript SDK targets **web only** — browser and Node. Apple platforms (iOS, iPadOS, macOS, watchOS, visionOS) consume the **Swift SDK** (P4, `sdk-swift` agent) directly. There is no React Native adapter in v1 and never will be — do not propose one, scope one, or build one. If you find React Native references in the codebase or contracts, flag them as drift to fix.
 
 ## Your Scope
 
@@ -29,12 +31,11 @@ Refer to `docs/architecture/requirements.md`. Non-negotiable constraints:
 
 **Logic-only:** No UI components, no map renderers, no theming (NFR-3.32). You expose reactive state; consumers render it.
 
-**Isomorphic:** Core must run in browser, Node, and React Native (NFR-3.33). No `window`, `document`, or browser globals in core. Abstract WebSocket construction.
+**Web-isomorphic core:** Core must run in browser and Node only (NFR-3.33). No `window`, `document`, or browser-only globals in the core entry — the same module is imported by browser bundles and by Node SSR / scripted contexts. Abstract WebSocket construction so the core picks `globalThis.WebSocket` (browser) or `ws` (Node) at runtime. The core MUST NOT include any React Native shim — `react-native` does not exist in this SDK's runtime matrix.
 
 **Platform entry points:**
-- `@myrobotaxi/sdk` — core (isomorphic)
-- `@myrobotaxi/sdk/react` — React hooks
-- `@myrobotaxi/sdk/react-native` — RN-specific exports if needed
+- `@myrobotaxi/sdk` — core (web-isomorphic: browser + Node)
+- `@myrobotaxi/sdk/react` — React hooks layer for browser / Next.js consumers
 
 **Event-driven freshness:** No client-side TTL timers. Staleness comes from server signals (NFR-3.7 through 3.9).
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -151,7 +151,7 @@ Issues carry one or more `Agent/<name>` labels in Linear that map directly to `.
 | Linear Label | Agent File | When to Use |
 |-------|-----------|-------------|
 | `Agent/sdk-architect` | `sdk-architect.md` | **Supervisor** — owns requirements + contract docs, reviews every PR for contract adherence, coordinates SDK work. Auto-invoked on contract-relevant paths. |
-| `Agent/sdk-typescript` | `sdk-typescript.md` | TypeScript SDK implementation (core, React, RN, Node) |
+| `Agent/sdk-typescript` | `sdk-typescript.md` | TypeScript SDK implementation (core, React, Node — web/Next.js consumers only; **no React Native**) |
 | `Agent/sdk-swift` | `sdk-swift.md` | Swift SDK implementation (iOS, iPadOS, macOS, watchOS, visionOS) |
 | `Agent/contract-tester` | `contract-tester.md` | Contract conformance, FR/NFR, chaos test scenarios |
 | `Agent/contract-guard` | `contract-guard.md` | Automated PR gate — blocks contract drift (session + CI) |
@@ -252,8 +252,8 @@ Work is organized into Linear Projects anchored to `docs/architecture/requiremen
 |---------|-------|
 | P1 — Contract foundation | AsyncAPI/OpenAPI specs, JSON Schema, fixtures, data classification |
 | P2 — Backend SDK v1 | Go server: atomicity, 1s nav intervals, AES-256-GCM encryption, RBAC, audit |
-| P3 — TypeScript SDK v1 | Isomorphic SDK: core + React + RN adapters, <75KB bundle |
-| P4 — Swift SDK v1 | iOS 26+/iPadOS/macOS/watchOS/visionOS |
+| P3 — TypeScript SDK v1 | Web/Next.js SDK: core (browser + Node) + React, <75KB bundle. **No React Native** — Apple platforms covered by P4. |
+| P4 — Swift SDK v1 | iOS 26+ / iPadOS 26+ / macOS 26+ / watchOS 26+ / visionOS 26+. iOS clients consume the Swift SDK directly, not via React Native bridging. |
 | P5 — Observability & Scale | OTel, Prometheus/Grafana, 5K-client load tests, SLOs |
 | P6 — Web test bench | Contract/FR/NFR/chaos validation UI |
 | P7 — Frontend integration | Next.js consumes TS SDK (depends on P3) |

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -243,7 +243,7 @@ Authentication and authorization for client WebSocket connections.
 
 ### 7. SDK (`pkg/sdk/`)
 
-Abstract interfaces that define the client contract. Both the Go WebSocket server implementation and future mobile SDK implementations conform to these interfaces.
+Abstract interfaces that define the client contract. Both the Go WebSocket server implementation and the Swift SDK (Apple platforms — iOS / iPadOS / macOS / watchOS / visionOS) conform to these interfaces. The TypeScript SDK (web + Next.js + Node) consumes the same wire protocol but is implemented in its own repo, not via this Go interface package. There is no React Native implementation in v1 — Apple platforms are covered by the Swift SDK directly.
 
 **Key types:**
 ```go

--- a/docs/architecture/requirements.md
+++ b/docs/architecture/requirements.md
@@ -213,24 +213,38 @@ Every persisted field MUST be labeled with a classification tier in the contract
 
 ### 3.12 Platform support
 
-**TypeScript SDK** — supports:
-- React (hooks layer, separate entry point)
+The SDK split is two implementations, each owning its native platform set. There is **no React Native** in v1 — Apple platforms consume the Swift SDK directly.
+
+**TypeScript SDK (`@myrobotaxi/sdk`)** — web/Next.js consumers only. Supports:
+- React (hooks layer, separate entry point — primary consumer is the MyRoboTaxi Next.js app)
 - Vanilla TypeScript (core client, no React dependency)
 - Node.js (SSR, scheduled tasks, server-side usage — no browser globals in core)
-- React Native (shared code with web, no `window`/`document` in core)
 
-**NFR-3.33** Core SDK uses a WebSocket abstraction that runs on browser `WebSocket`, Node `ws`, and React Native.
+**NFR-3.33** The core TypeScript SDK uses a WebSocket abstraction that runs on browser `WebSocket` and Node `ws` only. Apple platforms (iOS / iPadOS / macOS / watchOS / visionOS) MUST consume the Swift SDK directly (NFR-3.34) and MUST NOT consume the TypeScript SDK via React Native bridging.
 
-**Swift SDK** — supports:
+**Swift SDK (`MyRoboTaxiSDK`)** — Apple platforms only. Supports:
 - iOS 26+
 - iPadOS 26+
-- macOS (latest)
-- watchOS
-- visionOS
+- macOS 26+
+- watchOS 26+
+- visionOS 26+
 
-**NFR-3.34** Baseline: Swift 6, async/await, Observable state model, URLSession WebSocketTask (cross-platform).
-**NFR-3.35** No UIKit dependencies (UI-layer-agnostic).
-**NFR-3.36** watchOS constraint: aggressive lifecycle handling (background suspension, short-lived launches, incremental state hydration).
+**NFR-3.34** Baseline: Swift 6 with strict concurrency (`-strict-concurrency=complete`), async/await, structured concurrency with parent-child Task hierarchies, actor isolation for shared mutable state, `@Observable` (Swift 5.9+ Observation framework) for state exposure, `URLSessionWebSocketTask` for WebSocket transport. Distribution: Swift Package Manager only — no CocoaPods, no Carthage. The Swift SDK MUST NOT depend on:
+
+- third-party WebSocket libraries (no SocketRocket, no Starscream),
+- Combine for net-new code (Combine is in maintenance — use `AsyncSequence` / `AsyncStream`),
+- `@Published` / `ObservableObject` / `Combine.Publisher` on the public API (legacy state-exposure pattern),
+- `DispatchQueue.sync` or `NSLock` for shared state (use actor isolation).
+
+**NFR-3.35** No UIKit / AppKit / SwiftUI dependencies. The Swift SDK is UI-layer-agnostic — SwiftUI, UIKit, and AppKit consumers all compose state themselves.
+
+**NFR-3.36** Apple platform lifecycle handling: the Swift SDK MUST tolerate aggressive OS-driven app suspension (especially watchOS) and resume cleanly. Lifecycle bindings are specified in [`docs/contracts/swift-lifecycle.md`](../contracts/swift-lifecycle.md). Summary requirements:
+
+- **NFR-3.36a** Consumer-driven foreground reconnect: on receipt of an `handleForegroundTransition()` call from the consumer (forwarded from `ScenePhase.active`, `UIScene.willEnterForegroundNotification`, `WKApplicationDidBecomeActiveNotification`, or `NSApplication.didBecomeActiveNotification` — whichever matches the consumer's UI framework), the Swift SDK MUST bypass the reconnect backoff timer for the first attempt and reset the retry counter to 0. Backoff resumes only if the foreground reconnect attempt fails. The SDK is UI-framework-agnostic (NFR-3.35) and MUST NOT observe scene transitions itself.
+- **NFR-3.36b** The Swift SDK MUST expose `performBackgroundSnapshotRefresh()` and `performBackgroundDriveRoutePrefetch(maxDrives:)` async methods so consumers can invoke them from `BGAppRefreshTask` / `BGProcessingTask` handlers (iOS / iPadOS / macOS / visionOS) or `WKApplicationRefreshBackgroundTask` handlers (watchOS). The SDK MUST observe `Task.checkCancellation()` so consumer-supplied expiration handlers can cancel in-flight work. The SDK MUST NOT register or schedule background tasks itself — that is consumer responsibility.
+- **NFR-3.36c** watchOS sessions MUST tolerate `WKExtendedRuntimeSession` termination and consumer-signalled background transitions (`handleBackgroundTransition()`). On watchOS only, the SDK proactively closes the WebSocket on background and treats the close as `disconnected` (not `error`); on the next `handleForegroundTransition()` call the SDK rehydrates from the REST snapshot and applies the §7.2 reconnect sequence from `websocket-protocol.md`.
+
+**NFR-3.36d** Test framework: Swift Testing (`import Testing`, `@Test` macros) for all net-new tests. XCTest is acceptable only for legacy harnesses or APIs Swift Testing does not yet cover. All test fixtures `Sendable`; concurrency-safe by construction.
 
 ### 3.13 Versioning policy
 

--- a/docs/contracts/README.md
+++ b/docs/contracts/README.md
@@ -1,6 +1,6 @@
 # MyRoboTaxi SDK v1 — Contracts
 
-**Status:** Active — v1 contracts authored (six markdown docs + four machine-readable specs + 35 canonical fixtures).
+**Status:** Active — v1 contracts authored (eight markdown docs including [`swift-lifecycle.md`](swift-lifecycle.md) + four machine-readable specs + 35 canonical fixtures).
 **Owner:** `sdk-architect` agent
 **Anchors:** All contracts in this directory trace back to [`docs/architecture/requirements.md`](../architecture/requirements.md).
 
@@ -8,13 +8,13 @@
 
 ## What lives here
 
-This directory holds the **machine- and human-readable contracts** that bind the telemetry server, the TypeScript SDK, the Swift SDK, and the web/mobile consumers together. Every wire message, persisted field, and public SDK type has its authoritative definition here.
+This directory holds the **machine- and human-readable contracts** that bind the telemetry server, the TypeScript SDK (web + Next.js + Node), and the Swift SDK (iOS / iPadOS / macOS / watchOS / visionOS) together. Every wire message, persisted field, and public SDK type has its authoritative definition here. Apple platforms consume the Swift SDK directly; there is no React Native adapter.
 
 These contracts are the single source of truth. If the code and the contract disagree, the contract wins and the code is a bug.
 
 ---
 
-## The seven contract documents
+## The eight contract documents
 
 | Document | Purpose | Target artifact |
 |----------|---------|-----------------|
@@ -24,6 +24,7 @@ These contracts are the single source of truth. If the code and the contract dis
 | [`data-classification.md`](data-classification.md) | Labels every persisted field P0 (public), P1 (sensitive, encrypted at rest), or P2 (sensitive + access-logged). Drives logging redaction rules and encryption boundaries. | Reference table |
 | [`data-lifecycle.md`](data-lifecycle.md) | Retention windows, deletion semantics, audit log format, and the single-source-of-truth rule for every persisted field. | Policy doc + DB schema notes |
 | [`state-machine.md`](state-machine.md) | Connection state machine (`initializing | connecting | connected | disconnected | error`), drive lifecycle states, and per-group data freshness states (`loading | ready | stale | cleared | error`). | State diagrams + transition tables |
+| [`swift-lifecycle.md`](swift-lifecycle.md) | Apple platform lifecycle bindings for the Swift SDK only: `ScenePhase` wiring, `BGAppRefreshTask` / `BGProcessingTask` integration, `URLSessionConfiguration` requirements, watchOS extended-runtime semantics, visionOS scene transitions. Anchors NFR-3.36a-d. | Swift SDK contract supplement |
 | [`fixtures/README.md`](fixtures/README.md) | Index of canonical payload fixtures used for contract conformance testing across both SDKs and the server. | Fixture library |
 
 ### Machine-readable specs and schemas

--- a/docs/contracts/rest-api.md
+++ b/docs/contracts/rest-api.md
@@ -123,7 +123,7 @@ Authorization: Bearer <token>
 
 The token is the **same opaque session token** that the SDK passes in the WebSocket `auth` frame (see [`websocket-protocol.md`](websocket-protocol.md) §2.2). Both transports resolve the token from the consumer's `getToken()` callback (FR-6.1), so the SDK maintains a single credential surface and never stores the token itself.
 
-> **Why an HTTP header for REST but an in-band frame for WebSocket?** Browsers cannot set arbitrary headers on a WebSocket upgrade request, so the WS path pushes the token into the first WebSocket frame for portability (`websocket-protocol.md` §2.3 rationale). REST has no such constraint -- the standard `Authorization: Bearer <token>` header is universally supported by every HTTP client (browser `fetch`, Node `undici`, Swift `URLSession`, React Native `fetch`) and is the least-surprising choice.
+> **Why an HTTP header for REST but an in-band frame for WebSocket?** Browsers cannot set arbitrary headers on a WebSocket upgrade request, so the WS path pushes the token into the first WebSocket frame for portability (`websocket-protocol.md` §2.3 rationale). REST has no such constraint -- the standard `Authorization: Bearer <token>` header is universally supported by every HTTP client in the v1 client matrix (browser `fetch`, Node `undici`, Swift `URLSession` — including watchOS and visionOS variants) and is the least-surprising choice.
 
 ### 3.2 Server-side validation
 
@@ -716,8 +716,8 @@ A 60-minute drive captured at 1 Hz is approximately 3,600 points, which serializ
 The lazy-fetch guidance below is **about cellular bandwidth and perceived latency, not heap pressure**:
 
 - The SDK SHOULD fetch this endpoint lazily (on user tap of a drive's detail view), not eagerly for every drive in the list.
-- Eager pre-fetching of every drive's route would waste cellular bandwidth on every drive-list render, which is particularly bad on watchOS per NFR-3.36 (aggressive lifecycle handling, short-lived launches, incremental state hydration).
-- The SDK MAY fetch the route for the top 1-3 drives as an optimistic prefetch when the drive list is cold-loaded on WiFi, and MUST NOT prefetch on cellular.
+- Eager pre-fetching of every drive's route would waste cellular bandwidth on every drive-list render, which is particularly bad on watchOS per NFR-3.36c (aggressive lifecycle handling: extended-runtime sessions, short-lived launches, REST-snapshot rehydration).
+- The SDK MAY fetch the route for the top 1-3 drives as an optimistic prefetch when the drive list is cold-loaded on WiFi, and MUST NOT prefetch on cellular. On Apple platforms the Swift SDK MUST honor `URLSessionConfiguration.allowsExpensiveNetworkAccess = false` and `allowsConstrainedNetworkAccess = false` for prefetch requests, satisfying this rule against Low Data Mode and metered cellular without ad-hoc reachability checks.
 
 This is explicitly NOT an OOM concern -- a single drive's polyline fits in any v1 target runtime. The recommendation exists purely to protect data plans and perceived latency on low-bandwidth networks.
 

--- a/docs/contracts/schemas/ws-messages.schema.json
+++ b/docs/contracts/schemas/ws-messages.schema.json
@@ -270,7 +270,7 @@
     },
     "PingPayload": {
       "type": "object",
-      "description": "PLANNED — NOT accepted by the server today. Client->server ping. Today, browser clients rely on the server's outbound `heartbeat` frames (§7.4) and the underlying WebSocket protocol's PING/PONG control frames (handled transparently by coder/websocket) to detect liveness. An app-level `ping` is reserved for platforms where the WebSocket library does not expose RFC 6455 PING/PONG (some React Native runtimes, watchOS background sessions — NFR-3.36). Tracked as divergence DV-07 in websocket-protocol.md §10. Note: `auth_ok` has been pulled out of DV-07 and is v1-required (see AuthOkPayload); the rest of DV-07 remains deferred.",
+      "description": "PLANNED — NOT accepted by the server today. Client->server ping. Today, browser clients rely on the server's outbound `heartbeat` frames (§7.4) and the underlying WebSocket protocol's PING/PONG control frames (handled transparently by coder/websocket) to detect liveness. An app-level `ping` is reserved for platforms where the WebSocket library does not expose RFC 6455 PING/PONG — specifically watchOS extended-runtime sessions and iOS background sockets, per NFR-3.36 / NFR-3.36a-d. The TypeScript SDK runs on browser `WebSocket` and Node `ws`, both of which expose transport-level PING/PONG, so this is a Swift-SDK forward-compatibility concern only. Tracked as divergence DV-07 in websocket-protocol.md §10. Note: `auth_ok` has been pulled out of DV-07 and is v1-required (see AuthOkPayload); the rest of DV-07 remains deferred.",
       "additionalProperties": false,
       "properties": {
         "nonce": {

--- a/docs/contracts/state-machine.md
+++ b/docs/contracts/state-machine.md
@@ -25,6 +25,7 @@ The SDK never collapses these dimensions into a single enum (FR-8.2). The UI com
 | **NFR-3.11** | On reconnect, SDK MUST re-fetch DB snapshot and resume live stream without user intervention | Defines the snapshot-resume sequence |
 | **NFR-3.12** | SDK MUST gracefully tolerate offline: cached state from DB visible, connection state signals to UI, no forced reloads | Constrains offline behavior |
 | **NFR-3.13** | Offline tolerance: no maximum — cached data visible indefinitely | No expiry on cached data |
+| **NFR-3.36a** | Consumer-driven foreground reconnect (Swift SDK only): bypass backoff timer for first attempt on `handleForegroundTransition()`, reset retry counter to 0 | §5.3 consumer-driven foreground reconnect; detailed bindings in [`swift-lifecycle.md`](swift-lifecycle.md) |
 
 ---
 
@@ -80,7 +81,7 @@ stateDiagram-v2
 | C-9 | `disconnected` | `RECONNECT_TIMER_FIRED` | -- | `connecting` | Open WebSocket connection to server |
 | C-10 | `disconnected` | `USER_STOPPED` | User explicitly stops the SDK | `error` | Cancel reconnect timer; emit `connectionState` change |
 | C-11 | `error` | `USER_RETRY` | -- | `connecting` | Reset retry counter to 0; open WebSocket connection |
-| C-12 | `error` | `USER_DESTROYED` | -- | (terminal) | Release all resources; unsubscribe all listeners |
+| C-12 | `error` | `USER_DESTROYED` | -- | (terminal) | Release all resources; cancel observers (TS SDK: detach state-change subscribers; Swift SDK: cancel all `Task` handles and terminate any active `AsyncStream` continuations) |
 
 ### 1.3.1 C-3 trigger: `auth_ok` receipt
 
@@ -392,6 +393,27 @@ sequenceDiagram
 4. **Ordering guarantee.** The SDK MUST NOT apply live WebSocket updates for a group until the snapshot for that group has been applied. If live updates arrive before the snapshot fetch completes, they are queued and applied after the snapshot.
 
 5. **Idempotent reconnect.** Multiple rapid disconnect/reconnect cycles MUST NOT cause duplicate snapshot fetches or event deliveries. The SDK cancels any in-flight snapshot fetch when a new reconnect begins.
+
+### 5.3 Consumer-driven foreground reconnect (Swift SDK only)
+
+In addition to the transport-level triggers above (`WS_CLOSED`, `WS_ERROR`, backoff-timer fire), the Swift SDK on Apple platforms MUST also reconnect on **consumer-signalled foreground transitions**, bypassing the backoff timer for the first attempt (NFR-3.36a). The SDK is UI-framework-agnostic per NFR-3.35 — it does NOT observe scene transitions itself. Consumers forward them by calling `MyRoboTaxiClient.handleForegroundTransition()` from their app's lifecycle observer.
+
+Per-platform consumer wiring (the consumer's hook → SDK method `handleForegroundTransition`):
+
+| Platform | UI framework | Hook the consumer wires |
+|---|---|---|
+| iOS / iPadOS / visionOS | SwiftUI | `.onChange(of: scenePhase) { _, p in if p == .active { Task { await sdk.handleForegroundTransition() } } }` |
+| iOS / iPadOS / visionOS | UIKit | Observe `UIScene.willEnterForegroundNotification` |
+| watchOS | SwiftUI | `.onChange(of: scenePhase) { ... case .active: ... }` |
+| watchOS | WatchKit | Observe `WKApplicationDidBecomeActiveNotification` (or `WKApplicationDelegate.applicationDidBecomeActive()`) |
+| macOS | SwiftUI | `.onChange(of: scenePhase) { ... case .active: ... }` |
+| macOS | AppKit | Observe `NSApplication.didBecomeActiveNotification` |
+
+On invocation, the SDK MUST reset its retry counter to 0 and immediately attempt a reconnect using the §5.1 sequence; if that single attempt fails, normal §1.4 backoff resumes from attempt 1. This is paired with REST-snapshot rehydration per NFR-3.11 — the foreground reconnect is meaningless without restoring the per-group `dataState` from the snapshot before applying live frames.
+
+The TypeScript SDK has no equivalent. `document.visibilitychange` is consumer-controlled and explicitly OUT of v1 SDK scope — the TS SDK's only reconnect triggers are the transport-level events above. This delineation is intentional: the JS event loop never suspends mid-task, so silent socket death is rare; the Apple OS *will* suspend mid-task, so consumer-forwarded foreground signalling is required.
+
+Detailed Apple-platform bindings (the SDK's `handleForegroundTransition()` / `handleBackgroundTransition()` / `performBackgroundSnapshotRefresh()` / `performBackgroundDriveRoutePrefetch(maxDrives:)` API, and the consumer-side `BGAppRefreshTask` / `BGProcessingTask` / `WKApplicationRefreshBackgroundTask` registration patterns) are specified in [`swift-lifecycle.md`](swift-lifecycle.md).
 
 ---
 

--- a/docs/contracts/swift-lifecycle.md
+++ b/docs/contracts/swift-lifecycle.md
@@ -1,0 +1,394 @@
+# Swift SDK — Apple platform lifecycle contract
+
+**Status:** Active — v1.
+**Owner:** `sdk-architect` agent (with `sdk-swift` implementing).
+**Anchored:** NFR-3.10, NFR-3.11, NFR-3.34, NFR-3.35, NFR-3.36, NFR-3.36a-d.
+**Scope:** Swift SDK only. The TypeScript SDK has no platform-lifecycle contract — browsers and Node do not suspend SDK code mid-task.
+
+---
+
+## 1. Why this doc exists
+
+`websocket-protocol.md` §7 and `state-machine.md` §5 specify the SDK's reconnect, heartbeat, and snapshot-resume behavior in transport-neutral terms. Apple platforms add a layer the JS runtime does not have: **the OS will suspend the process mid-task**. A `URLSessionWebSocketTask` that was healthy a millisecond ago can be silently frozen and later thawed without any close frame. Reconnection therefore has two distinct triggers on Apple platforms:
+
+1. **Transport-level** — what `state-machine.md` §1 specifies (`WS_CLOSED`, `WS_ERROR`, backoff-timer fire).
+2. **OS-driven** — scene-foreground notifications and background-task wake-ups, specific to UIKit / AppKit / SwiftUI / WatchKit.
+
+This document specifies (a) the SDK API surface for receiving (2) from the consumer, and (b) the per-platform consumer-side wiring that translates Apple's OS notifications into SDK calls. The SDK itself is UI-framework-agnostic per NFR-3.35 — it does NOT import SwiftUI, UIKit, AppKit, WatchKit, or BackgroundTasks. Consumers, who already run inside a UI-framework context, do the observing and forward events to the SDK via async methods.
+
+## 2. Platform → notification matrix (consumer-side reference)
+
+This matrix lists the OS notifications consumers MUST observe and which SDK methods they map to. The SDK does not see these names — it only receives the corresponding `handleForegroundTransition()` / `handleBackgroundTransition()` / `performBackgroundSnapshotRefresh()` / `performBackgroundDriveRoutePrefetch(maxDrives:)` calls.
+
+| Platform | UI framework | Foreground notification (→ `handleForegroundTransition`) | Background notification (→ `handleBackgroundTransition`) | Background-task source (→ `performBackgroundSnapshotRefresh` / `performBackgroundDriveRoutePrefetch`) |
+|---|---|---|---|---|
+| iOS 26+ | SwiftUI | `ScenePhase.active` | `ScenePhase.background` | `BGAppRefreshTask`, `BGProcessingTask` |
+| iOS 26+ | UIKit | `UIScene.willEnterForegroundNotification` | `UIScene.didEnterBackgroundNotification` | `BGAppRefreshTask`, `BGProcessingTask` |
+| iPadOS 26+ | SwiftUI | `ScenePhase.active` | `ScenePhase.background` | `BGAppRefreshTask`, `BGProcessingTask` |
+| iPadOS 26+ | UIKit | `UIScene.willEnterForegroundNotification` | `UIScene.didEnterBackgroundNotification` | `BGAppRefreshTask`, `BGProcessingTask` |
+| macOS 26+ | SwiftUI | `ScenePhase.active` | `ScenePhase.background` | n/a (foreground triggers + persistent connection) |
+| macOS 26+ | AppKit | `NSApplication.didBecomeActiveNotification` | `NSApplication.didResignActiveNotification` | n/a |
+| watchOS 26+ | SwiftUI | `ScenePhase.active` | `ScenePhase.background` | `WKApplicationRefreshBackgroundTask` (no `BGAppRefreshTask` on watchOS) |
+| watchOS 26+ | WatchKit | `WKApplicationDidBecomeActiveNotification` | `WKApplicationWillResignActiveNotification` | `WKApplicationRefreshBackgroundTask` |
+| visionOS 26+ | SwiftUI | `ScenePhase.active` (window scenes and `ImmersiveSpace`) | `ScenePhase.background` | `BGAppRefreshTask` |
+| visionOS 26+ | UIKit | `UIScene.willEnterForegroundNotification` | `UIScene.didEnterBackgroundNotification` | `BGAppRefreshTask` |
+
+`ScenePhase.inactive` (and the equivalent `WKApplicationWillResignActiveNotification`) is intentionally NOT mapped to an SDK method — the SDK does not change connection state on transient inactive transitions (§3.4).
+
+## 3. Consumer-driven lifecycle integration
+
+The Swift SDK is UI-framework-agnostic per NFR-3.35 — it MUST NOT `import SwiftUI`, `import UIKit`, `import AppKit`, `import WatchKit`, or `import BackgroundTasks`. The consumer's app, which already runs inside one of those frameworks, observes scene transitions and forwards them to the SDK via a small lifecycle API. This keeps the SDK linkable from headless contexts (Swift on the server, command-line tools, test rigs) and from any UI-framework choice.
+
+### 3.1 SDK lifecycle API
+
+The SDK's public `MyRoboTaxiClient` actor exposes two foreground-lifecycle methods. Both are `async`, idempotent, and `Sendable`-safe.
+
+```swift
+public actor MyRoboTaxiClient {
+    /// Call when the app or a scene is about to enter the foreground.
+    /// Triggers an immediate reconnect attempt with retry counter reset (NFR-3.36a).
+    /// Idempotent: rapid back-to-back calls collapse to a single reconnect attempt.
+    nonisolated public func handleForegroundTransition() async
+
+    /// Call when the app or a scene has entered the background.
+    /// On watchOS, closes the WebSocket proactively (NFR-3.36c).
+    /// On other platforms, no-op — the OS will suspend the socket; the §7.4.1 watchdog covers staleness.
+    /// Idempotent.
+    nonisolated public func handleBackgroundTransition() async
+}
+```
+
+These methods are declared `nonisolated` so consumer call sites (most of which are `@MainActor`-isolated SwiftUI / UIKit / AppKit / WatchKit observers) can invoke them without the call site itself needing to enter the SDK actor's isolation. The `async` body internally hops into actor isolation to mutate state — the call site sees a clean `Task { await sdk.handleForegroundTransition() }` with no priority-inheritance surprises.
+
+The SDK additionally exposes two background-task entry points consumers invoke from inside their registered task handlers (`BGTaskScheduler` on iOS / iPadOS / macOS / visionOS; `WKApplicationDelegate.handle(_:)` on watchOS):
+
+```swift
+extension MyRoboTaxiClient {
+    /// Run from a background-task handler. Fetches the REST snapshot for every owned vehicle.
+    /// Throws `CancellationError` when the consumer's expiration handler cancels the parent Task.
+    /// No-op when `connectionState == .connected` (foreground session has fresher data).
+    public func performBackgroundSnapshotRefresh() async throws
+
+    /// Run from a background-task handler when on WiFi. Prefetches the top-N drive routes per rest-api.md §7.3.
+    /// Honors `URLSessionConfiguration.allowsExpensiveNetworkAccess = false`.
+    /// Throws `CancellationError` on parent-task cancellation.
+    public func performBackgroundDriveRoutePrefetch(maxDrives: Int = 3) async throws
+}
+```
+
+The SDK does NOT register or schedule background tasks. Registration (Info.plist `BGTaskSchedulerPermittedIdentifiers`, `BGTaskScheduler.shared.register`, `WKApplicationDelegate.handle(_:)`) is consumer responsibility.
+
+### 3.2 Consumer wiring — examples
+
+#### SwiftUI (iOS / iPadOS / macOS / watchOS / visionOS)
+
+```swift
+@main
+struct MyApp: App {
+    @Environment(\.scenePhase) private var scenePhase
+    let sdk = MyRoboTaxiClient(/* ... */)
+
+    var body: some Scene {
+        WindowGroup {
+            ContentView()
+                .environment(sdk)
+        }
+        .onChange(of: scenePhase) { _, newPhase in
+            switch newPhase {
+            case .active:
+                Task { await sdk.handleForegroundTransition() }
+            case .background:
+                Task { await sdk.handleBackgroundTransition() }
+            case .inactive:
+                break // no-op — see §3.4
+            @unknown default:
+                break
+            }
+        }
+    }
+}
+```
+
+#### UIKit (iOS / iPadOS)
+
+The SDK does NOT expose a singleton — see §9.2. Consumers construct `MyRoboTaxiClient` once at app launch (typically in their `AppDelegate`) and hold the instance themselves. The example below assumes the consumer has resolved that instance into a property `sdk: MyRoboTaxiClient` on the scene delegate.
+
+The closure passed to `NotificationCenter.addObserver(forName:object:queue:using:)` is `@Sendable` under Swift 6. Capturing `[weak self]` would require `self` (a `UIResponder` subclass) to be `Sendable`, which it is not. The idiomatic fix is `[weak sdk = self.sdk]` — the actor IS `Sendable`, so this compiles cleanly and avoids the implicit retain-self trap.
+
+```swift
+final class SceneDelegate: UIResponder, UIWindowSceneDelegate {
+    /// Consumer-owned. Resolved from the app's dependency container at scene creation time.
+    let sdk: MyRoboTaxiClient
+
+    init(sdk: MyRoboTaxiClient) {
+        self.sdk = sdk
+        super.init()
+    }
+
+    func scene(_ scene: UIScene, willConnectTo: UISceneSession, options: UIScene.ConnectionOptions) {
+        let center = NotificationCenter.default
+        center.addObserver(forName: UIScene.willEnterForegroundNotification, object: scene, queue: .main) { [weak sdk = self.sdk] _ in
+            Task { await sdk?.handleForegroundTransition() }
+        }
+        center.addObserver(forName: UIScene.didEnterBackgroundNotification, object: scene, queue: .main) { [weak sdk = self.sdk] _ in
+            Task { await sdk?.handleBackgroundTransition() }
+        }
+    }
+}
+```
+
+#### AppKit (macOS)
+
+```swift
+final class AppDelegate: NSObject, NSApplicationDelegate {
+    /// Consumer-owned. Constructed once when the app delegate initializes.
+    let sdk: MyRoboTaxiClient
+
+    override init() {
+        self.sdk = MyRoboTaxiClient(/* config */)
+        super.init()
+    }
+
+    func applicationDidFinishLaunching(_ notification: Notification) {
+        let center = NotificationCenter.default
+        center.addObserver(forName: NSApplication.didBecomeActiveNotification, object: nil, queue: .main) { [weak sdk = self.sdk] _ in
+            Task { await sdk?.handleForegroundTransition() }
+        }
+        center.addObserver(forName: NSApplication.didResignActiveNotification, object: nil, queue: .main) { [weak sdk = self.sdk] _ in
+            Task { await sdk?.handleBackgroundTransition() }
+        }
+    }
+}
+```
+
+#### WatchKit (watchOS, classic)
+
+```swift
+final class ExtensionDelegate: NSObject, WKApplicationDelegate {
+    /// Consumer-owned. Constructed by the extension delegate at app launch.
+    let sdk: MyRoboTaxiClient
+
+    override init() {
+        self.sdk = MyRoboTaxiClient(/* config */)
+        super.init()
+    }
+
+    func applicationDidBecomeActive() {
+        Task { [sdk] in await sdk.handleForegroundTransition() }
+    }
+
+    func applicationWillResignActive() {
+        Task { [sdk] in await sdk.handleBackgroundTransition() }
+    }
+}
+```
+
+### 3.3 SDK behavior on each call
+
+#### `handleForegroundTransition()`
+
+1. Cancel any currently-pending §1.4 backoff timer (`state-machine.md`).
+2. Reset the retry counter to 0 (NFR-3.36a).
+3. If `connectionState == .disconnected`, immediately fire `WS_OPEN_REQUESTED` (state-machine.md §1.3 C-2): transition `disconnected -> connecting` and run the §5.1 reconnect sequence.
+4. If `connectionState == .connected`, do nothing — the watchdog (§7.4.1 of `websocket-protocol.md`) will catch any stale socket within at most 30 s, and the next watchdog-driven `WS_CLOSED` will re-enter the same flow with the retry counter still 0.
+5. If `connectionState == .connecting`, do nothing — let the in-flight attempt complete or time out per the existing pre-`auth_ok` 6 s bound (websocket-protocol.md §2.3 rule 4).
+6. Idempotent: repeated calls within a short window collapse to a single reconnect attempt (state-machine.md §5.2 rule 5).
+
+#### `handleBackgroundTransition()`
+
+1. **iOS / iPadOS / visionOS / macOS:** continue holding the WebSocket open if the OS permits. `URLSessionWebSocketTask` will be silently suspended by the OS within seconds of background entry on iOS-class platforms; that is expected and correct. The SDK does NOT proactively close on background.
+2. **watchOS only** (`#if os(watchOS)` inside the SDK): proactively close the WebSocket per NFR-3.36c. watchOS extended-runtime sessions are scarce and must be released. Transition `connected -> disconnected` with reason `app_backgrounded`. On the next `handleForegroundTransition()` call, run §3.3 above; rehydration follows NFR-3.11 (REST snapshot before live stream).
+3. Idempotent.
+
+The watchOS branch is selected at compile time inside the SDK via `#if os(watchOS)` — consumers do NOT pass a platform marker. This keeps the public API uniform across Apple platforms while preserving the watchOS-specific behavior NFR-3.36c demands.
+
+### 3.4 No SDK API for `inactive` / `willResignActive`
+
+The transient `inactive` state on iOS (system alerts, control center pull-down, watch crown twist, command-center summon) is intentionally NOT exposed as an SDK lifecycle method. The SDK does not change connection state on this transition. Consumers MUST NOT forward `inactive` notifications to the SDK; doing so would cause unnecessary reconnect churn.
+
+## 4. URLSessionConfiguration contract
+
+The Swift SDK MUST construct its `URLSession` for both REST and WebSocket transports with the following configuration:
+
+| Property | Value | Rationale |
+|---|---|---|
+| `waitsForConnectivity` | `true` | Defer connection attempts when offline rather than failing fast — the OS will surface connectivity changes back to the SDK and the §5.1 sequence runs once the network is available |
+| `allowsExpensiveNetworkAccess` | `false` for REST prefetch (rest-api.md §7.3); `true` for the primary WebSocket and on-demand REST | Honors Low Data Mode and metered cellular for opportunistic prefetches; primary live transport is exempt because the user is actively engaged |
+| `allowsConstrainedNetworkAccess` | same as `allowsExpensiveNetworkAccess` | Same Low Data Mode semantics |
+| `multipathServiceType` | `.handover` for the WebSocket; `.none` for REST | Allows seamless WiFi↔cellular handover for the live stream without dropping the socket; REST requests don't benefit |
+| `timeoutIntervalForRequest` | 30 s for REST; **not applicable** to WebSocket | REST timeout is long enough for snapshot fetches over slow networks; WebSocket liveness is governed by the §7.4.1 watchdog instead |
+| `timeoutIntervalForResource` | 60 s for REST | Hard cap on a single REST call (e.g., a slow drive-route response) |
+
+The SDK MUST NOT use `URLSessionConfiguration.background(withIdentifier:)` for the WebSocket. Background URL sessions don't support WebSocket tasks; the consumer-registered `BGAppRefreshTask` / `WKApplicationRefreshBackgroundTask` flow (§5) is the only supported path for background snapshot refresh.
+
+## 5. Consumer-registered background tasks
+
+Background-task scheduling is **consumer responsibility**. The consumer's app registers identifiers (`Info.plist BGTaskSchedulerPermittedIdentifiers` on iOS-class platforms) and writes the handler closure that calls into the SDK's `performBackgroundSnapshotRefresh()` / `performBackgroundDriveRoutePrefetch(maxDrives:)` methods.
+
+This split keeps the SDK free of `BackgroundTasks` framework imports (which don't exist on watchOS) and lets consumers tune cadence, identifiers, and registration policy without changing the SDK.
+
+### 5.1 BGAppRefreshTask — snapshot refresh (iOS / iPadOS / macOS / visionOS)
+
+Identifier: consumer-chosen (e.g., `<bundle-id>.myrobotaxi.snapshotRefresh`). Default cadence: 30 minutes (consumer-tunable). The OS gives the handler roughly 30 seconds to complete.
+
+```swift
+import BackgroundTasks
+
+// `sdk` here is the consumer-owned MyRoboTaxiClient instance, in scope wherever
+// the consumer registers their BGTaskScheduler handlers (typically App init or
+// AppDelegate.application(_:didFinishLaunchingWithOptions:)).
+BGTaskScheduler.shared.register(forTaskWithIdentifier: "com.example.myrobotaxi.snapshotRefresh", using: nil) { [sdk] task in
+    guard let task = task as? BGAppRefreshTask else { return }
+
+    // Schedule the next refresh first so cancellation doesn't drop the cadence.
+    let next = BGAppRefreshTaskRequest(identifier: task.identifier)
+    next.earliestBeginDate = Date(timeIntervalSinceNow: 30 * 60)
+    try? BGTaskScheduler.shared.submit(next)
+
+    let work = Task {
+        do {
+            try await sdk.performBackgroundSnapshotRefresh()
+            task.setTaskCompleted(success: true)
+        } catch {
+            task.setTaskCompleted(success: false)
+        }
+    }
+    task.expirationHandler = { work.cancel() }
+}
+```
+
+Strong capture of `sdk` (an actor, hence `Sendable`) is correct here: BGTaskScheduler handlers are one-shot, run independently of any view-controller lifecycle, and MUST complete or fail explicitly. A weak capture would race against app teardown and silently no-op.
+
+The SDK's `performBackgroundSnapshotRefresh()` MUST:
+
+1. Be safe to call concurrently with foreground SDK activity — actor isolation handles this.
+2. Fetch the REST `GET /vehicles/{id}/snapshot` for every vehicle in the cached ownership set. No WebSocket activity.
+3. Apply the snapshot to internal `@Observable` state.
+4. Observe `Task.checkCancellation()` between vehicle fetches so the consumer's `expirationHandler` (which calls `Task.cancel()`) terminates the work promptly.
+5. Be a no-op when `connectionState == .connected`: a long-lived foreground session has fresher data than any snapshot fetch could provide.
+
+### 5.2 BGProcessingTask — drive-route prefetch (iOS / iPadOS / macOS / visionOS)
+
+Identifier: consumer-chosen (e.g., `<bundle-id>.myrobotaxi.driveRoutePrefetch`). Used for warming the top-N drive routes (rest-api.md §7.3) in the background, only on WiFi. The consumer sets `task.requiresNetworkConnectivity = true` and `task.requiresExternalPower` per their own policy.
+
+```swift
+BGTaskScheduler.shared.register(forTaskWithIdentifier: "com.example.myrobotaxi.driveRoutePrefetch", using: nil) { [sdk] task in
+    guard let task = task as? BGProcessingTask else { return }
+    let work = Task {
+        do {
+            try await sdk.performBackgroundDriveRoutePrefetch(maxDrives: 3)
+            task.setTaskCompleted(success: true)
+        } catch {
+            task.setTaskCompleted(success: false)
+        }
+    }
+    task.expirationHandler = { work.cancel() }
+}
+```
+
+The SDK's `performBackgroundDriveRoutePrefetch(maxDrives:)` MUST:
+
+1. Honor `URLSessionConfiguration.allowsExpensiveNetworkAccess = false` so cellular requests are deferred (NFR-3.36b, rest-api.md §7.3).
+2. Cap at the consumer-supplied `maxDrives` (default 3).
+3. Observe `Task.checkCancellation()` between drive fetches.
+
+### 5.3 watchOS — WKApplicationRefreshBackgroundTask
+
+watchOS does not have `BackgroundTasks`. The consumer's `WKApplicationDelegate.handle(_:)` method dispatches `WKApplicationRefreshBackgroundTask` instances and calls the same SDK method:
+
+```swift
+final class ExtensionDelegate: NSObject, WKApplicationDelegate {
+    /// Consumer-owned. Same instance shown in §3.2 WatchKit example.
+    let sdk: MyRoboTaxiClient
+
+    override init() {
+        self.sdk = MyRoboTaxiClient(/* config */)
+        super.init()
+    }
+
+    func handle(_ backgroundTasks: Set<WKRefreshBackgroundTask>) {
+        for task in backgroundTasks {
+            if let refresh = task as? WKApplicationRefreshBackgroundTask {
+                Task { [sdk] in
+                    try? await sdk.performBackgroundSnapshotRefresh()
+                    refresh.setTaskCompletedWithSnapshot(false)
+                }
+            } else {
+                task.setTaskCompletedWithSnapshot(false)
+            }
+        }
+    }
+}
+```
+
+watchOS does NOT provide an explicit expiration handler in the same shape as iOS; the OS terminates the task. The SDK MUST tolerate abrupt termination — `performBackgroundSnapshotRefresh()` MUST leave the SDK's internal state consistent if cancelled mid-fetch.
+
+Drive-route prefetch is NOT supported on watchOS — bandwidth is too constrained (rest-api.md §7.3, NFR-3.36c).
+
+## 6. watchOS-specific behavior
+
+watchOS has the strictest lifecycle constraints in the Apple platform family. The Swift SDK MUST treat watchOS as the worst-case lifecycle target — anything that works correctly on watchOS works correctly on every other Apple platform.
+
+| Constraint | Implication |
+|---|---|
+| Apps may be foregrounded for as little as **5 seconds** before backgrounding | Cold launches must reach a renderable state without waiting on a fresh WebSocket frame; first paint reads from REST snapshot (NFR-3.11) |
+| Extended-runtime sessions terminate without warning | Treat session-end as `disconnected` (NOT `error`); rehydrate from snapshot on resume via the next `handleForegroundTransition()` call (NFR-3.36c) |
+| Background WebSocket connections aren't supported on watchOS the way they are on iOS | Proactive close on `handleBackgroundTransition()`; rely on `WKApplicationRefreshBackgroundTask` (§5.3) for any scheduled work |
+| Bandwidth is precious | Honor `URLSessionConfiguration.allowsExpensiveNetworkAccess = false` aggressively; never opportunistically prefetch on watchOS |
+
+The SDK MUST NOT block first paint on the WebSocket. The watch UI renders from the REST snapshot; the WebSocket fills in live updates as they arrive.
+
+## 7. visionOS-specific behavior
+
+visionOS adds two scene types beyond standard iOS: `WindowGroup` (2D windows) and `ImmersiveSpace` (mixed/full immersion). Both are governed by `ScenePhase` from the consumer's perspective and map identically into `handleForegroundTransition()` / `handleBackgroundTransition()` from the SDK's perspective — no visionOS-specific SDK code path.
+
+Two visionOS-specific notes for the consumer wiring:
+
+1. **Immersive scene transitions** can be fast (`ImmersiveSpace.dismiss` returns within milliseconds). The SDK's foreground handler is idempotent (§3.3 rule 6), but the consumer's `.onChange(of: scenePhase)` may fire many times in rapid succession during immersion changes. That's fine — repeated calls collapse.
+2. **Spatial audio / persistent windows** may keep the app in the foreground longer than a typical iOS session. The §7.4.1 liveness watchdog still applies — long foreground durations are not exempt.
+
+## 8. macOS-specific behavior
+
+macOS apps typically remain in the foreground for hours. The SDK's behavior on macOS is dominated by the §3 lifecycle wiring plus the §7.4.1 liveness watchdog. There is no `BGAppRefreshTask` analog on macOS — the SDK relies on the long-lived foreground connection.
+
+The one macOS-specific consideration: when the user puts the Mac to sleep, the WebSocket socket is preserved by the OS but data flow halts. On wake, the consumer's `NSApplication.didBecomeActiveNotification` (or SwiftUI `.onChange(of: scenePhase) { case .active: ... }`) observer fires and calls `handleForegroundTransition()`. By that time the §7.4.1 watchdog has already detected silent staleness and transitioned `connected -> disconnected`; the SDK runs the standard reconnect sequence.
+
+## 9. Anti-patterns
+
+The split below mirrors the SDK / consumer responsibility boundary. SDK anti-patterns are enforced by `contract-guard` (Rule CG-SWIFT-1); consumer anti-patterns are documented as wiring guidance.
+
+### 9.1 SDK-internal anti-patterns (Rule CG-SWIFT-1)
+
+The Swift SDK module MUST NOT:
+
+- **Import any UI framework.** `import SwiftUI`, `import UIKit`, `import AppKit`, `import WatchKit`, and `import BackgroundTasks` are all forbidden in the SDK target. Lifecycle and background-task wiring is consumer responsibility (§3, §5); the SDK exposes only async methods. This rule is what NFR-3.35 enforces and what makes the SDK linkable from headless Swift contexts.
+- **Use `Timer` or `DispatchSourceTimer` for staleness detection.** Freshness is event-driven (NFR-3.7); the §7.4.1 watchdog is the only liveness mechanism.
+- **Resume an in-flight `URLSessionWebSocketTask` from a background URL session** (`URLSessionConfiguration.background(withIdentifier:)`). Background URL sessions don't support WebSocket tasks.
+- **Schedule reconnects from a `Task.detached`** outside the SDK actor's isolation. All reconnect / state-transition work MUST run inside the SDK actor.
+- **Expose `Combine.Publisher`, `@Published`, or `ObservableObject` on the public API.** Use `@Observable` (Swift 5.9+ Observation framework) plus `AsyncStream` per NFR-3.34.
+
+### 9.2 Consumer wiring anti-patterns (informational guidance)
+
+Consumers SHOULD avoid:
+
+- **Holding strong references to `BGTask` instances beyond the handler closure.** Retain cycles will cause termination assertions.
+- **Calling `task.setTaskCompleted(success:)` from a `Task.detached`** outside the registered handler closure. The closure must remain on the foreground OS-managed dispatch.
+- **Forwarding `ScenePhase.inactive` to the SDK.** `inactive` is transient (§3.4); forwarding it causes reconnect churn.
+- **Using `Combine` or `@Published` to observe `ScenePhase` in their app.** Use SwiftUI's environment value (`@Environment(\.scenePhase)`) or `NotificationCenter.default.notifications(named:)` (an `AsyncSequence`).
+- **Capturing `[weak self]` in `@Sendable` notification observer closures** when `self` is a `UIResponder`/`NSObject` subclass (i.e., not `Sendable`). Capture `[weak sdk = self.sdk]` instead — the actor is `Sendable` and weak capture lets the observer no-op if the SDK has been torn down.
+- **Exposing the SDK as a singleton** in your own app (e.g., `MyRoboTaxiClient.shared`). The SDK does not ship a singleton, and consumers SHOULD NOT add one — singletons block multi-tenant test rigs and prevent dependency injection.
+
+## 10. Cross-references
+
+- [`state-machine.md`](state-machine.md) §1 — connection state machine, §5 — transport-level reconnect, §5.3 — consumer-driven foreground reconnect.
+- [`websocket-protocol.md`](websocket-protocol.md) §2.3 — pre-`auth_ok` 6 s timer; §7 — heartbeat + reconnect; §7.5 — Apple suspend/resume binding.
+- [`rest-api.md`](rest-api.md) §7.3 — drive-route lazy-fetch, Low Data Mode rules.
+- [`docs/architecture/requirements.md`](../architecture/requirements.md) §3.12 — platform support, NFR-3.34/35/36/36a-d.
+
+## 11. Change log
+
+| Date | Change | Reviewer |
+|---|---|---|
+| 2026-04-25 | Initial authoring as part of the RN-removal audit. Establishes Apple platform lifecycle contract previously implicit/missing. Introduces NFR-3.36a-d. | sdk-architect agent |
+| 2026-04-25 | Reframed lifecycle integration as **consumer-driven**: SDK exposes `handleForegroundTransition()` / `handleBackgroundTransition()` / `performBackgroundSnapshotRefresh()` / `performBackgroundDriveRoutePrefetch(maxDrives:)` async methods; consumers observe Apple OS notifications and forward to those methods. Resolves contradiction with NFR-3.35 (no UI-framework imports). Anti-patterns split into SDK-internal (Rule CG-SWIFT-1) vs consumer-wiring (informational). | sdk-architect agent |
+| 2026-04-26 | Post-review fixes (sdk-swift agent): (1) lifecycle methods declared `nonisolated` so `@MainActor` call sites don't hop through actor isolation; (2) renamed from `application*` (UIKit-coded) to `handle*Transition` (framework-neutral, mirrors CKSyncEngine precedent); (3) dropped `MyRoboTaxiClient.shared` from all wiring examples — SDK exposes no singleton; (4) wiring examples now capture `[weak sdk = self.sdk]` instead of `[weak self]` (UIResponder/NSObject are not `Sendable`); (5) BGTaskScheduler examples use strong `[sdk]` capture (one-shot handlers); (6) deleted obsolete "outside `MainActor`" anti-pattern bullet (obviated by `nonisolated`). | sdk-swift + sdk-architect agents |

--- a/docs/contracts/websocket-protocol.md
+++ b/docs/contracts/websocket-protocol.md
@@ -47,6 +47,7 @@ Every FR/NFR listed here is anchored in at least one section of this doc. The ta
 | **NFR-3.13** | Offline tolerance: no maximum on cached visibility | §7.2 reconnect invariants #3 |
 | **NFR-3.21** | Vehicle ownership enforced on every subscription | §2.2 vehicle resolution; §4.5 ownership filtering (+ DV-09 mid-connection drift) |
 | **NFR-3.22** | TLS in transit (WSS for browsers/apps) | §1.1 transport; §1.2 origin enforcement |
+| **NFR-3.36** + **NFR-3.36a-d** | Apple platform lifecycle (Swift SDK only): consumer-driven foreground reconnect, suspended-socket close semantics, background-task entry points | §7.5 Apple platform suspend/resume; detailed bindings in [`swift-lifecycle.md`](swift-lifecycle.md) |
 
 ---
 
@@ -715,7 +716,7 @@ NOT yet implemented. Today, application-level ping is unnecessary because:
 1. The [`coder/websocket`](https://github.com/coder/websocket) library handles RFC 6455 PING/PONG control frames transparently in both directions.
 2. The server emits `heartbeat` frames on a 15-second cadence (§7.4), giving the SDK a frequent positive liveness signal.
 
-A future application-level `ping` is reserved for platforms where the WebSocket library does not expose RFC 6455 PING/PONG (some React Native runtimes, watchOS background sessions per NFR-3.36).
+A future application-level `ping` is reserved for platforms where the WebSocket library does not expose RFC 6455 PING/PONG -- specifically watchOS extended-runtime sessions and iOS background sockets per NFR-3.36 / NFR-3.36a-d. The TypeScript SDK runs on browser `WebSocket` and Node `ws`, both of which expose transport-level PING/PONG, so the application-level `ping` is a Swift-SDK forward-compatibility concern only.
 
 ```jsonc
 {
@@ -922,6 +923,20 @@ Per NFR-3.7, freshness is event-driven and not time-based. The SDK MUST NOT:
 - Use heartbeat cadence to derive any `dataState` transition.
 
 The only legitimate uses of heartbeat in the SDK are: (a) reset the liveness watchdog, (b) update an internal "last frame received" timestamp for debug telemetry.
+
+### 7.5 Apple platform suspend/resume (Swift SDK only)
+
+> **Anchored:** NFR-3.36, NFR-3.36a-d. Detailed bindings in [`swift-lifecycle.md`](swift-lifecycle.md).
+
+When the iOS / iPadOS / watchOS / visionOS / macOS process is suspended by the OS, `URLSessionWebSocketTask` does not deliver a close frame; the socket falls silent. The Swift SDK MUST detect liveness via the heartbeat-watchdog timeout in §7.4.1 and transition `connected -> disconnected` with a typed reason of `heartbeat_timeout` -- NOT `transport_close`. This is the only path by which a suspended-then-resumed app reaches `disconnected`.
+
+The SDK is UI-framework-agnostic per NFR-3.35 and MUST NOT observe scene transitions itself. Consumers forward foreground transitions by calling `MyRoboTaxiClient.handleForegroundTransition()` from their app's lifecycle observer (SwiftUI `@Environment(\.scenePhase)`, UIKit `UIScene.willEnterForegroundNotification`, WatchKit `WKApplicationDidBecomeActiveNotification`, or AppKit `NSApplication.didBecomeActiveNotification`). On receiving that call the SDK MUST execute the §7.2 reconnect sequence with a **first-attempt backoff bypass** (NFR-3.36a): reset retry counter to 0 and immediately attempt reconnect; if it fails, normal §7.1 backoff resumes from attempt 1.
+
+Per-platform consumer wiring (notifications → SDK method) is enumerated in [`swift-lifecycle.md`](swift-lifecycle.md) §2 and §3.2.
+
+For background-driven snapshot refresh (no foreground transition required), the Swift SDK MUST expose `performBackgroundSnapshotRefresh()` and `performBackgroundDriveRoutePrefetch(maxDrives:)` async methods per NFR-3.36b. Consumers register the platform-specific background-task identifiers (`BGAppRefreshTask` / `BGProcessingTask` on iOS / iPadOS / macOS / visionOS; `WKApplicationRefreshBackgroundTask` on watchOS) themselves and call those SDK methods from inside the registered handler. The SDK observes `Task.checkCancellation()` so consumer-supplied expiration handlers can cancel in-flight work cleanly.
+
+Browser and Node consumers (TypeScript SDK) have no analogous lifecycle: `document.visibilitychange` is consumer-controlled and explicitly OUT of v1 SDK scope, and the Node event loop never suspends mid-task. This section binds Apple platforms only.
 
 ---
 


### PR DESCRIPTION
## Summary

Closes [MYR-44](https://linear.app/myrobotaxi/issue/MYR-44/audit-drop-react-native-formalize-swift-apple-platform-lifecycle).

Doc-only audit. Removes React Native from the SDK contract surface (where it had drifted into NFR-3.33 and several contract docs) and formalizes the Apple-platform lifecycle behavior that was previously implicit. The actual platform split is **TS SDK = web/Next.js + Node only; Swift SDK = all Apple platforms (iOS / iPadOS / macOS / watchOS / visionOS at 26+)**.

- 7 explicit React Native references removed from `requirements.md`, `CLAUDE.md`, `websocket-protocol.md`, `rest-api.md`, `ws-messages.schema.json`, and the SDK agent files. Remaining mentions are exclusively in negation context ("no React Native", "MUST NOT consume via RN bridging") to prevent regression.
- New `docs/contracts/swift-lifecycle.md` (the eighth contract doc) specifies the Apple-platform lifecycle contract: SDK exposes `nonisolated public func handleForegroundTransition() async`, `handleBackgroundTransition()`, `performBackgroundSnapshotRefresh()`, `performBackgroundDriveRoutePrefetch(maxDrives:)` async methods. Consumers observe Apple OS notifications (SwiftUI `ScenePhase`, UIKit `UIScene`, AppKit `NSApplication`, WatchKit `WKApplication`) and forward to those methods. The SDK does NOT import any UI framework per NFR-3.35.
- New NFR-3.36a-d formalize: consumer-driven foreground reconnect with backoff bypass; background-task entry points; watchOS extended-runtime tolerance; Swift Testing as the default test framework.
- Cross-doc consistency: `websocket-protocol.md` §7.5 and `state-machine.md` §5.3 now anchor the Apple lifecycle work; both anchored-requirements summary tables include the new NFRs.
- TS SDK agent (`.claude/agents/sdk-typescript.md`) and Swift SDK agent (`.claude/agents/sdk-swift.md`) refreshed with explicit constraints (no third-party WebSocket libs, no Combine for net-new code, no `@Published`/`ObservableObject`, no `DispatchQueue` locks, SPM-only, Swift Testing default).

## Process

Three parallel discovery agents (`Explore`, `sdk-architect`, `sdk-swift`) produced the cleanup plan; two parallel validation passes after edits. One mid-pass correction caught and fixed: the lifecycle doc initially said "the SDK internally observes `ScenePhase`" — but `ScenePhase` is a SwiftUI type, contradicting NFR-3.35 (no UI-framework imports). Reframed as consumer-driven; API names follow CKSyncEngine precedent (operation-named, framework-neutral) over UIKit-coded names. Final review: APPROVED by both `sdk-architect` and `sdk-swift`.

## Anchored FRs/NFRs

- NFR-3.33 (rewritten) — TS SDK runtime matrix: browser `WebSocket` + Node `ws` only.
- NFR-3.34 (expanded) — Swift SDK baseline + explicit bans on third-party WebSocket libs, Combine, `@Published`, DispatchQueue locks.
- NFR-3.35 (expanded) — UI-framework-agnostic SDK; no UIKit / AppKit / SwiftUI / WatchKit / BackgroundTasks imports.
- NFR-3.36 (expanded) — Apple platform lifecycle parent.
- **NFR-3.36a (NEW)** — Consumer-driven foreground reconnect.
- **NFR-3.36b (NEW)** — Background-task entry points.
- **NFR-3.36c (NEW)** — watchOS extended-runtime tolerance.
- **NFR-3.36d (NEW)** — Swift Testing default.

## Out of scope (follow-ups in separate Linear issues)

- Linear project P3 description updated separately to drop React Native references.
- 4 missing P2 issues (RBAC field masking, DV-07 subscribe/unsubscribe, server-side typed error code emission, REST snapshot completeness conformance test) — being filed as separate Linear issues.
- 8 P3 issues (TS SDK breakdown: schema codegen, WS reconnect, snapshot+delta reconciler, typed CoreError union, React adapter, bundle-size CI gate, conformance test suite, release pipeline) — being filed as separate Linear issues.

## Test plan

- [ ] `contract-guard` CI check passes (no contract drift; new contract doc registered in `docs/contracts/README.md`; anchored-requirements tables updated).
- [ ] `sdk-architect` PR review approves contract adherence.
- [ ] No fixture or AsyncAPI/OpenAPI regeneration required (verified — wire shapes are identical, only descriptive prose changed; PingPayload `description` field is non-normative).
- [ ] No Go code touched — `go vet`, `golangci-lint`, build, and tests all pass trivially.

🤖 Generated with [Claude Code](https://claude.com/claude-code)