### PR TITLE
MYR-45 PR1 RBAC contract foundation: handler-layer mask + audit shape

### DIFF
--- a/docs/contracts/data-classification.md
+++ b/docs/contracts/data-classification.md
@@ -391,6 +391,20 @@ The `contract-guard` agent/CI check enforces the following rules derived from th
 
 **Fix:** Implement AES-256-GCM encrypt/decrypt in the store layer and add a round-trip test.
 
+### Rule CG-DC-5: Role-mask coverage for SDK-exposed fields
+
+**Anchored:** NFR-3.19, NFR-3.20, FR-5.4, FR-5.5.
+
+**Trigger:** Any PR that adds a field to a payload schema (`docs/contracts/schemas/vehicle-state.schema.json`, drive-detail / drive-route response shapes in `docs/contracts/rest-api.md` §7), OR any PR that adds a column to a `Vehicle` / `Drive` / `DriveRoutePoint` / `Invite` row that is then exposed over REST or WebSocket.
+
+**Check:** Every persisted column listed in this document's §1 that is exposed over a REST endpoint or WebSocket frame MUST appear in [`rest-api.md`](rest-api.md) §5.2's per-resource mask matrix — under at least one role's "Visible fields" set, OR explicitly enumerated as "not exposed in v1" with rationale. The mask matrix is the single source-of-truth consumed by both the WebSocket per-role projection (`websocket-protocol.md` §4.6) and the REST handler-layer mask (`rest-api.md` §5.1); a field that lands in a payload schema without a §5.2 mask entry would default to "owner-only via fail-closed allow-list" and silently disappear from viewer payloads, hiding the gap from review.
+
+**Why it matters:** without this gate, a field can be added to a wire schema (e.g., a new `Vehicle.someField`) and merged before the §5.2 matrix decides whether viewers should see it. The runtime fail-closed default keeps viewers safe from leaks but creates silent UX regressions ("why is the viewer's app missing the new field?") that surface only at runtime.
+
+**Fix:** Update [`rest-api.md`](rest-api.md) §5.2 in the same PR. Either add the field to the appropriate role's "Visible fields" list, or document explicitly that it is not exposed in v1.
+
+**Rule does NOT apply to:** Prisma-owned columns that are never surfaced over REST or WS (e.g., `User.id`, `Account.refresh_token`). These are documented in §1 for completeness but are out of the SDK contract surface.
+
 ---
 
 ## 6. Classification summary

--- a/docs/contracts/data-lifecycle.md
+++ b/docs/contracts/data-lifecycle.md
@@ -294,6 +294,7 @@ CREATE INDEX "AuditLog_timestamp_idx" ON "AuditLog" ("timestamp");
 | `drive_deleted` | Single drive record deleted | User |
 | `invite_revoked` | Sharing invite revoked | User |
 | `tokens_refreshed` | OAuth tokens rotated | System (token refresh) |
+| `mask_applied` | Role-based field mask removed at least one field from a REST response or WebSocket broadcast (sampled at 1%) | System (broadcast / handler layer); see [`rest-api.md`](rest-api.md) §5.3 |
 
 **`targetType` values:**
 
@@ -304,6 +305,8 @@ CREATE INDEX "AuditLog_timestamp_idx" ON "AuditLog" ("timestamp");
 | `drive` | A Drive record (or batch of drives) |
 | `invite` | An Invite record |
 | `account` | An Account (OAuth) record |
+| `rest_response` | A REST API response that was mask-projected (paired with `action: mask_applied`) |
+| `ws_broadcast` | A WebSocket frame that was mask-projected (paired with `action: mask_applied`) |
 
 **`initiator` values:**
 

--- a/docs/contracts/rest-api.md
+++ b/docs/contracts/rest-api.md
@@ -45,7 +45,7 @@ Every FR/NFR listed here is anchored in at least one section of this doc. The ta
 | **NFR-3.5** | Snapshot must contain enough data to render the full UI (no per-field spinners) | §7.1 `GET /vehicles/{vehicleId}/snapshot` |
 | **NFR-3.11** | Reconnect re-fetches DB snapshot before resuming live stream | §7.1 + cross-ref to `websocket-protocol.md` §7.2 reconnect sequence |
 | **NFR-3.19** | Every WS broadcast projected through recipient's role mask; no raw fan-out | §5 RBAC field masks (applied to REST too) |
-| **NFR-3.20** | Persisted DB reads respect viewer's role-based field visibility | §5 RBAC field masks |
+| **NFR-3.20** | REST responses are projected through the caller's role mask before encoding (handler-layer mask; the underlying DB read returns plaintext and is role-agnostic) | §5 RBAC field masks |
 | **NFR-3.21** | Vehicle ownership enforced on every API call | §3 Authentication + §5 RBAC |
 | **NFR-3.22** | TLS in transit for all external connections | §2.1 Transport |
 | **NFR-3.23** | AES-256-GCM application-level encryption for P1 fields | §7.4 drive route transport note; §8 resource schemas |
@@ -334,7 +334,7 @@ v1 defines two roles:
 | `owner` | Full | Full (create/delete invites, delete account) | FR-5.4 |
 | `viewer` | Full read of the vehicle's live state, drive history, and route playback | None | FR-5.4 |
 
-The third architectural slot `limited_viewer` is NOT a v1 role but is kept available as an extension seam per FR-5.5. The masking machinery below is defined as a static per-role projection applied at the store layer, so adding a third role is a one-file change (a new mask entry) rather than an architectural change.
+The third architectural slot `limited_viewer` is NOT a v1 role but is kept available as an extension seam per FR-5.5. The masking machinery below is defined as a static per-role projection applied at the handler layer (see §5.1) via `internal/mask/`, so adding a third role is a one-file change (a new mask entry) rather than an architectural change.
 
 ### 5.1 Masking rule
 
@@ -356,7 +356,7 @@ The mask is applied at the **handler layer**: the store returns plaintext, fully
 |------|----------------|-------|
 | `owner` | All fields in [`schemas/vehicle-state.schema.json`](schemas/vehicle-state.schema.json) | Including GPS, nav, charge, gear -- the full v1 `VehicleState` shape. |
 | `viewer` | All fields EXCEPT `licensePlate` | **Note:** `licensePlate` is a Prisma-owned column per [`data-classification.md`](data-classification.md) §1.3 and is NOT currently a member of `vehicle-state.schema.json`, so this mask rule is **forward-looking**: it codifies the behavior the first time `licensePlate` is surfaced over the SDK. Viewers retain full GPS, nav, and charge visibility because the whole point of sharing is to watch the vehicle in real time (FR-5.1, FR-5.4). |
-| `limited_viewer` (FR-5.5 future slot) | All fields EXCEPT `licensePlate`, `navRouteCoordinates`, `destinationName`, `destinationAddress`, `destinationLatitude`, `destinationLongitude`, `originLatitude`, `originLongitude`; `latitude`/`longitude` reduced to a coarse-grained hash (city-block resolution) | Documented here as the extension seam for FR-5.5. NOT implemented in v1. The mask is a static per-role projection; adding the `limited_viewer` row is a one-file store-layer change. |
+| `limited_viewer` (FR-5.5 future slot) | All fields EXCEPT `licensePlate`, `navRouteCoordinates`, `destinationName`, `destinationAddress`, `destinationLatitude`, `destinationLongitude`, `originLatitude`, `originLongitude`; `latitude`/`longitude` reduced to a coarse-grained hash (city-block resolution) | Documented here as the extension seam for FR-5.5. NOT implemented in v1. The mask is a static per-role projection; adding the `limited_viewer` row is a one-file handler-layer change in `internal/mask/`. |
 
 #### 5.2.2 Drive list (`GET /api/vehicles/{vehicleId}/drives`)
 
@@ -402,13 +402,16 @@ Note on the Invite response shape: `email` is **P1** per `data-classification.md
 
 > **Anchored:** NFR-3.20, FR-10 (audit infrastructure), `data-lifecycle.md` §4.
 
-Every REST response and every WebSocket frame whose mask projection removed at least one field MUST be audit-logged at a **1% sampling rate**, computed deterministically by hash:
+Every REST response and every WebSocket frame whose mask projection removed at least one field MUST be audit-logged at a **1% sampling rate**, computed deterministically by hash. The hash inputs differ per channel because the WS audit emit is per-`(vehicleId, role, frame)` at the hub (not per-client), while the REST audit emit is per-request:
 
 ```
-shouldAudit := hash(userId || resourceId || frameSeq) mod 100 == 0
+REST: shouldAudit := hash(userId || requestId || resourceId) mod 100 == 0
+WS:   shouldAudit := hash(vehicleId || role || frameSeq)    mod 100 == 0
 ```
 
-Hash-based sampling rather than a counter avoids concentrating samples on bursty vehicles (a counter samples every 100th frame regardless of source; hash-based sampling distributes uniformly across the active vehicle set, which is essential for incident triage).
+`requestId` is the `X-Request-ID` echoed per §4.4. `frameSeq` is the envelope sequence number once DV-02 lands; until then, the hub uses an in-process monotonic per-vehicle counter.
+
+Hash-based sampling rather than a counter avoids concentrating samples on bursty vehicles (a counter samples every 100th regardless of source; hash-based sampling distributes uniformly across the active vehicle set, which is essential for incident triage).
 
 Audit entries land in the existing `AuditLog` table per `data-lifecycle.md` §4 with:
 
@@ -428,9 +431,9 @@ For WebSocket broadcasts, the audit emit happens **once per (vehicleId, role, fr
 
 ### 5.4 Extension seam for a third role (FR-5.5)
 
-The RBAC masking machinery is implemented as a static lookup table keyed by `(resourceType, role)` at the store layer. Adding a new role is a three-step change:
+The RBAC masking machinery is implemented as a static lookup table keyed by `(resourceType, role)` in `internal/mask/`, consumed by both the REST handler layer (§5.1) and the WebSocket hub's per-role pre-projection (`websocket-protocol.md` §4.6). Adding a new role is a three-step change:
 
-1. Add the role name to the `Role` enum in the store layer.
+1. Add the role name to the `Role` enum in `internal/auth/`.
 2. Add mask entries for each resource type that the new role should see (or inherit from `viewer` with a diff).
 3. Wire the role into the `Authenticator.ResolveRole(userId, vehicleId)` call site.
 

--- a/docs/contracts/rest-api.md
+++ b/docs/contracts/rest-api.md
@@ -338,7 +338,15 @@ The third architectural slot `limited_viewer` is NOT a v1 role but is kept avail
 
 ### 5.1 Masking rule
 
-Every REST response MUST be projected through the caller's role mask **server-side** before being written to the response body. No raw fan-out to callers (NFR-3.19 is about the WS path; NFR-3.20 extends the same rule to REST). The mask is applied in the store layer -- the REST handler receives an already-masked object from the repository.
+Every REST response MUST be projected through the caller's role mask **server-side** before being written to the response body. No raw fan-out to callers (NFR-3.19 is about the WS path; NFR-3.20 extends the same rule to REST).
+
+The mask is applied at the **handler layer**: the store returns plaintext, fully-decrypted objects, and each REST handler invokes `mask.Apply(obj, role)` from `internal/mask/` before encoding. Three reasons the store stays role-agnostic:
+
+1. **Store reuse.** The same `VehicleRepo.Get` is called from cron jobs (drive pruning per `data-lifecycle.md` §5), audit-log writers, and admin / ops tooling that have no role concept. Making the store role-aware would force every non-handler caller to fabricate a fake role.
+2. **Test isolation.** Store tests don't need to set up role plumbing; they exercise the persistence layer in isolation.
+3. **Single point of consistency with the WS path.** The WebSocket broadcaster reads from the event bus, not the store. If the mask were attached to the store layer, the WS path would bypass it entirely. Anchoring the mask at the handler layer keeps it adjacent to the WS hub's per-role pre-projection (`websocket-protocol.md` §4.6) — both paths consume the same `internal/mask/` matrix.
+
+**Output shape: absent, not nulled.** The mask MUST remove denied fields from the JSON entirely (no key emitted) rather than emit them with a `null` value. Emitting `null` would leak the existence of the field to the viewer, which is itself information. The Go implementation projects through `map[string]any` rather than relying on `omitempty` (which only suppresses zero values, not access-control denials).
 
 ### 5.2 Per-resource masks
 
@@ -390,7 +398,35 @@ Note on the Invite response shape: `email` is **P1** per `data-classification.md
 |----------|-------------|-------|
 | `DELETE /api/users/me` | Self only | The authenticated user can delete only their own account. There is no admin deletion, no cross-user deletion, no "delete all viewers of my vehicle" operation. |
 
-### 5.3 Extension seam for a third role (FR-5.5)
+### 5.3 Audit log sampling for masked responses
+
+> **Anchored:** NFR-3.20, FR-10 (audit infrastructure), `data-lifecycle.md` §4.
+
+Every REST response and every WebSocket frame whose mask projection removed at least one field MUST be audit-logged at a **1% sampling rate**, computed deterministically by hash:
+
+```
+shouldAudit := hash(userId || resourceId || frameSeq) mod 100 == 0
+```
+
+Hash-based sampling rather than a counter avoids concentrating samples on bursty vehicles (a counter samples every 100th frame regardless of source; hash-based sampling distributes uniformly across the active vehicle set, which is essential for incident triage).
+
+Audit entries land in the existing `AuditLog` table per `data-lifecycle.md` §4 with:
+
+| Column | Value |
+|---|---|
+| `action` | `mask_applied` (NEW enum value — see `data-lifecycle.md` §4.2) |
+| `targetType` | `rest_response` for REST, `ws_broadcast` for WebSocket |
+| `targetId` | The `vehicleId` or `driveId` whose response was masked |
+| `initiator` | `user` (the consumer's request triggered the response) |
+| `metadata` | `{ "role": "viewer", "channel": "rest" \| "ws", "fieldsMasked": ["licensePlate", ...], "endpoint": "/api/vehicles/{id}/snapshot" }` |
+
+`metadata.fieldsMasked` is a list of column names. Column names are P0 (they appear in this contract and in `data-classification.md` §1) — the audit log MUST NOT contain any actual masked field values, only their names.
+
+Audit-log entries for masked responses are themselves P0 (per `data-classification.md` §2.3 already-classified rules) and follow the same indefinite retention as all other audit entries (NFR-3.29).
+
+For WebSocket broadcasts, the audit emit happens **once per (vehicleId, role, frame)** at the hub layer, not per client — keeping the audit volume proportional to vehicle activity, not to viewer count.
+
+### 5.4 Extension seam for a third role (FR-5.5)
 
 The RBAC masking machinery is implemented as a static lookup table keyed by `(resourceType, role)` at the store layer. Adding a new role is a three-step change:
 

--- a/docs/contracts/websocket-protocol.md
+++ b/docs/contracts/websocket-protocol.md
@@ -45,6 +45,7 @@ Every FR/NFR listed here is anchored in at least one section of this doc. The ta
 | **NFR-3.11** | Reconnect re-fetches DB snapshot, resumes live stream | §7.2 reconnect sequence; §7.3 snapshot-resume semantics |
 | **NFR-3.12** | Graceful offline: cached state visible, no forced reloads | §7.2 reconnect invariants #2, #3 |
 | **NFR-3.13** | Offline tolerance: no maximum on cached visibility | §7.2 reconnect invariants #3 |
+| **NFR-3.19** | Every WS broadcast projected through recipient's role mask; no raw fan-out | §4.6 per-role projection at broadcast (matrix in [`rest-api.md`](rest-api.md) §5.2) |
 | **NFR-3.21** | Vehicle ownership enforced on every subscription | §2.2 vehicle resolution; §4.5 ownership filtering (+ DV-09 mid-connection drift) |
 | **NFR-3.22** | TLS in transit (WSS for browsers/apps) | §1.1 transport; §1.2 origin enforcement |
 | **NFR-3.36** + **NFR-3.36a-d** | Apple platform lifecycle (Swift SDK only): consumer-driven foreground reconnect, suspended-socket close semantics, background-task entry points | §7.5 Apple platform suspend/resume; detailed bindings in [`swift-lifecycle.md`](swift-lifecycle.md) |
@@ -624,9 +625,33 @@ Per [`state-machine.md`](state-machine.md) §4.2, `connectivity` does NOT direct
 
 The SDK can rely on the following contract: **an authenticated production client will NEVER receive a `vehicle_update`, `drive_started`, `drive_ended`, or `connectivity` frame for a vehicle it does not own at handshake time.**
 
-> **Divergence (DV-09):** Ownership changes after the handshake (e.g., invite revoked) take effect only on the next reconnection -- the in-memory `vehicleIDs` snapshot is not refreshed mid-connection. Tracked in §10.
+> **Divergence (DV-09):** Ownership AND role changes after the handshake take effect only on the next reconnection -- both the `vehicleIDs` snapshot and the per-vehicle role snapshot used by §4.6 are captured at handshake time and are not refreshed mid-connection. Tracked in §10.
 
 `heartbeat` frames are broadcast to ALL clients regardless of vehicle ownership via [`Hub.BroadcastAll`](../../internal/ws/hub.go) line 90 -- they carry no vehicle-scoped data.
+
+### 4.6 Per-role projection at broadcast (NFR-3.19)
+
+> **Anchored:** NFR-3.19, NFR-3.20, FR-5.4. Per-resource mask matrix is canonical in [`rest-api.md`](rest-api.md) §5.2; the same matrix governs both transports.
+
+NFR-3.19 requires every WebSocket broadcast to be projected through the recipient's role mask before sending. To satisfy this without per-client marshaling cost, the hub MUST pre-marshal **once per role per frame**, then fan out the role-appropriate bytes to each subscribed client based on that client's per-vehicle role:
+
+```
+EventBus -> Hub.Broadcast(vehicleId, plaintext)
+  framesByRole := { for each role in v1Roles:
+      role -> marshal(mask.Apply(plaintext, mask.For(resourceType, role)))
+  }
+  for each client subscribed to vehicleId:
+      role := client.vehicleRoles[vehicleId]   // resolved at handshake (§2.2)
+      client.enqueue(framesByRole[role])
+```
+
+Marshal cost is `O(|roles|)` per frame, fan-out is `O(|clients|)`. With v1's two-role matrix (`owner`, `viewer`) this is essentially free; FR-5.5's future `limited_viewer` makes it `O(3)`.
+
+The mask matrix is the **same matrix used by the REST handler layer** (`rest-api.md` §5.2) — a single source-of-truth per resource type. The Go implementation lives in `internal/mask/` and is consumed by both the WS hub and the REST handlers (`rest-api.md` §5.1 handler-layer rule). This keeps owner/viewer behavior identical across transports and gives `contract-guard` a single set of mask tables to validate against the schema.
+
+`Client.vehicleRoles map[VehicleID]Role` is populated at handshake time alongside `Client.vehicleIDs`. The `Authenticator.ResolveRole(ctx, userId, vehicleId)` interface method returns the role for each owned vehicle. Like `vehicleIDs`, `vehicleRoles` is a snapshot — see DV-09 below for the mid-connection refresh gap, which extends to role downgrade (e.g., a viewer being upgraded to owner mid-connection does not reflect until reconnection).
+
+**Empty-payload suppression.** If a role's mask projection yields a payload with no remaining fields (every field in the original frame was masked away), the hub MUST omit the frame for that role rather than send an empty `vehicle_update`. Sending an empty broadcast would leak "something happened on this vehicle" to a viewer who shouldn't even know the field existed.
 
 ---
 
@@ -1003,7 +1028,7 @@ Read this legend before scanning the catalogue. A row's **Status** column classi
 | **DV-06** | Open | `auth_timeout` close code conflated with `auth_failed` | Both errors close with `websocket.StatusPolicyViolation` (1008). SDK has to read the `error.code` to decide retry policy; fragile if the error frame races the close. | Map `auth_timeout` to a dedicated close code (proposed: `4001` Auth Token Expired) so SDKs can branch on the close code alone. Requires updating `handler.go:handleUpgrade` error path + SDK close-code switch. | FR-7.1, FR-7.3, §6.2 | `MYR-XX Emit distinct close code for auth_timeout vs auth_failed` |
 | **DV-07** | Open (reduced) | Client control frames (`subscribe`/`unsubscribe`/`ping`/`pong`) and typed `permission_denied` | `readPump` ignores all post-auth client frames. Per-vehicle routing is implicit at handshake time. No typed error frame for `permission_denied`/`vehicle_not_owned`. | Implement `subscribe`/`unsubscribe` for per-vehicle routing, `sinceSeq` resume (depends on DV-02), and typed `permission_denied` / `vehicle_not_owned` error frames with corresponding close code 4002. **Note: `auth_ok` has been pulled OUT of DV-07 and is v1-required** -- see the new §2.3 / §4 catalog entry and the RESOLVED divergence is not tracked separately (the wire contract is the trigger for the implementation issue). | FR-8.1, NFR-3.21, §5 | `MYR-XX Implement per-vehicle subscribe/unsubscribe + permission_denied error frame` |
 | **DV-08** | **RESOLVED (target documented; wiring still pending)** | Per-IP and per-user connection caps | `HandlerConfig.MaxConnectionsPerIP` exists in [`handler.go`](../../internal/ws/handler.go) line 33 and `handleUpgrade` checks it, but [`cmd/telemetry-server/main.go`](../../cmd/telemetry-server/main.go) line 178 constructs `HandlerConfig` without populating it. `WebSocketConfig.MaxConnectionsPerUser` (default **5**, [`internal/config/defaults.go`](../../internal/config/defaults.go) line 67) exists but is not threaded into the handler either. | **Ship both caps:** per-IP **64** (pre-auth, breach -> HTTP 429, no WS handshake), per-user **5** (post-auth, breach -> `error` frame `code="rate_limited"` + close **4003 Server Overload**). See §1.3 for enforcement points and rationale and §6.1.1 for the `rate_limited` reconnect policy. The wiring change is a follow-up implementation issue. | NFR-3.6, §1.3, §6.1.1, §6.2 | `MYR-XX Wire MaxConnectionsPerIP (64) + MaxConnectionsPerUser (5) into HandlerConfig with asymmetric enforcement` |
-| **DV-09** | Open | Vehicle ownership snapshot stale mid-connection | `Client.vehicleIDs` is captured at handshake time. Revoking an invite while a viewer is connected does not stop that viewer's stream until reconnection. | Add a hub-side ownership refresh hook (server-pushed) OR force-disconnect affected clients with close code `4002`. Needs a mechanism for the sharing service to notify the hub. | NFR-3.21, FR-5.3, §4.5 | `MYR-XX Refresh WebSocket client vehicle scope on invite revocation` |
+| **DV-09** | Open | Vehicle ownership AND role snapshot stale mid-connection | `Client.vehicleIDs` and `Client.vehicleRoles` are both captured at handshake time. Revoking an invite while a viewer is connected does not stop that viewer's stream; promoting a viewer to owner (or vice versa) does not change the per-frame role projection (§4.6) until reconnection. | Add a hub-side ownership/role refresh hook (server-pushed) OR force-disconnect affected clients with close code `4002`. Needs a mechanism for the sharing service to notify the hub. | NFR-3.19, NFR-3.21, FR-5.3, §4.5, §4.6 | `MYR-XX Refresh WebSocket client vehicle scope and role on share-state change` |
 | **DV-10** | Open | `speed` not in GPS atomic group | `requirements.md` NFR-3.1 lists `speed` in the GPS group. [`vehicle-state-schema.md`](vehicle-state-schema.md) §7.1 resolves `speed` as ungrouped (2 s cadence vs. 10 m GPS delta filter). Server delivers `speed` independently. | Amend NFR-3.1 in `requirements.md` to reflect the resolved decision. No wire change needed. | NFR-3.1, §4.1.7 | `MYR-XX Amend NFR-3.1 to remove speed from GPS atomic group` |
 | **DV-11** | **RESOLVED** | `drive_ended` wire payload is summary-only (FR-3.4 scope split) | Server emits summary fields only; full FR-3.4 fields are persisted in `Drive` and fetched via REST `GET /drives/{id}`. | **v1 ships the summary on the wire + an explicit `fetchDrive(driveId)` SDK helper** (unanimous recommendation from sdk-typescript and sdk-swift). Target SDK API: `client.onDriveEnded(cb)` + `await client.fetchDrive(id)` + TS `useDrive(id)` React hook + Swift `client.fetchDrive(_:)` async method. REST endpoint is `GET /drives/{id}` -- authoritative reference is [`rest-api.md`](rest-api.md) (placeholder until that doc is authored; see README index). No wire change; documented in §4.3 and [`state-machine.md`](state-machine.md) §3.3 / §4.1. | FR-3.1, FR-3.4, §4.3 | (No implementation issue needed for server; TS/Swift SDK issues implement `fetchDrive`.) |
 | **DV-12** | **RESOLVED** | `drive_ended.duration` string format dropped | **Resolved by [MYR-32](https://linear.app/myrobotaxi/issue/MYR-32).** Server now emits `durationSeconds` (float64, `DriveStats.Duration.Seconds()`) on the `drive_ended` wire frame. The Go `time.Duration.String()` format is no longer emitted. `messages.go` struct field renamed from `Duration string` to `DurationSeconds float64` with JSON tag `"durationSeconds"`. `broadcaster.go:handleDriveEnded` calls `.Seconds()` instead of `.String()`. Tests verify the JSON key name and float64 roundtrip. | (Resolved.) | FR-3.4 ergonomics, §4.3 | [`MYR-32`](https://linear.app/myrobotaxi/issue/MYR-32) — Emit drive_ended.durationSeconds (replace duration string) |


### PR DESCRIPTION
## Summary

First of two PRs for [MYR-45](https://linear.app/myrobotaxi/issue/MYR-45/implement-role-based-broadcast-filtering-and-db-read-field-masks). **Doc-only** contract foundation that establishes the role-mask design before any Go implementation lands. Split per `sdk-architect` recommendation — landing the contract first lets `contract-tester` write FR-5.4 / NFR-3.19 conformance scenarios against a frozen surface while PR2 implements.

## What changes

**`rest-api.md` §5.1 — mask layer revised from store → handler.** Three reasons: store reuse for cron/audit/admin paths that have no role concept, test isolation, and single point of consistency with the WS path which reads from the event bus rather than the store. Also pins "absent, not nulled" semantics — denied fields removed from JSON entirely via `map[string]any` projection, not via `omitempty` (which only suppresses zero values).

**`rest-api.md` §5.3 (new) — Audit log sampling.** Hash-based deterministic 1% sampling. Audit emit happens once per `(vehicleId, role, frame)` at the hub layer, not per client. metadata shape pinned: `role`, `channel`, `fieldsMasked` (column names only — names are P0; values are NEVER in the audit log), `endpoint`. The old §5.3 (extension seam for third role) renumbers to §5.4 — no cross-doc references break.

**`websocket-protocol.md` §4.6 (new) — Per-role projection at broadcast.** Hub pre-marshals once per role per frame, fans out role-appropriate bytes per client. Marshal cost `O(|roles|)`, fan-out `O(|clients|)`. Mask matrix is the same one consumed by REST handlers — single source-of-truth. `Authenticator.ResolveRole(ctx, userId, vehicleId)` is the new interface method (PR2 implements). **Empty-payload suppression:** if a role's projection yields zero remaining fields, the hub omits the frame for that role — sending an empty `vehicle_update` would leak "something happened on this vehicle" to a viewer who shouldn't even know the field existed.

**`websocket-protocol.md` §10 DV-09 expanded.** Previously only covered ownership staleness; now also covers role-snapshot staleness and role downgrade.

**`websocket-protocol.md` anchored-requirements table.** NFR-3.19 row added pointing at §4.6.

**`data-classification.md` §5 CG-DC-5 (new contract-guard rule) — Role-mask coverage for SDK-exposed fields.** Every persisted column exposed over REST or WS MUST appear in `rest-api.md` §5.2's per-resource mask matrix, or be explicitly enumerated as "not exposed in v1". Without this gate, a field can be added to a wire schema and merged before §5.2 decides viewer visibility — the runtime fail-closed default keeps viewers safe from leaks but the missing field surfaces as a silent UX regression in production.

**`data-lifecycle.md` §4.2 — AuditLog enums.** New `action: mask_applied` and new `targetType` values `rest_response` / `ws_broadcast`.

## Why split

PR1 is reviewable in 30 minutes by `sdk-architect` alone — no Go, no tests, no migration. PR2 has 5+ touch points (auth interface change, mask package + generator, WS hub pre-projection, REST handler integration, AuditLog migration, audit sampler) and a security-review surface. Splitting also lets `contract-tester` author FR-5.4 / NFR-3.19 / NFR-3.20 conformance scenarios against the frozen contract while PR2 is in flight.

## Out of scope (lands in PR2 of MYR-45)

- `internal/auth.Role` + `Authenticator.ResolveRole` interface method.
- `internal/mask/` package + `masks_generated.go` generated from `rest-api.md` §5.2.
- `Client.vehicleRoles` cache populated at handshake.
- `Hub.Broadcast` per-role pre-projection.
- REST handler `mask.Apply` integration (note: only `/api/vehicle-status/{vin}` exists today; the other §5.2 endpoints will pick up the mask "for free" at the handler layer when they're built).
- Audit emit + 1% deterministic sampler.
- `AuditLog` migration adding the `mask_applied` action and the new targetType enum values.

## Anchored FRs/NFRs

- FR-5.4 — owner/viewer roles, server-side field masks
- FR-5.5 — extensible to a third role without schema changes
- NFR-3.19 — every WS broadcast projected through recipient's role mask
- NFR-3.20 — persisted DB reads respect viewer's role-based field visibility

## Process notes

`sdk-architect` produced the design memo (consumer-driven matrix sourcing, store-vs-handler layer trade-off, hash-based sampling, allow-list fail-closed, empty-payload suppression). `Explore` mapped current code paths in parallel and surfaced one important reality check: the canonical REST endpoints in MYR-45's AC (`/snapshot`, `/drives`, `/drives/{id}`, `/drives/{id}/route`) **don't exist in code yet** — only `/api/vehicle-status/{vin}` does. PR1 still locks the SoT so the future endpoints pick up masking at handler-layer when built; PR2 wires the existing endpoint + the WS path.

## Test plan

- [ ] `contract-guard` CI passes (CG-DC-5 is rule definition only in this PR; enforcement scaffolding lands with PR2).
- [ ] `sdk-architect` PR review approves the layer-attribution change (store → handler).
- [ ] No fixture regeneration required (no schema or AsyncAPI/OpenAPI shape changed).
- [ ] No Go code touched — `go vet`, `golangci-lint`, build, and tests pass trivially.

🤖 Generated with [Claude Code](https://claude.com/claude-code)