### PR TITLE
MYR-16 AES-256-GCM column encryption foundation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,6 +12,13 @@ DATABASE_URL=postgres://postgres:dev@postgres:5432/myrobotaxi
 # Generate with: openssl rand -hex 32
 AUTH_SECRET=CHANGEME-run-openssl-rand-hex-32
 
+# ---- Encryption (NFR-3.23, NFR-3.24) -----------------------------------------
+# AES-256 key for column-level encryption. Required at startup.
+# Generate with: openssl rand -base64 32
+# For key rotation, switch to the versioned shape (ENCRYPTION_KEY_V1,
+# ENCRYPTION_KEY_V2, ENCRYPTION_WRITE_VERSION) — see docs/contracts/key-rotation.md.
+ENCRYPTION_KEY=CHANGEME-run-openssl-rand-base64-32
+
 # ---- Tesla HTTP Proxy --------------------------------------------------------
 # Path to the Tesla app private key used to sign Fleet API commands.
 # The proxy is only started when this is set and the file exists.

--- a/cmd/telemetry-server/main.go
+++ b/cmd/telemetry-server/main.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/tnando/my-robo-taxi-telemetry/internal/auth"
 	"github.com/tnando/my-robo-taxi-telemetry/internal/config"
+	"github.com/tnando/my-robo-taxi-telemetry/internal/cryptox"
 	"github.com/tnando/my-robo-taxi-telemetry/internal/drives"
 	"github.com/tnando/my-robo-taxi-telemetry/internal/events"
 	"github.com/tnando/my-robo-taxi-telemetry/internal/geocode"
@@ -97,6 +98,27 @@ func run() error { //nolint:funlen // composition root — sequential dependency
 	reg := prometheus.NewRegistry()
 	reg.MustRegister(collectors.NewGoCollector())
 	reg.MustRegister(collectors.NewProcessCollector(collectors.ProcessCollectorOpts{}))
+
+	// --- Column encryption foundation (NFR-3.23, NFR-3.24) ---
+	// Loads the AES-256-GCM key set so the binary fails-fast on missing
+	// or invalid ENCRYPTION_KEY at startup. The Encryptor is constructed
+	// but not yet wired into the store layer; per-table column rollouts
+	// are tracked by follow-on Linear issues that require coordinated
+	// Prisma schema changes in ../my-robo-taxi/. See
+	// docs/contracts/key-rotation.md and docs/contracts/data-classification.md
+	// §3.3 for the encryption contract.
+	keySet, err := cryptox.LoadKeySetFromEnv()
+	if err != nil {
+		return fmt.Errorf("loading encryption key set: %w", err)
+	}
+	encryptor, err := cryptox.NewEncryptor(keySet)
+	if err != nil {
+		return fmt.Errorf("constructing encryptor: %w", err)
+	}
+	_ = encryptor // foundation: column wiring lands in follow-on PRs (MYR-16 cross-repo rollout issues)
+	logger.Info("encryptor initialized",
+		slog.Int("write_version", int(keySet.WriteVersion())),
+	)
 
 	// --- Database connection ---
 	db, err := store.NewDB(ctx, cfg.Database(), logger.With(slog.String("component", "store")), store.NoopMetrics{})

--- a/cmd/telemetry-server/main.go
+++ b/cmd/telemetry-server/main.go
@@ -45,7 +45,7 @@ func main() {
 	}
 }
 
-func run() error { //nolint:funlen // composition root — sequential dependency wiring
+func run() error { //nolint:funlen,cyclop // composition root — sequential dependency wiring; each new dependency adds a guard, not branching logic
 	// --- Flag parsing ---
 	var (
 		configPath = flag.String("config", "", "path to JSON configuration file")

--- a/cmd/telemetry-server/main.go
+++ b/cmd/telemetry-server/main.go
@@ -6,8 +6,6 @@ package main
 
 import (
 	"context"
-	"crypto/tls"
-	"crypto/x509"
 	"flag"
 	"fmt"
 	"log/slog"
@@ -19,9 +17,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/collectors"
 
-	"github.com/tnando/my-robo-taxi-telemetry/internal/auth"
 	"github.com/tnando/my-robo-taxi-telemetry/internal/config"
-	"github.com/tnando/my-robo-taxi-telemetry/internal/cryptox"
 	"github.com/tnando/my-robo-taxi-telemetry/internal/drives"
 	"github.com/tnando/my-robo-taxi-telemetry/internal/events"
 	"github.com/tnando/my-robo-taxi-telemetry/internal/geocode"
@@ -45,7 +41,7 @@ func main() {
 	}
 }
 
-func run() error { //nolint:funlen,cyclop // composition root — sequential dependency wiring; each new dependency adds a guard, not branching logic
+func run() error { //nolint:funlen // composition root — sequential dependency wiring; helpers extracted to wiring.go
 	// --- Flag parsing ---
 	var (
 		configPath = flag.String("config", "", "path to JSON configuration file")
@@ -100,25 +96,11 @@ func run() error { //nolint:funlen,cyclop // composition root — sequential dep
 	reg.MustRegister(collectors.NewProcessCollector(collectors.ProcessCollectorOpts{}))
 
 	// --- Column encryption foundation (NFR-3.23, NFR-3.24) ---
-	// Loads the AES-256-GCM key set so the binary fails-fast on missing
-	// or invalid ENCRYPTION_KEY at startup. The Encryptor is constructed
-	// but not yet wired into the store layer; per-table column rollouts
-	// are tracked by follow-on Linear issues that require coordinated
-	// Prisma schema changes in ../my-robo-taxi/. See
-	// docs/contracts/key-rotation.md and docs/contracts/data-classification.md
-	// §3.3 for the encryption contract.
-	keySet, err := cryptox.LoadKeySetFromEnv()
+	encryptor, err := setupEncryption(logger)
 	if err != nil {
-		return fmt.Errorf("loading encryption key set: %w", err)
-	}
-	encryptor, err := cryptox.NewEncryptor(keySet)
-	if err != nil {
-		return fmt.Errorf("constructing encryptor: %w", err)
+		return err
 	}
 	_ = encryptor // foundation: column wiring lands in follow-on PRs (MYR-16 cross-repo rollout issues)
-	logger.Info("encryptor initialized",
-		slog.Int("write_version", int(keySet.WriteVersion())),
-	)
 
 	// --- Database connection ---
 	db, err := store.NewDB(ctx, cfg.Database(), logger.With(slog.String("component", "store")), store.NoopMetrics{})
@@ -200,84 +182,31 @@ func run() error { //nolint:funlen,cyclop // composition root — sequential dep
 	go hub.RunHeartbeat(ctx, cfg.WebSocket().HeartbeatInterval)
 
 	// --- Client authenticator ---
-	var authenticator ws.Authenticator
-	if *devMode {
-		logger.Warn("dev mode enabled: WebSocket auth disabled, accepting any token")
-		authenticator = &ws.NoopAuthenticator{}
-	} else {
-		authenticator = auth.NewJWTAuthenticator(
-			cfg.Auth().Secret,
-			cfg.Auth().TokenIssuer,
-			cfg.Auth().TokenAudience,
-			db.Pool(),
-		)
-		logger.Info("JWT authentication enabled for WebSocket clients")
-	}
+	authenticator := setupAuthenticator(cfg, db.Pool(), *devMode, logger)
 
-	// --- HTTP servers ---
+	// --- HTTP server + route registration ---
 	srv := server.New(cfg.Server(), logger, db, reg, cfg.TeslaPublicKey())
-	srv.SetTeslaHandler(recv.Handler())
 	originPatterns := cfg.WebSocket().AllowedOrigins
 	if len(originPatterns) == 0 {
 		originPatterns = []string{"*"} // default: allow all (restrict in production config)
 	}
-	srv.SetClientHandler(hub.Handler(authenticator, ws.HandlerConfig{
-		WriteTimeout:   cfg.WebSocket().WriteTimeout,
-		OriginPatterns: originPatterns,
-	}))
+	setupHTTPHandlers(httpRouteDeps{
+		cfg:            cfg,
+		srv:            srv,
+		hub:            hub,
+		authenticator:  authenticator,
+		recv:           recv,
+		bus:            bus,
+		vinCache:       vinCache,
+		accountRepo:    accountRepo,
+		debugGate:      debugGate,
+		originPatterns: originPatterns,
+		logger:         logger,
+	})
 
-	// --- Vehicle status endpoint (always available) ---
-	statusHandler := telemetry.NewVehicleStatusHandler(
-		authenticator,
-		&vehicleOwnerAdapter{cache: vinCache},
-		recv,
-		logger.With(slog.String("component", "vehicle-status")),
-	)
-	srv.HandleFunc("GET /api/vehicle-status/{vin}", statusHandler.ServeHTTP)
-
-	// --- Fleet config push endpoint (optional — requires proxy config) ---
-	setupFleetConfigEndpoint(cfg, srv, authenticator, vinCache, accountRepo, logger)
-
-	// --- Debug fields endpoint ---
-	// Mounted when resolveDebugFieldsGate says so — either because the
-	// server is running with --dev (token optional) or because an operator
-	// has set DEBUG_FIELDS_TOKEN on a production instance to let
-	// `ops fields watch` stream real-Tesla frames. Auth is enforced by
-	// DebugFieldsHandler via the X-Debug-Token header / ?token= query param
-	// when APIKey is non-empty.
-	if debugGate.Enabled {
-		debugHandler := telemetry.NewDebugFieldsHandler(
-			bus,
-			logger.With(slog.String("component", "debug-fields")),
-			telemetry.DebugFieldsConfig{
-				APIKey:         debugGate.Token,
-				OriginPatterns: originPatterns,
-			},
-		)
-		srv.HandleFunc("GET /api/debug/fields", debugHandler.ServeHTTP)
-		logger.Info("/api/debug/fields endpoint enabled",
-			slog.String("gate", debugGate.Reason),
-			slog.Bool("token_required", debugGate.Token != ""),
-		)
-	}
-
-	// Configure mTLS on Tesla port. TLS is required for vehicle connections —
-	// without it, Tesla vehicles cannot complete the handshake and report EOF.
-	if cfg.TLS().CertFile == "" || cfg.TLS().KeyFile == "" {
-		logger.Warn("TLS cert/key not configured — Tesla mTLS port will serve plain TCP (dev only)",
-			slog.String("cert_file", cfg.TLS().CertFile),
-			slog.String("key_file", cfg.TLS().KeyFile),
-		)
-	} else {
-		teslaTLS, err := buildTeslaTLS(cfg.TLS())
-		if err != nil {
-			return fmt.Errorf("building Tesla mTLS config: %w", err)
-		}
-		srv.SetTeslaTLS(teslaTLS)
-		logger.Info("Tesla mTLS configured",
-			slog.String("cert_file", cfg.TLS().CertFile),
-			slog.Bool("client_ca_loaded", cfg.TLS().CAFile != ""),
-		)
+	// --- Tesla mTLS ---
+	if err := setupTeslaTLS(cfg, srv, logger); err != nil {
+		return err
 	}
 
 	logger.Info("starting HTTP servers")
@@ -287,66 +216,6 @@ func run() error { //nolint:funlen,cyclop // composition root — sequential dep
 
 	logger.Info("telemetry-server stopped cleanly")
 	return nil
-}
-
-// setupFleetConfigEndpoint registers the POST /api/fleet-config/{vin}
-// handler if the proxy URL and fleet telemetry hostname are configured.
-// When Tesla OAuth credentials are available, it also enables automatic
-// token refresh.
-func setupFleetConfigEndpoint(
-	cfg *config.Config,
-	srv *server.Server,
-	authenticator ws.Authenticator,
-	vinCache *store.VINCache,
-	accountRepo *store.AccountRepo,
-	logger *slog.Logger,
-) {
-	if cfg.Proxy().URL == "" || cfg.Proxy().FleetTelemetryHostname == "" {
-		logger.Warn("fleet config push disabled: proxy URL or telemetry hostname not configured")
-		return
-	}
-
-	fleetClient := telemetry.NewFleetAPIClient(telemetry.FleetAPIConfig{
-		BaseURL:    cfg.Proxy().URL,
-		HTTPClient: proxyHTTPClient(cfg.Proxy().URL, logger),
-	}, logger.With(slog.String("component", "fleet")))
-
-	// Map config.ProxyConfig fields → telemetry.EndpointConfig.
-	// If new proxy fields are added to config, update this mapping.
-	var fleetOpts []telemetry.FleetConfigOption
-	if cfg.TeslaOAuth().ClientID != "" {
-		// Intentional mapping: config.TeslaOAuthConfig and telemetry.TeslaOAuthConfig
-		// have identical fields but live in separate dependency layers. Don't "DRY"
-		// them — config is infra, telemetry is domain. The copy keeps them decoupled.
-		refresher := telemetry.NewTokenRefresher(telemetry.TeslaOAuthConfig{
-			ClientID:     cfg.TeslaOAuth().ClientID,
-			ClientSecret: cfg.TeslaOAuth().ClientSecret,
-		}, logger.With(slog.String("component", "token-refresh")))
-		updater := &teslaTokenUpdaterAdapter{repo: accountRepo}
-		fleetOpts = append(fleetOpts, telemetry.WithTokenRefresher(refresher, updater))
-		logger.Info("Tesla token auto-refresh enabled")
-	} else {
-		logger.Warn("Tesla token auto-refresh disabled: AUTH_TESLA_ID not set")
-	}
-
-	fleetHandler := telemetry.NewFleetConfigHandler(
-		authenticator,
-		&vehicleOwnerAdapter{cache: vinCache},
-		&teslaTokenAdapter{repo: accountRepo},
-		fleetClient,
-		telemetry.EndpointConfig{
-			Hostname: cfg.Proxy().FleetTelemetryHostname,
-			Port:     cfg.Proxy().FleetTelemetryPort,
-			CA:       cfg.Proxy().FleetTelemetryCA,
-		},
-		logger.With(slog.String("component", "fleet-config")),
-		fleetOpts...,
-	)
-
-	srv.HandleFunc("POST /api/fleet-config/{vin}", fleetHandler.ServeHTTP)
-	logger.Info("fleet config push endpoint enabled",
-		slog.String("proxy_url", cfg.Proxy().URL),
-	)
 }
 
 func newLogger(level string) (*slog.Logger, error) {
@@ -365,38 +234,6 @@ func newLogger(level string) (*slog.Logger, error) {
 	}
 
 	return slog.New(handler), nil
-}
-
-// buildTeslaTLS creates a TLS config for the Tesla mTLS port.
-// It loads the server cert/key and optionally a CA for verifying client certs.
-// If no CA file is configured, client certs are requested but not verified
-// (suitable for local dev with self-signed certs).
-func buildTeslaTLS(cfg config.TLSConfig) (*tls.Config, error) {
-	cert, err := tls.LoadX509KeyPair(cfg.CertFile, cfg.KeyFile)
-	if err != nil {
-		return nil, fmt.Errorf("loading server cert: %w", err)
-	}
-
-	tlsCfg := &tls.Config{
-		Certificates: []tls.Certificate{cert},
-		ClientAuth:   tls.RequestClientCert,
-		MinVersion:   tls.VersionTLS12,
-	}
-
-	if cfg.CAFile != "" {
-		caPEM, err := os.ReadFile(cfg.CAFile) // #nosec G304 -- operator-configured cert path
-		if err != nil {
-			return nil, fmt.Errorf("reading CA file: %w", err)
-		}
-		pool := x509.NewCertPool()
-		if !pool.AppendCertsFromPEM(caPEM) {
-			return nil, fmt.Errorf("no valid certs found in CA file %s", cfg.CAFile)
-		}
-		tlsCfg.ClientCAs = pool
-		tlsCfg.ClientAuth = tls.RequireAndVerifyClientCert
-	}
-
-	return tlsCfg, nil
 }
 
 // newGeocoder creates a Geocoder based on whether a Mapbox token is

--- a/cmd/telemetry-server/wiring.go
+++ b/cmd/telemetry-server/wiring.go
@@ -1,0 +1,241 @@
+// Wiring helpers split out of main.go to keep the composition root under
+// the CLAUDE.md 300-line cap. None of these add abstraction over what
+// run() already did inline — they are pure code-organization extractions.
+package main
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"fmt"
+	"log/slog"
+	"os"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/tnando/my-robo-taxi-telemetry/internal/auth"
+	"github.com/tnando/my-robo-taxi-telemetry/internal/config"
+	"github.com/tnando/my-robo-taxi-telemetry/internal/cryptox"
+	"github.com/tnando/my-robo-taxi-telemetry/internal/events"
+	"github.com/tnando/my-robo-taxi-telemetry/internal/server"
+	"github.com/tnando/my-robo-taxi-telemetry/internal/store"
+	"github.com/tnando/my-robo-taxi-telemetry/internal/telemetry"
+	"github.com/tnando/my-robo-taxi-telemetry/internal/ws"
+)
+
+// setupEncryption loads the AES-256-GCM key set so the binary fails-fast
+// on missing or invalid ENCRYPTION_KEY at startup (NFR-3.23, NFR-3.24).
+// The Encryptor is returned for future use by the store layer; per-table
+// column rollouts are tracked by follow-on Linear issues that require
+// coordinated Prisma schema changes in ../my-robo-taxi/. See
+// docs/contracts/key-rotation.md and docs/contracts/data-classification.md
+// §3.3 for the encryption contract.
+func setupEncryption(logger *slog.Logger) (cryptox.Encryptor, error) {
+	keySet, err := cryptox.LoadKeySetFromEnv()
+	if err != nil {
+		return nil, fmt.Errorf("loading encryption key set: %w", err)
+	}
+	encryptor, err := cryptox.NewEncryptor(keySet)
+	if err != nil {
+		return nil, fmt.Errorf("constructing encryptor: %w", err)
+	}
+	logger.Info("encryptor initialized",
+		slog.Int("write_version", int(keySet.WriteVersion())),
+	)
+	return encryptor, nil
+}
+
+// setupAuthenticator returns a NoopAuthenticator in dev mode (accepts any
+// token) or a JWTAuthenticator wired against the auth secret + DB pool in
+// production mode.
+func setupAuthenticator(cfg *config.Config, dbPool *pgxpool.Pool, devMode bool, logger *slog.Logger) ws.Authenticator {
+	if devMode {
+		logger.Warn("dev mode enabled: WebSocket auth disabled, accepting any token")
+		return &ws.NoopAuthenticator{}
+	}
+	logger.Info("JWT authentication enabled for WebSocket clients")
+	return auth.NewJWTAuthenticator(
+		cfg.Auth().Secret,
+		cfg.Auth().TokenIssuer,
+		cfg.Auth().TokenAudience,
+		dbPool,
+	)
+}
+
+// httpRouteDeps bundles the dependencies required to register the HTTP
+// route surface. Grouped into a struct so setupHTTPHandlers's signature
+// stays readable and so adding a new dep doesn't ripple through call
+// sites.
+type httpRouteDeps struct {
+	cfg            *config.Config
+	srv            *server.Server
+	hub            *ws.Hub
+	authenticator  ws.Authenticator
+	recv           *telemetry.Receiver
+	bus            events.Bus
+	vinCache       *store.VINCache
+	accountRepo    *store.AccountRepo
+	debugGate      debugFieldsGate
+	originPatterns []string
+	logger         *slog.Logger
+}
+
+// setupHTTPHandlers wires every HTTP handler the server exposes:
+// the WebSocket client handler, the Tesla mTLS handler, the
+// vehicle-status REST endpoint, the optional fleet-config push, and
+// the optional debug-fields stream. It does NOT start the server —
+// the caller owns srv.Start.
+func setupHTTPHandlers(deps httpRouteDeps) {
+	deps.srv.SetTeslaHandler(deps.recv.Handler())
+	deps.srv.SetClientHandler(deps.hub.Handler(deps.authenticator, ws.HandlerConfig{
+		WriteTimeout:   deps.cfg.WebSocket().WriteTimeout,
+		OriginPatterns: deps.originPatterns,
+	}))
+
+	statusHandler := telemetry.NewVehicleStatusHandler(
+		deps.authenticator,
+		&vehicleOwnerAdapter{cache: deps.vinCache},
+		deps.recv,
+		deps.logger.With(slog.String("component", "vehicle-status")),
+	)
+	deps.srv.HandleFunc("GET /api/vehicle-status/{vin}", statusHandler.ServeHTTP)
+
+	setupFleetConfigEndpoint(deps.cfg, deps.srv, deps.authenticator, deps.vinCache, deps.accountRepo, deps.logger)
+
+	// Mounted when resolveDebugFieldsGate says so — either because the
+	// server is running with --dev (token optional) or because an operator
+	// has set DEBUG_FIELDS_TOKEN on a production instance to let
+	// `ops fields watch` stream real-Tesla frames. Auth is enforced by
+	// DebugFieldsHandler via the X-Debug-Token header / ?token= query
+	// param when APIKey is non-empty.
+	if deps.debugGate.Enabled {
+		debugHandler := telemetry.NewDebugFieldsHandler(
+			deps.bus,
+			deps.logger.With(slog.String("component", "debug-fields")),
+			telemetry.DebugFieldsConfig{
+				APIKey:         deps.debugGate.Token,
+				OriginPatterns: deps.originPatterns,
+			},
+		)
+		deps.srv.HandleFunc("GET /api/debug/fields", debugHandler.ServeHTTP)
+		deps.logger.Info("/api/debug/fields endpoint enabled",
+			slog.String("gate", deps.debugGate.Reason),
+			slog.Bool("token_required", deps.debugGate.Token != ""),
+		)
+	}
+}
+
+// setupTeslaTLS configures mTLS on the Tesla port. Without it, Tesla
+// vehicles cannot complete the handshake and report EOF. If the cert/key
+// is not configured (dev only), the function logs a warning and returns
+// nil so the Tesla port serves plain TCP.
+func setupTeslaTLS(cfg *config.Config, srv *server.Server, logger *slog.Logger) error {
+	if cfg.TLS().CertFile == "" || cfg.TLS().KeyFile == "" {
+		logger.Warn("TLS cert/key not configured — Tesla mTLS port will serve plain TCP (dev only)",
+			slog.String("cert_file", cfg.TLS().CertFile),
+			slog.String("key_file", cfg.TLS().KeyFile),
+		)
+		return nil
+	}
+	teslaTLS, err := buildTeslaTLS(cfg.TLS())
+	if err != nil {
+		return fmt.Errorf("building Tesla mTLS config: %w", err)
+	}
+	srv.SetTeslaTLS(teslaTLS)
+	logger.Info("Tesla mTLS configured",
+		slog.String("cert_file", cfg.TLS().CertFile),
+		slog.Bool("client_ca_loaded", cfg.TLS().CAFile != ""),
+	)
+	return nil
+}
+
+// setupFleetConfigEndpoint registers the POST /api/fleet-config/{vin}
+// handler if the proxy URL and fleet telemetry hostname are configured.
+// When Tesla OAuth credentials are available, it also enables automatic
+// token refresh.
+func setupFleetConfigEndpoint(
+	cfg *config.Config,
+	srv *server.Server,
+	authenticator ws.Authenticator,
+	vinCache *store.VINCache,
+	accountRepo *store.AccountRepo,
+	logger *slog.Logger,
+) {
+	if cfg.Proxy().URL == "" || cfg.Proxy().FleetTelemetryHostname == "" {
+		logger.Warn("fleet config push disabled: proxy URL or telemetry hostname not configured")
+		return
+	}
+
+	fleetClient := telemetry.NewFleetAPIClient(telemetry.FleetAPIConfig{
+		BaseURL:    cfg.Proxy().URL,
+		HTTPClient: proxyHTTPClient(cfg.Proxy().URL, logger),
+	}, logger.With(slog.String("component", "fleet")))
+
+	// Map config.ProxyConfig fields → telemetry.EndpointConfig.
+	// If new proxy fields are added to config, update this mapping.
+	var fleetOpts []telemetry.FleetConfigOption
+	if cfg.TeslaOAuth().ClientID != "" {
+		// Intentional mapping: config.TeslaOAuthConfig and telemetry.TeslaOAuthConfig
+		// have identical fields but live in separate dependency layers. Don't "DRY"
+		// them — config is infra, telemetry is domain. The copy keeps them decoupled.
+		refresher := telemetry.NewTokenRefresher(telemetry.TeslaOAuthConfig{
+			ClientID:     cfg.TeslaOAuth().ClientID,
+			ClientSecret: cfg.TeslaOAuth().ClientSecret,
+		}, logger.With(slog.String("component", "token-refresh")))
+		updater := &teslaTokenUpdaterAdapter{repo: accountRepo}
+		fleetOpts = append(fleetOpts, telemetry.WithTokenRefresher(refresher, updater))
+		logger.Info("Tesla token auto-refresh enabled")
+	} else {
+		logger.Warn("Tesla token auto-refresh disabled: AUTH_TESLA_ID not set")
+	}
+
+	fleetHandler := telemetry.NewFleetConfigHandler(
+		authenticator,
+		&vehicleOwnerAdapter{cache: vinCache},
+		&teslaTokenAdapter{repo: accountRepo},
+		fleetClient,
+		telemetry.EndpointConfig{
+			Hostname: cfg.Proxy().FleetTelemetryHostname,
+			Port:     cfg.Proxy().FleetTelemetryPort,
+			CA:       cfg.Proxy().FleetTelemetryCA,
+		},
+		logger.With(slog.String("component", "fleet-config")),
+		fleetOpts...,
+	)
+
+	srv.HandleFunc("POST /api/fleet-config/{vin}", fleetHandler.ServeHTTP)
+	logger.Info("fleet config push endpoint enabled",
+		slog.String("proxy_url", cfg.Proxy().URL),
+	)
+}
+
+// buildTeslaTLS creates a TLS config for the Tesla mTLS port. It loads
+// the server cert/key and optionally a CA for verifying client certs.
+// If no CA file is configured, client certs are requested but not
+// verified (suitable for local dev with self-signed certs).
+func buildTeslaTLS(cfg config.TLSConfig) (*tls.Config, error) {
+	cert, err := tls.LoadX509KeyPair(cfg.CertFile, cfg.KeyFile)
+	if err != nil {
+		return nil, fmt.Errorf("loading server cert: %w", err)
+	}
+
+	tlsCfg := &tls.Config{
+		Certificates: []tls.Certificate{cert},
+		ClientAuth:   tls.RequestClientCert,
+		MinVersion:   tls.VersionTLS12,
+	}
+
+	if cfg.CAFile != "" {
+		caPEM, err := os.ReadFile(cfg.CAFile) // #nosec G304 -- operator-configured cert path
+		if err != nil {
+			return nil, fmt.Errorf("reading CA file: %w", err)
+		}
+		pool := x509.NewCertPool()
+		if !pool.AppendCertsFromPEM(caPEM) {
+			return nil, fmt.Errorf("no valid certs found in CA file %s", cfg.CAFile)
+		}
+		tlsCfg.ClientCAs = pool
+		tlsCfg.ClientAuth = tls.RequireAndVerifyClientCert
+	}
+
+	return tlsCfg, nil
+}

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -26,6 +26,9 @@ services:
     environment:
       DATABASE_URL: postgres://postgres:test@postgres-test:5432/telemetry_test
       AUTH_SECRET: test-secret-not-for-production
+      # 32 bytes of 0xAB base64-encoded — clearly not a real secret.
+      # See docs/contracts/key-rotation.md for the production env-var schema.
+      ENCRYPTION_KEY: q6urq6urq6urq6urq6urq6urq6urq6urq6urq6urq6s=
       LOG_FORMAT: json
     depends_on:
       postgres-test:

--- a/docs/contracts/README.md
+++ b/docs/contracts/README.md
@@ -1,6 +1,6 @@
 # MyRoboTaxi SDK v1 — Contracts
 
-**Status:** Active — v1 contracts authored (eight markdown docs including [`swift-lifecycle.md`](swift-lifecycle.md) + four machine-readable specs + 35 canonical fixtures).
+**Status:** Active — v1 contracts authored (nine markdown docs including [`swift-lifecycle.md`](swift-lifecycle.md) and [`key-rotation.md`](key-rotation.md) + four machine-readable specs + 35 canonical fixtures).
 **Owner:** `sdk-architect` agent
 **Anchors:** All contracts in this directory trace back to [`docs/architecture/requirements.md`](../architecture/requirements.md).
 
@@ -23,6 +23,7 @@ These contracts are the single source of truth. If the code and the contract dis
 | [`vehicle-state-schema.md`](vehicle-state-schema.md) | Canonical JSON Schema for vehicle, nav, charge, GPS, and gear state. Declares atomic groups and per-field types, nullability, and units. | JSON Schema draft-2020-12 at [`schemas/vehicle-state.schema.json`](schemas/vehicle-state.schema.json) |
 | [`data-classification.md`](data-classification.md) | Labels every persisted field P0 (public), P1 (sensitive, encrypted at rest), or P2 (sensitive + access-logged). Drives logging redaction rules and encryption boundaries. | Reference table |
 | [`data-lifecycle.md`](data-lifecycle.md) | Retention windows, deletion semantics, audit log format, and the single-source-of-truth rule for every persisted field. | Policy doc + DB schema notes |
+| [`key-rotation.md`](key-rotation.md) | Encryption key rotation contract: ciphertext format, env-var schema (single-key shorthand + versioned shape), happy-path and emergency-retire procedures, observability counters, failure-mode table. Anchors NFR-3.26. | Operational runbook |
 | [`state-machine.md`](state-machine.md) | Connection state machine (`initializing | connecting | connected | disconnected | error`), drive lifecycle states, and per-group data freshness states (`loading | ready | stale | cleared | error`). | State diagrams + transition tables |
 | [`swift-lifecycle.md`](swift-lifecycle.md) | Apple platform lifecycle bindings for the Swift SDK only: `ScenePhase` wiring, `BGAppRefreshTask` / `BGProcessingTask` integration, `URLSessionConfiguration` requirements, watchOS extended-runtime semantics, visionOS scene transitions. Anchors NFR-3.36a-d. | Swift SDK contract supplement |
 | [`fixtures/README.md`](fixtures/README.md) | Index of canonical payload fixtures used for contract conformance testing across both SDKs and the server. | Fixture library |

--- a/docs/contracts/README.md
+++ b/docs/contracts/README.md
@@ -14,7 +14,7 @@ These contracts are the single source of truth. If the code and the contract dis
 
 ---
 
-## The eight contract documents
+## The nine contract documents
 
 | Document | Purpose | Target artifact |
 |----------|---------|-----------------|

--- a/docs/contracts/data-classification.md
+++ b/docs/contracts/data-classification.md
@@ -286,12 +286,13 @@ These P1 columns are sensitive and must never appear in logs, but are NOT encryp
 
 ### 3.3 Encryption implementation contract
 
-- **Algorithm:** AES-256-GCM (authenticated encryption with associated data)
-- **Key source:** `ENCRYPTION_KEY` environment variable (Fly.io secret, NFR-3.24)
-- **Nonce:** 12-byte random nonce prepended to each ciphertext
-- **Encoding:** `base64(nonce || ciphertext || tag)` stored as `Text` in PostgreSQL
+- **Algorithm:** AES-256-GCM (authenticated encryption with associated data).
+- **Canonical primitive:** [`internal/cryptox.Encryptor`](../../internal/cryptox/encryptor.go) is the only entry point for column-level encryption. The store layer uses the interface; never call `crypto/aes` or `crypto/cipher` directly from outside `internal/cryptox/`.
+- **Key source:** `ENCRYPTION_KEY` environment variable (Fly.io secret, NFR-3.24) for single-key deployments. During key rotation, switch to the versioned shape: `ENCRYPTION_KEY_V{N}` plus `ENCRYPTION_WRITE_VERSION`. See [`key-rotation.md`](key-rotation.md) for the full env-var schema and rotation procedure (NFR-3.26).
+- **Ciphertext format:** `[1B version][12B nonce][N B ciphertext + 16B GCM tag]`, base64-encoded as `Text` in PostgreSQL. The version byte routes the decrypt path to the matching key in the active `KeySet`, enabling in-place key rotation without re-encrypting old rows up front. Version `0x00` is reserved as invalid; `0x01` is the only emitted version today.
+- **Nonce:** 12-byte cryptographically-random nonce per call (NIST SP 800-38D §5.2.1.1). Catastrophic GCM failure mode is nonce reuse; the package guarantees fresh nonces per `Encrypt` call.
 - **Transparency:** Encrypt on write, decrypt on read, entirely within the store layer (NFR-3.25). The SDK, WebSocket broadcaster, and REST API handlers operate on plaintext values.
-- **Key rotation:** Documented in a separate contract doc per NFR-3.26
+- **Foundation status (as of MYR-16, 2026-05-01):** the `internal/cryptox` package + startup wiring are landed; `ENCRYPTION_KEY` is required at startup. **No P1 columns are yet encrypted on disk** — the per-column rollouts require coordinated Prisma migrations in `../my-robo-taxi/` and are tracked as separate Linear issues (one per migration unit: OAuth tokens, Vehicle GPS coords, route blobs).
 
 ---
 

--- a/docs/contracts/key-rotation.md
+++ b/docs/contracts/key-rotation.md
@@ -28,6 +28,7 @@ Every value emitted by `internal/cryptox.Encryptor` is base64-encoded:
 
 - `version` routes the decrypt path to the matching key in the active `KeySet`. Reserved: `0x00` is INVALID — guards against zero-init buffers being silently accepted.
 - `nonce` is freshly random per call (NIST SP 800-38D §5.2.1.1). Catastrophic GCM failure mode is nonce reuse; never patch this constant or reuse a nonce.
+- **Nonce-space rotation guidance.** With 96-bit random nonces the birthday-collision probability hits 2⁻³² at roughly 2³² (~4 billion) encryptions per key. NIST's stated bound is also 2³². Plan to retire any single key before it reaches ~1 billion encryptions across all P1 columns combined to stay well below the bound. At telemetry rates (e.g., ~10 GPS frames/sec/vehicle × 1000 vehicles × 86400 sec/day ≈ 0.86B/day for the GPS columns alone), this implies an annual or sooner rotation cadence once the GPS rollout lands. Re-evaluate the cadence as part of the column-rollout PRs once production write rates per column are measured.
 - `ciphertext + tag` is the standard AES-GCM output. Tampering produces an authentication failure on `Decrypt` — never silently accepted.
 
 The minimum ciphertext length is `1 + 12 + 16 = 29` bytes pre-base64. `Decrypt` rejects shorter inputs with `ErrCiphertextTooShort` before invoking AES.

--- a/docs/contracts/key-rotation.md
+++ b/docs/contracts/key-rotation.md
@@ -1,0 +1,124 @@
+# Encryption key rotation
+
+## Purpose
+
+Operational contract for rotating the AES-256-GCM keys that protect P1 columns at rest (NFR-3.23). Defines the env-var schema both shapes accept, the procedure for retiring a key, and the observability operators rely on to confirm rotation completed before a key is dropped.
+
+## Anchored requirements
+
+- **NFR-3.22** — TLS in transit for all connections.
+- **NFR-3.23** — AES-256-GCM column-level encryption for P1 fields.
+- **NFR-3.24** — encryption key stored as Fly.io secret (`ENCRYPTION_KEY`).
+- **NFR-3.25** — encryption transparent to SDK consumers (server store layer only).
+- **NFR-3.26** — key rotation strategy (this document).
+
+## Threat model
+
+- An attacker with database read access (e.g., a leaked Supabase backup, an over-privileged ops account, or a misconfigured replica) is the primary adversary in scope.
+- Application memory is out of scope for the rotation strategy itself: a compromised running process exposes plaintext regardless of at-rest encryption.
+- Loss of the active key = loss of access to all rows encrypted under it. The KeySet design keeps retired keys readable until rotation is provably complete (see §"Procedure"), preventing accidental data loss during rotation.
+
+## Ciphertext format
+
+Every value emitted by `internal/cryptox.Encryptor` is base64-encoded:
+
+```
+[1 byte version][12 bytes nonce][N bytes ciphertext + 16 bytes GCM auth tag]
+```
+
+- `version` routes the decrypt path to the matching key in the active `KeySet`. Reserved: `0x00` is INVALID — guards against zero-init buffers being silently accepted.
+- `nonce` is freshly random per call (NIST SP 800-38D §5.2.1.1). Catastrophic GCM failure mode is nonce reuse; never patch this constant or reuse a nonce.
+- `ciphertext + tag` is the standard AES-GCM output. Tampering produces an authentication failure on `Decrypt` — never silently accepted.
+
+The minimum ciphertext length is `1 + 12 + 16 = 29` bytes pre-base64. `Decrypt` rejects shorter inputs with `ErrCiphertextTooShort` before invoking AES.
+
+## Env-var schema
+
+The Encryptor accepts two deployment shapes; pick exactly one.
+
+### Single-key shorthand (no rotation in progress)
+
+```
+ENCRYPTION_KEY=base64(32 random bytes)
+```
+
+`writeVersion` is fixed at `0x01`. The KeySet is `{0x01: <key>}`. Use this shape when no rotation is in progress and you do NOT need to keep an old key readable.
+
+### Versioned shape (rotation in progress, or after rotation completes)
+
+```
+ENCRYPTION_KEY_V1=base64(32 random bytes)   # old key, retained for read
+ENCRYPTION_KEY_V2=base64(32 random bytes)   # new key
+ENCRYPTION_WRITE_VERSION=2                   # Encrypt uses V2; Decrypt fans out by version byte
+```
+
+- `ENCRYPTION_KEY_V{N}` may be present for any byte value `1..255`.
+- `ENCRYPTION_WRITE_VERSION` MUST point to a present `ENCRYPTION_KEY_V{N}` — startup fails otherwise.
+- All present versioned keys are added to the readable set, so ciphertexts written under any version remain decryptable.
+
+### Mutual exclusivity
+
+Setting both `ENCRYPTION_KEY` and any `ENCRYPTION_KEY_V{N}` is a configuration error. Startup fails with a clear message. Pick exactly one shape per deployment.
+
+### Empty values
+
+Any empty env-var value is treated as not-set. This is so a deployment cannot silently launch with an empty key, and so test harnesses that clear vars with `t.Setenv("ENCRYPTION_KEY", "")` behave identically to "not set."
+
+## Procedure: rotate from V1 to V2
+
+This is the canonical happy-path rotation. Each step is independent and observable.
+
+1. **Generate the new key.** `head -c 32 /dev/urandom | base64`. Store it in your secret manager (Fly.io secrets, AWS Secrets Manager, etc.) as `ENCRYPTION_KEY_V2`.
+
+2. **Switch the deployment to versioned shape.** Set `ENCRYPTION_KEY_V1` to the value that was previously `ENCRYPTION_KEY`, and unset `ENCRYPTION_KEY`. Set `ENCRYPTION_KEY_V2` to the new key. Set `ENCRYPTION_WRITE_VERSION=1` (still writing v1 — this step only adds the v2 key to the readable set so we can't get cut off mid-rotation). Deploy.
+
+3. **Verify v1 + v2 are both readable.** Hit a few `/snapshot` endpoints; confirm decrypts succeed. Optional: synthesize a v2 ciphertext via a one-shot CLI tool and confirm decrypt fans out to v2 correctly.
+
+4. **Flip the active write version.** Set `ENCRYPTION_WRITE_VERSION=2`. Deploy. New writes are now under v2; existing v1 ciphertexts remain readable.
+
+5. **Re-encrypt the corpus.** A background job reads each P1 column, decrypts under the version-routed key, re-encrypts under v2 (the active write version), and writes back. The job MUST be idempotent — re-running on already-v2 rows is a no-op (decrypt v2 → encrypt v2). Track progress with the `cryptox_decrypt_total{version="..."}` counter (see §"Observability").
+
+6. **Confirm v1 is no longer reached.** When `cryptox_decrypt_total{version="1"}` has been zero for at least 24 hours under representative production load, retirement is safe. If a long-tail row remains v1, the metric stays nonzero — do NOT retire v1 in that case.
+
+7. **Retire v1.** Unset `ENCRYPTION_KEY_V1` from the secret manager. Deploy. The KeySet now only has v2; any v1 ciphertext that surfaces post-retirement returns `ErrUnknownKeyVersion` — surfacing the bug rather than silently failing.
+
+8. **(Optional) Collapse to single-key shorthand.** If no further rotation is planned in the near term, set `ENCRYPTION_KEY` to the v2 key value, unset `ENCRYPTION_KEY_V2` and `ENCRYPTION_WRITE_VERSION`. The semantic is unchanged; the env footprint shrinks.
+
+## Procedure: emergency retire (suspected key compromise)
+
+1. Treat the suspected-compromised key as untrusted; assume an attacker can decrypt any data encrypted under it.
+2. Generate a new key as `ENCRYPTION_KEY_V{N+1}`. Set `ENCRYPTION_WRITE_VERSION=N+1`. Deploy.
+3. Run the re-encrypt-on-read job at maximum throughput. Monitor `cryptox_decrypt_total{version="N"}` decay.
+4. Do NOT wait for the standard 24-hour zero window — retire the compromised version as soon as the decrypt metric reaches zero. Any rows that fail to re-encrypt in time will surface `ErrUnknownKeyVersion` post-retirement and can be re-keyed individually after the immediate threat is neutralized.
+5. Rotate the secret-store credentials too — if the key leaked, the secret-store access path may also be compromised.
+
+## Observability
+
+The `internal/cryptox` package emits one counter per decrypt call (TODO: wired in a follow-on PR alongside the first column rollout):
+
+- `cryptox_decrypt_total{version="N"}` — increments on every successful decrypt of a ciphertext stamped with version `N`. During rotation, the v1 series should decay to zero before v1 is retired.
+
+Until the counter is wired (see "Foundation status" in `data-classification.md` §3.3), rotation operators rely on the application logs (`encryptor initialized` at startup logs `write_version`) and integration tests against representative production data shapes.
+
+## Failure modes
+
+| Symptom | Likely cause | Action |
+|---------|--------------|--------|
+| `cryptox: ciphertext shorter than minimum` | DB row truncated/corrupt; not produced by `cryptox` | Inspect the row; if real, restore from backup. |
+| `cryptox: invalid ciphertext version 0x00` | Zero-init buffer leaked into a row; or a bug in producer | Inspect the row; check that the writer goes through `cryptox.Encryptor`. |
+| `cryptox: unknown key version: version=N` | Ciphertext under retired key, or future version not yet deployed | Restore the retired key (read-only) and run the re-encrypt job, OR roll forward to a deployment that has version N's key. |
+| `gcm.Open: cipher: message authentication failed` | Tampered ciphertext, wrong key, or wrong-version key | Investigate: integrity attack, KeySet misconfiguration, or row corruption. Never accept the value. |
+| Startup fails: `loading encryption key set: ...` | `ENCRYPTION_KEY` (or the versioned shape) missing/invalid | Set the secret per §"Env-var schema". The binary deliberately fails-fast (NFR-3.24). |
+
+## References
+
+- Implementation: [`internal/cryptox/`](../../internal/cryptox/)
+- Classification table: [`data-classification.md`](data-classification.md) §3
+- Anchored requirements: [`docs/architecture/requirements.md`](../architecture/requirements.md) NFR-3.22 — NFR-3.26
+- NIST SP 800-38D — Recommendation for Block Cipher Modes of Operation: Galois/Counter Mode (GCM) and GMAC
+
+## Change log
+
+| Date | Change | Author |
+|------|--------|--------|
+| 2026-05-01 | Initial draft authored by [MYR-16](https://linear.app/myrobotaxi/issue/MYR-16). Defines the ciphertext format, env-var schema (single-key shorthand + versioned shape), rotation procedure, emergency retire procedure, observability plan, and failure-mode table. Foundation only — no P1 column is yet encrypted on disk; per-column rollouts are tracked as separate Linear issues. | sdk-architect + go-engineer |

--- a/docs/contracts/key-rotation.md
+++ b/docs/contracts/key-rotation.md
@@ -1,5 +1,7 @@
 # Encryption key rotation
 
+> **Status (as of MYR-16, 2026-05-01): foundation only.** The `internal/cryptox` package and the startup wiring are landed and `ENCRYPTION_KEY` is required at boot, but **no P1 column is yet encrypted on disk**. Per-column rollouts require coordinated Prisma migrations in `../my-robo-taxi/` and are tracked as separate Linear issues. **Do NOT execute the rotation procedure in production until at least one column is encrypted AND the `cryptox_decrypt_total{version="N"}` counter is wired** (see §"Observability") — without the counter, step 6 of the procedure cannot be completed safely.
+
 ## Purpose
 
 Operational contract for rotating the AES-256-GCM keys that protect P1 columns at rest (NFR-3.23). Defines the env-var schema both shapes accept, the procedure for retiring a key, and the observability operators rely on to confirm rotation completed before a key is dropped.

--- a/fly.toml
+++ b/fly.toml
@@ -8,7 +8,8 @@
 # Prometheus metrics (port 9090) is internal only — access via `fly proxy 9090`.
 #
 # Deploy: fly deploy
-# Secrets: fly secrets set DATABASE_URL=... AUTH_SECRET=... TESLA_KEY_FILE_B64=...
+# Secrets: fly secrets set DATABASE_URL=... AUTH_SECRET=... ENCRYPTION_KEY=... TESLA_KEY_FILE_B64=...
+# Generate ENCRYPTION_KEY with: openssl rand -base64 32 (see docs/contracts/key-rotation.md).
 
 app = 'my-robo-taxi-telemetry'
 primary_region = 'iad'

--- a/internal/cryptox/aes_gcm.go
+++ b/internal/cryptox/aes_gcm.go
@@ -1,0 +1,114 @@
+package cryptox
+
+import (
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/rand"
+	"errors"
+	"fmt"
+	"io"
+)
+
+// Ciphertext format constants. Public so external code can size buffers and
+// reason about wire-format requirements without depending on internal
+// AES-GCM constants.
+const (
+	// versionV1 is the first ciphertext version emitted by this package.
+	// AES-256-GCM with a random 12-byte nonce.
+	versionV1 byte = 0x01
+
+	// nonceLen is the GCM standard nonce length. NIST SP 800-38D §5.2.1.1.
+	nonceLen = 12
+
+	// gcmTagLen is the AES-GCM authentication tag length appended to ciphertext.
+	gcmTagLen = 16
+
+	// keyLen is the AES-256 key length in bytes.
+	keyLen = 32
+
+	// MinCiphertextLen is the minimum size in bytes of a valid raw
+	// (pre-base64) ciphertext blob: version + nonce + auth tag. A blob
+	// shorter than this cannot have come from this package — reject with
+	// ErrCiphertextTooShort before invoking AES.
+	MinCiphertextLen = 1 + nonceLen + gcmTagLen
+)
+
+// Sentinel errors. Callers route by error identity, never on string match.
+var (
+	// ErrCiphertextTooShort is returned when a ciphertext blob is shorter
+	// than the minimum valid size. Defends against panics on truncated or
+	// corrupt rows.
+	ErrCiphertextTooShort = errors.New("cryptox: ciphertext shorter than minimum")
+
+	// ErrUnknownKeyVersion is returned when Decrypt sees a version byte for
+	// which no key is registered in the KeySet. After a key retirement,
+	// existing ciphertexts encrypted under the retired key surface this
+	// error; the operator must restore the retired key (read-only) or
+	// re-encrypt the affected rows before retiring.
+	ErrUnknownKeyVersion = errors.New("cryptox: unknown key version")
+
+	// ErrInvalidVersion is returned for the reserved 0x00 byte. 0x00 is
+	// reserved as "INVALID" so a zero-initialized buffer at position 0
+	// cannot be silently accepted.
+	ErrInvalidVersion = errors.New("cryptox: invalid ciphertext version 0x00")
+
+	// ErrInvalidKeyLength is returned when LoadKeySetFromEnv decodes a key
+	// that is not exactly 32 bytes (256 bits) after base64 decoding.
+	ErrInvalidKeyLength = errors.New("cryptox: key must be 32 bytes (AES-256)")
+)
+
+// encryptGCM seals plaintext under key using AES-256-GCM with a fresh random
+// nonce. Returns nonce||ciphertext||tag (no version prefix; version is
+// applied by the Encryptor wrapper). Caller MUST pass a 32-byte key —
+// length is enforced by the AES cipher constructor.
+func encryptGCM(key, plaintext []byte) ([]byte, error) {
+	block, err := aes.NewCipher(key)
+	if err != nil {
+		return nil, fmt.Errorf("cryptox.encryptGCM: aes.NewCipher: %w", err)
+	}
+	gcm, err := cipher.NewGCM(block)
+	if err != nil {
+		return nil, fmt.Errorf("cryptox.encryptGCM: cipher.NewGCM: %w", err)
+	}
+
+	nonce := make([]byte, gcm.NonceSize())
+	if _, err := io.ReadFull(rand.Reader, nonce); err != nil {
+		return nil, fmt.Errorf("cryptox.encryptGCM: read random nonce: %w", err)
+	}
+
+	// Seal appends ciphertext+tag onto its first arg, allowing us to lay
+	// out nonce||ct||tag in a single allocation.
+	out := make([]byte, len(nonce), len(nonce)+len(plaintext)+gcm.Overhead())
+	copy(out, nonce)
+	out = gcm.Seal(out, nonce, plaintext, nil)
+	return out, nil
+}
+
+// decryptGCM opens nonce||ciphertext||tag under key using AES-256-GCM.
+// Returns ErrCiphertextTooShort for blobs shorter than nonce+tag. Returns
+// the GCM authentication failure (wrapped) for any tampered/wrong-key
+// input — never accepts a tampered blob.
+func decryptGCM(key, blob []byte) ([]byte, error) {
+	if len(blob) < nonceLen+gcmTagLen {
+		return nil, ErrCiphertextTooShort
+	}
+	block, err := aes.NewCipher(key)
+	if err != nil {
+		return nil, fmt.Errorf("cryptox.decryptGCM: aes.NewCipher: %w", err)
+	}
+	gcm, err := cipher.NewGCM(block)
+	if err != nil {
+		return nil, fmt.Errorf("cryptox.decryptGCM: cipher.NewGCM: %w", err)
+	}
+
+	nonce := blob[:nonceLen]
+	ct := blob[nonceLen:]
+	plaintext, err := gcm.Open(nil, nonce, ct, nil)
+	if err != nil {
+		// Wrapped without leaking ct/nonce contents — message is generic
+		// because GCM's failure mode (auth tag mismatch) is identical for
+		// wrong-key, tampered-ct, and tampered-tag, by design.
+		return nil, fmt.Errorf("cryptox.decryptGCM: gcm.Open: %w", err)
+	}
+	return plaintext, nil
+}

--- a/internal/cryptox/aes_gcm_test.go
+++ b/internal/cryptox/aes_gcm_test.go
@@ -1,0 +1,149 @@
+package cryptox
+
+import (
+	"bytes"
+	"crypto/rand"
+	"errors"
+	"io"
+	"testing"
+)
+
+func mustRandKey(t *testing.T) []byte {
+	t.Helper()
+	key := make([]byte, keyLen)
+	if _, err := io.ReadFull(rand.Reader, key); err != nil {
+		t.Fatalf("rand key: %v", err)
+	}
+	return key
+}
+
+func TestEncryptGCM_Roundtrip(t *testing.T) {
+	tests := []struct {
+		name      string
+		plaintext []byte
+	}{
+		{"empty", []byte{}},
+		{"short ascii", []byte("hello")},
+		{"binary", []byte{0x00, 0xFF, 0x10, 0xAB, 0x00}},
+		{"longer than block size", bytes.Repeat([]byte("abc123"), 100)},
+		{"exact AES block (16 bytes)", bytes.Repeat([]byte("a"), 16)},
+		{"single byte", []byte{0x42}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			key := mustRandKey(t)
+			ct, err := encryptGCM(key, tt.plaintext)
+			if err != nil {
+				t.Fatalf("encryptGCM: %v", err)
+			}
+			pt, err := decryptGCM(key, ct)
+			if err != nil {
+				t.Fatalf("decryptGCM: %v", err)
+			}
+			if !bytes.Equal(pt, tt.plaintext) {
+				t.Fatalf("roundtrip mismatch: got %v want %v", pt, tt.plaintext)
+			}
+		})
+	}
+}
+
+func TestEncryptGCM_NonceUniqueness(t *testing.T) {
+	// Encrypting the same plaintext under the same key must produce
+	// different ciphertexts because the random nonce is unique per call.
+	// Catastrophic GCM failure mode is nonce reuse → key recovery.
+	key := mustRandKey(t)
+	plaintext := []byte("the same thing every time")
+	const N = 1000
+
+	seen := make(map[string]struct{}, N)
+	for i := 0; i < N; i++ {
+		ct, err := encryptGCM(key, plaintext)
+		if err != nil {
+			t.Fatalf("iter %d: encryptGCM: %v", i, err)
+		}
+		nonce := string(ct[:nonceLen])
+		if _, dup := seen[nonce]; dup {
+			t.Fatalf("nonce collision at iter %d", i)
+		}
+		seen[nonce] = struct{}{}
+	}
+}
+
+func TestDecryptGCM_TamperedCiphertext(t *testing.T) {
+	key := mustRandKey(t)
+	ct, err := encryptGCM(key, []byte("genuine"))
+	if err != nil {
+		t.Fatalf("encryptGCM: %v", err)
+	}
+
+	// Flip one byte in the ciphertext body (between nonce and tag).
+	// GCM auth check must fail.
+	if len(ct) <= nonceLen+gcmTagLen {
+		t.Fatalf("ciphertext too short to tamper: %d bytes", len(ct))
+	}
+	// Pick a byte in the middle of the ct+tag region.
+	tamperIdx := nonceLen + (len(ct)-nonceLen-gcmTagLen)/2
+	tampered := append([]byte(nil), ct...)
+	tampered[tamperIdx] ^= 0xFF
+
+	if _, err := decryptGCM(key, tampered); err == nil {
+		t.Fatal("expected error on tampered ciphertext, got nil")
+	}
+}
+
+func TestDecryptGCM_TamperedAuthTag(t *testing.T) {
+	key := mustRandKey(t)
+	ct, err := encryptGCM(key, []byte("genuine"))
+	if err != nil {
+		t.Fatalf("encryptGCM: %v", err)
+	}
+
+	// Flip the last byte (within the GCM auth tag).
+	tampered := append([]byte(nil), ct...)
+	tampered[len(tampered)-1] ^= 0x01
+
+	if _, err := decryptGCM(key, tampered); err == nil {
+		t.Fatal("expected error on tampered auth tag, got nil")
+	}
+}
+
+func TestDecryptGCM_WrongKey(t *testing.T) {
+	keyA := mustRandKey(t)
+	keyB := mustRandKey(t)
+	ct, err := encryptGCM(keyA, []byte("secret"))
+	if err != nil {
+		t.Fatalf("encryptGCM: %v", err)
+	}
+	if _, err := decryptGCM(keyB, ct); err == nil {
+		t.Fatal("expected error decrypting with wrong key, got nil")
+	}
+}
+
+func TestDecryptGCM_ShortInput(t *testing.T) {
+	key := mustRandKey(t)
+	tests := [][]byte{
+		nil,
+		{},
+		{0x00},
+		bytes.Repeat([]byte{0xAB}, nonceLen),               // nonce only
+		bytes.Repeat([]byte{0xAB}, nonceLen+gcmTagLen-1),   // 1 byte short of min
+	}
+	for i, blob := range tests {
+		if _, err := decryptGCM(key, blob); !errors.Is(err, ErrCiphertextTooShort) {
+			t.Fatalf("case %d: expected ErrCiphertextTooShort, got %v", i, err)
+		}
+	}
+}
+
+func TestDecryptGCM_InvalidKeySize(t *testing.T) {
+	// AES.NewCipher rejects keys that are not 16/24/32 bytes. The wrapper
+	// must propagate that error rather than panic.
+	for _, n := range []int{0, 15, 17, 31, 33, 48} {
+		bad := make([]byte, n)
+		ct := bytes.Repeat([]byte{0xAB}, MinCiphertextLen)
+		if _, err := decryptGCM(bad, ct); err == nil {
+			t.Fatalf("len=%d: expected error from AES.NewCipher, got nil", n)
+		}
+	}
+}

--- a/internal/cryptox/encryptor.go
+++ b/internal/cryptox/encryptor.go
@@ -3,6 +3,7 @@ package cryptox
 import (
 	"encoding/base64"
 	"fmt"
+	"log/slog"
 )
 
 // Encryptor is the public surface for column-level encryption (NFR-3.23).
@@ -13,18 +14,31 @@ import (
 // P1 column today is a Postgres Text or JSON value — base64 keeps the
 // stored shape uniform. Raw byte ciphertext is intentionally NOT exposed
 // outside the package.
+//
+// # Empty-string sentinel
+//
+// The empty string round-trips through both methods unchanged: EncryptString("")
+// returns ("", nil) and DecryptString("") returns ("", nil). This sentinel
+// represents an absent value (NULL column, optional field) so the store
+// layer can keep the encrypt-on-write/decrypt-on-read code path uniform
+// for nullable P1 columns. Callers MUST NOT use the empty string to
+// encrypt genuine zero-length payloads — there is no signal distinguishing
+// "absent" from "encrypted empty". If a future column requires
+// authenticated empty payloads, add an explicit Encrypt(plaintext []byte)
+// method that bypasses the sentinel.
 type Encryptor interface {
 	// EncryptString seals s under the active write key and returns the
 	// base64-encoded ciphertext blob (version || nonce || ct || tag).
-	// Empty input returns the empty string by design — callers should
-	// not encrypt empty payloads.
+	// Empty input returns the empty string per the package sentinel
+	// contract above.
 	EncryptString(s string) (string, error)
 
 	// DecryptString opens a base64 ciphertext produced by EncryptString
 	// (or a compatible producer using the same KeySet). Returns
 	// ErrCiphertextTooShort, ErrInvalidVersion, or ErrUnknownKeyVersion
 	// for malformed input; returns a wrapped GCM auth-failure error for
-	// tampered/wrong-key input.
+	// tampered/wrong-key input. Empty input returns the empty string per
+	// the package sentinel contract above.
 	DecryptString(ciphertext string) (string, error)
 }
 
@@ -34,6 +48,14 @@ type Encryptor interface {
 // re-encrypting old ciphertexts up front (see docs/contracts/key-rotation.md).
 type keySetEncryptor struct {
 	ks *KeySet
+}
+
+// LogValue redacts the encryptor when a structured logger walks pointer
+// fields (e.g., slog.Any("enc", enc)). Defense-in-depth alongside
+// KeySet.String — even though the encryptor doesn't directly expose key
+// material, slog.Any can recurse into struct fields on some handlers.
+func (e *keySetEncryptor) LogValue() slog.Value {
+	return slog.StringValue("<Encryptor:redacted>")
 }
 
 // NewEncryptor wraps a KeySet in an Encryptor. Returns an error if ks is

--- a/internal/cryptox/encryptor.go
+++ b/internal/cryptox/encryptor.go
@@ -1,0 +1,99 @@
+package cryptox
+
+import (
+	"encoding/base64"
+	"fmt"
+)
+
+// Encryptor is the public surface for column-level encryption (NFR-3.23).
+// All P1 fields per docs/contracts/data-classification.md §3.3 are
+// expected to round-trip through this interface in the eventual rollout.
+//
+// The interface accepts/returns base64 strings on the wire because every
+// P1 column today is a Postgres Text or JSON value — base64 keeps the
+// stored shape uniform. Raw byte ciphertext is intentionally NOT exposed
+// outside the package.
+type Encryptor interface {
+	// EncryptString seals s under the active write key and returns the
+	// base64-encoded ciphertext blob (version || nonce || ct || tag).
+	// Empty input returns the empty string by design — callers should
+	// not encrypt empty payloads.
+	EncryptString(s string) (string, error)
+
+	// DecryptString opens a base64 ciphertext produced by EncryptString
+	// (or a compatible producer using the same KeySet). Returns
+	// ErrCiphertextTooShort, ErrInvalidVersion, or ErrUnknownKeyVersion
+	// for malformed input; returns a wrapped GCM auth-failure error for
+	// tampered/wrong-key input.
+	DecryptString(ciphertext string) (string, error)
+}
+
+// keySetEncryptor is the concrete Encryptor backed by a KeySet. The
+// version byte at position 0 of every ciphertext routes Decrypt to the
+// matching key in keys, supporting in-place key rotation without
+// re-encrypting old ciphertexts up front (see docs/contracts/key-rotation.md).
+type keySetEncryptor struct {
+	ks *KeySet
+}
+
+// NewEncryptor wraps a KeySet in an Encryptor. Returns an error if ks is
+// nil or has no write key (defensive — LoadKeySetFromEnv already enforces
+// this, but in-process construction by tests bypasses that path).
+func NewEncryptor(ks *KeySet) (Encryptor, error) {
+	if ks == nil {
+		return nil, fmt.Errorf("cryptox.NewEncryptor: nil KeySet")
+	}
+	if _, ok := ks.keyForVersion(ks.writeVersion); !ok {
+		return nil, fmt.Errorf("cryptox.NewEncryptor: write version %d has no key in KeySet", ks.writeVersion)
+	}
+	return &keySetEncryptor{ks: ks}, nil
+}
+
+// EncryptString seals s, prepends the active write version byte, and
+// returns base64-encoded output.
+func (e *keySetEncryptor) EncryptString(s string) (string, error) {
+	if s == "" {
+		return "", nil
+	}
+	writeKey, ok := e.ks.keyForVersion(e.ks.writeVersion)
+	if !ok {
+		// Defensive — NewEncryptor already validated this.
+		return "", fmt.Errorf("cryptox.EncryptString: write key missing for version %d", e.ks.writeVersion)
+	}
+	body, err := encryptGCM(writeKey, []byte(s))
+	if err != nil {
+		return "", err
+	}
+	blob := make([]byte, 0, 1+len(body))
+	blob = append(blob, e.ks.writeVersion)
+	blob = append(blob, body...)
+	return base64.StdEncoding.EncodeToString(blob), nil
+}
+
+// DecryptString reverses EncryptString. Routes by version byte; rejects
+// ciphertexts whose version byte has no key in the KeySet.
+func (e *keySetEncryptor) DecryptString(ciphertext string) (string, error) {
+	if ciphertext == "" {
+		return "", nil
+	}
+	blob, err := base64.StdEncoding.DecodeString(ciphertext)
+	if err != nil {
+		return "", fmt.Errorf("cryptox.DecryptString: base64 decode: %w", err)
+	}
+	if len(blob) < MinCiphertextLen {
+		return "", ErrCiphertextTooShort
+	}
+	version := blob[0]
+	if version == 0x00 {
+		return "", ErrInvalidVersion
+	}
+	key, ok := e.ks.keyForVersion(version)
+	if !ok {
+		return "", fmt.Errorf("%w: version=%d", ErrUnknownKeyVersion, version)
+	}
+	plaintext, err := decryptGCM(key, blob[1:])
+	if err != nil {
+		return "", err
+	}
+	return string(plaintext), nil
+}

--- a/internal/cryptox/encryptor_test.go
+++ b/internal/cryptox/encryptor_test.go
@@ -226,3 +226,36 @@ func TestEncryptor_NonceUniquenessSamePlaintext(t *testing.T) {
 		t.Fatal("ciphertexts must differ across calls (nonce reuse risk)")
 	}
 }
+
+// FuzzDecryptString exercises DecryptString against arbitrary base64-ish
+// input to catch regressions in the version + length gating before AES is
+// invoked. Seeds cover the documented error paths (empty, too-short,
+// invalid version 0x00, unknown version, malformed base64) plus a real
+// roundtrip ciphertext. Run with `go test -fuzz=FuzzDecryptString` for
+// extended exploration; the seed corpus runs on every `go test`.
+func FuzzDecryptString(f *testing.F) {
+	enc, err := NewEncryptor(newTestKeySet(&testing.T{}, versionV1, versionV1))
+	if err != nil {
+		f.Fatalf("NewEncryptor: %v", err)
+	}
+
+	// Seed corpus: documented error paths + a valid ciphertext.
+	f.Add("")                                                    // empty sentinel
+	f.Add("!!!not-base64!!!")                                    // base64 decode failure
+	f.Add(base64.StdEncoding.EncodeToString([]byte{0x00}))       // too short, version 0x00
+	f.Add(base64.StdEncoding.EncodeToString(make([]byte, 28)))   // one short of MinCiphertextLen
+	f.Add(base64.StdEncoding.EncodeToString(make([]byte, 29)))   // exactly min, version 0x00 = invalid
+	tooLong := make([]byte, 29)
+	tooLong[0] = 0xFF
+	f.Add(base64.StdEncoding.EncodeToString(tooLong))            // unknown version
+	if ct, err := enc.EncryptString("seed"); err == nil {
+		f.Add(ct)
+	}
+
+	f.Fuzz(func(t *testing.T, in string) {
+		// Property: DecryptString must never panic on any input. Errors
+		// are expected for most inputs; only valid ciphertexts decrypt
+		// successfully.
+		_, _ = enc.DecryptString(in)
+	})
+}

--- a/internal/cryptox/encryptor_test.go
+++ b/internal/cryptox/encryptor_test.go
@@ -1,0 +1,228 @@
+package cryptox
+
+import (
+	"encoding/base64"
+	"errors"
+	"strings"
+	"testing"
+)
+
+func newTestKeySet(t *testing.T, writeVersion byte, versions ...byte) *KeySet {
+	t.Helper()
+	keys := make(map[byte][]byte, len(versions))
+	for _, v := range versions {
+		key := make([]byte, keyLen)
+		for i := range key {
+			// Make each version's key distinguishable so we can detect
+			// cross-version leakage in tests.
+			key[i] = v
+		}
+		keys[v] = key
+	}
+	return &KeySet{writeVersion: writeVersion, keys: keys}
+}
+
+func TestEncryptor_RoundtripV1(t *testing.T) {
+	enc, err := NewEncryptor(newTestKeySet(t, versionV1, versionV1))
+	if err != nil {
+		t.Fatalf("NewEncryptor: %v", err)
+	}
+
+	tests := []string{
+		"hello",
+		"unicode: 日本語",
+		strings.Repeat("a", 4096),
+		"with newline\nand tab\t",
+		`{"json":"payload","number":42}`,
+	}
+
+	for _, plaintext := range tests {
+		t.Run(plaintext[:min(20, len(plaintext))], func(t *testing.T) {
+			ct, err := enc.EncryptString(plaintext)
+			if err != nil {
+				t.Fatalf("EncryptString: %v", err)
+			}
+			pt, err := enc.DecryptString(ct)
+			if err != nil {
+				t.Fatalf("DecryptString: %v", err)
+			}
+			if pt != plaintext {
+				t.Fatalf("roundtrip mismatch: got %q, want %q", pt, plaintext)
+			}
+		})
+	}
+}
+
+func TestEncryptor_EmptyStringPassthrough(t *testing.T) {
+	enc, err := NewEncryptor(newTestKeySet(t, versionV1, versionV1))
+	if err != nil {
+		t.Fatalf("NewEncryptor: %v", err)
+	}
+	ct, err := enc.EncryptString("")
+	if err != nil || ct != "" {
+		t.Fatalf("EncryptString(\"\") = (%q, %v), want (\"\", nil)", ct, err)
+	}
+	pt, err := enc.DecryptString("")
+	if err != nil || pt != "" {
+		t.Fatalf("DecryptString(\"\") = (%q, %v), want (\"\", nil)", pt, err)
+	}
+}
+
+func TestEncryptor_VersionByteIsActiveWriteVersion(t *testing.T) {
+	// Both v1 and v2 keys present, write version is v2.
+	ks := newTestKeySet(t, 2, 1, 2)
+	enc, err := NewEncryptor(ks)
+	if err != nil {
+		t.Fatalf("NewEncryptor: %v", err)
+	}
+
+	ct, err := enc.EncryptString("payload")
+	if err != nil {
+		t.Fatalf("EncryptString: %v", err)
+	}
+
+	blob, err := base64.StdEncoding.DecodeString(ct)
+	if err != nil {
+		t.Fatalf("base64 decode: %v", err)
+	}
+	if blob[0] != 2 {
+		t.Fatalf("version byte = %d, want 2", blob[0])
+	}
+}
+
+func TestEncryptor_DecryptCrossVersion(t *testing.T) {
+	// Encrypt under v1, then load a KeySet that has both v1 (read-only)
+	// and v2 (active write). Decrypt must succeed via the v1 key.
+	v1Only := newTestKeySet(t, 1, 1)
+	encV1, err := NewEncryptor(v1Only)
+	if err != nil {
+		t.Fatalf("NewEncryptor v1: %v", err)
+	}
+	ct, err := encV1.EncryptString("legacy payload")
+	if err != nil {
+		t.Fatalf("EncryptString v1: %v", err)
+	}
+
+	bothVersions := newTestKeySet(t, 2, 1, 2)
+	encBoth, err := NewEncryptor(bothVersions)
+	if err != nil {
+		t.Fatalf("NewEncryptor both: %v", err)
+	}
+	pt, err := encBoth.DecryptString(ct)
+	if err != nil {
+		t.Fatalf("DecryptString cross-version: %v", err)
+	}
+	if pt != "legacy payload" {
+		t.Fatalf("got %q, want \"legacy payload\"", pt)
+	}
+}
+
+func TestEncryptor_UnknownKeyVersion(t *testing.T) {
+	// Encrypt under v1, then try to decrypt with a KeySet that has only v2.
+	// The version byte v1 has no matching key — must surface
+	// ErrUnknownKeyVersion.
+	v1Only := newTestKeySet(t, 1, 1)
+	encV1, err := NewEncryptor(v1Only)
+	if err != nil {
+		t.Fatalf("NewEncryptor v1: %v", err)
+	}
+	ct, err := encV1.EncryptString("retired payload")
+	if err != nil {
+		t.Fatalf("EncryptString: %v", err)
+	}
+
+	v2Only := newTestKeySet(t, 2, 2)
+	encV2, err := NewEncryptor(v2Only)
+	if err != nil {
+		t.Fatalf("NewEncryptor v2: %v", err)
+	}
+	if _, err := encV2.DecryptString(ct); !errors.Is(err, ErrUnknownKeyVersion) {
+		t.Fatalf("expected ErrUnknownKeyVersion, got %v", err)
+	}
+}
+
+func TestEncryptor_InvalidVersionByte(t *testing.T) {
+	// Manually craft a ciphertext with version byte 0x00 (reserved as
+	// invalid). Must surface ErrInvalidVersion.
+	enc, err := NewEncryptor(newTestKeySet(t, versionV1, versionV1))
+	if err != nil {
+		t.Fatalf("NewEncryptor: %v", err)
+	}
+
+	// Real ciphertext to get a well-formed nonce+tag, then overwrite the
+	// version byte with 0x00.
+	ct, err := enc.EncryptString("hello")
+	if err != nil {
+		t.Fatalf("EncryptString: %v", err)
+	}
+	blob, err := base64.StdEncoding.DecodeString(ct)
+	if err != nil {
+		t.Fatalf("base64 decode: %v", err)
+	}
+	blob[0] = 0x00
+	tampered := base64.StdEncoding.EncodeToString(blob)
+
+	if _, err := enc.DecryptString(tampered); !errors.Is(err, ErrInvalidVersion) {
+		t.Fatalf("expected ErrInvalidVersion, got %v", err)
+	}
+}
+
+func TestEncryptor_TooShortCiphertext(t *testing.T) {
+	enc, err := NewEncryptor(newTestKeySet(t, versionV1, versionV1))
+	if err != nil {
+		t.Fatalf("NewEncryptor: %v", err)
+	}
+
+	// 1 byte short of MinCiphertextLen.
+	short := base64.StdEncoding.EncodeToString(make([]byte, MinCiphertextLen-1))
+	if _, err := enc.DecryptString(short); !errors.Is(err, ErrCiphertextTooShort) {
+		t.Fatalf("expected ErrCiphertextTooShort, got %v", err)
+	}
+}
+
+func TestEncryptor_InvalidBase64(t *testing.T) {
+	enc, err := NewEncryptor(newTestKeySet(t, versionV1, versionV1))
+	if err != nil {
+		t.Fatalf("NewEncryptor: %v", err)
+	}
+	if _, err := enc.DecryptString("!!!not-base64!!!"); err == nil {
+		t.Fatal("expected base64 decode error, got nil")
+	}
+}
+
+func TestNewEncryptor_RejectsNilKeySet(t *testing.T) {
+	if _, err := NewEncryptor(nil); err == nil {
+		t.Fatal("expected error for nil KeySet, got nil")
+	}
+}
+
+func TestNewEncryptor_RejectsKeySetWithoutWriteKey(t *testing.T) {
+	// writeVersion=2 but only v1 in keys — should refuse.
+	ks := &KeySet{writeVersion: 2, keys: map[byte][]byte{1: make([]byte, keyLen)}}
+	if _, err := NewEncryptor(ks); err == nil {
+		t.Fatal("expected error for missing write key, got nil")
+	}
+}
+
+func TestEncryptor_NonceUniquenessSamePlaintext(t *testing.T) {
+	enc, err := NewEncryptor(newTestKeySet(t, versionV1, versionV1))
+	if err != nil {
+		t.Fatalf("NewEncryptor: %v", err)
+	}
+
+	// Encrypt the same plaintext twice — outputs MUST differ because the
+	// random nonce is fresh per call. Catastrophic GCM failure mode is
+	// nonce reuse (key recovery).
+	const same = "deterministic input"
+	a, err := enc.EncryptString(same)
+	if err != nil {
+		t.Fatalf("EncryptString a: %v", err)
+	}
+	b, err := enc.EncryptString(same)
+	if err != nil {
+		t.Fatalf("EncryptString b: %v", err)
+	}
+	if a == b {
+		t.Fatal("ciphertexts must differ across calls (nonce reuse risk)")
+	}
+}

--- a/internal/cryptox/key.go
+++ b/internal/cryptox/key.go
@@ -1,0 +1,191 @@
+package cryptox
+
+import (
+	"encoding/base64"
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+)
+
+// Env var names for the two supported deployment shapes.
+const (
+	// envSingleKey is the single-key shorthand: ENCRYPTION_KEY=base64(32B).
+	// Implies versionV1 is both the active write version and the only
+	// readable version. Use this shape for v1 deployments before any key
+	// rotation.
+	envSingleKey = "ENCRYPTION_KEY"
+
+	// envWriteVersion selects the active write version when running in
+	// versioned shape (mutually exclusive with envSingleKey). Value is the
+	// decimal version byte (e.g., "2").
+	envWriteVersion = "ENCRYPTION_WRITE_VERSION"
+
+	// envVersionedKeyPrefix is the prefix for versioned keys:
+	// ENCRYPTION_KEY_V1=base64(32B), ENCRYPTION_KEY_V2=base64(32B), ...
+	envVersionedKeyPrefix = "ENCRYPTION_KEY_V"
+)
+
+// KeySet holds the active write key plus 0..N retired-but-still-readable
+// keys, indexed by version byte. Encrypt always uses writeVersion; Decrypt
+// fans out by the version byte at the head of the ciphertext.
+//
+// Construct via LoadKeySetFromEnv. The zero value is unusable.
+//
+// KeySet deliberately does NOT implement Stringer (other than the redacted
+// String) or MarshalJSON to prevent accidental key material leaks via
+// slog.Any or json.Marshal. Default %v formatting prints "<KeySet:redacted>".
+type KeySet struct {
+	writeVersion byte
+	keys         map[byte][]byte
+}
+
+// String returns a redacted placeholder. Defends against accidental
+// slog.Any("ks", ks) or fmt.Sprintf("%v", ks) leaks of key material.
+func (k *KeySet) String() string {
+	if k == nil {
+		return "<KeySet:nil>"
+	}
+	return "<KeySet:redacted>"
+}
+
+// WriteVersion reports the active version used by Encrypt. Used by
+// observability code (e.g., metrics tagged with the write version).
+func (k *KeySet) WriteVersion() byte {
+	return k.writeVersion
+}
+
+// HasVersion reports whether the KeySet can decrypt ciphertexts written
+// under the given version. Useful for fail-fast checks at startup or in
+// tests; the runtime decryption path uses keyForVersion directly.
+func (k *KeySet) HasVersion(v byte) bool {
+	_, ok := k.keys[v]
+	return ok
+}
+
+// keyForVersion returns the key for a ciphertext version. Package-private
+// because only the Encryptor's Decrypt path needs it; exposing it would
+// invite callers to encrypt directly with raw keys, bypassing the
+// version-prefix protocol.
+func (k *KeySet) keyForVersion(v byte) ([]byte, bool) {
+	key, ok := k.keys[v]
+	return key, ok
+}
+
+// LoadKeySetFromEnv reads encryption keys from the process environment.
+// Two shapes are accepted:
+//
+//   - Single-key shorthand: ENCRYPTION_KEY=base64(32B). writeVersion=v1,
+//     readable versions={v1}.
+//   - Versioned shape: ENCRYPTION_KEY_V1=base64(32B), ENCRYPTION_KEY_V2=...,
+//     plus ENCRYPTION_WRITE_VERSION=N selecting the active write version.
+//     All present versioned keys are added to the readable set.
+//
+// Empty env var values are treated as not-set so that a deployment cannot
+// silently launch with an empty key. Returns ErrInvalidKeyLength if any
+// key, after base64 decoding, is not exactly 32 bytes. Returns a wrapped
+// error if both shapes are present (configuration ambiguity) or if
+// neither is present.
+func LoadKeySetFromEnv() (*KeySet, error) {
+	single := os.Getenv(envSingleKey)
+	hasSingle := single != ""
+
+	versioned := versionedKeysFromEnv()
+
+	switch {
+	case hasSingle && len(versioned) > 0:
+		return nil, fmt.Errorf("cryptox.LoadKeySetFromEnv: both %s and %sN keys are set; pick one shape", envSingleKey, envVersionedKeyPrefix)
+	case hasSingle:
+		key, err := decodeAndValidate(single)
+		if err != nil {
+			return nil, fmt.Errorf("cryptox.LoadKeySetFromEnv(%s): %w", envSingleKey, err)
+		}
+		return &KeySet{
+			writeVersion: versionV1,
+			keys:         map[byte][]byte{versionV1: key},
+		}, nil
+	case len(versioned) > 0:
+		writeVer, err := writeVersionFromEnv()
+		if err != nil {
+			return nil, fmt.Errorf("cryptox.LoadKeySetFromEnv: %w", err)
+		}
+		ks := &KeySet{writeVersion: writeVer, keys: make(map[byte][]byte, len(versioned))}
+		for v, b64 := range versioned {
+			key, err := decodeAndValidate(b64)
+			if err != nil {
+				return nil, fmt.Errorf("cryptox.LoadKeySetFromEnv(%s%d): %w", envVersionedKeyPrefix, v, err)
+			}
+			ks.keys[v] = key
+		}
+		if _, ok := ks.keys[writeVer]; !ok {
+			return nil, fmt.Errorf("cryptox.LoadKeySetFromEnv: %s=%d but no %s%d found", envWriteVersion, writeVer, envVersionedKeyPrefix, writeVer)
+		}
+		return ks, nil
+	default:
+		return nil, fmt.Errorf("cryptox.LoadKeySetFromEnv: neither %s nor %sN are set", envSingleKey, envVersionedKeyPrefix)
+	}
+}
+
+// versionedKeysFromEnv scans os.Environ() for ENCRYPTION_KEY_V<N> entries
+// and returns a map of version byte → base64 value.
+func versionedKeysFromEnv() map[byte]string {
+	out := make(map[byte]string)
+	for _, kv := range os.Environ() {
+		eq := strings.IndexByte(kv, '=')
+		if eq < 0 {
+			continue
+		}
+		name := kv[:eq]
+		if !strings.HasPrefix(name, envVersionedKeyPrefix) {
+			continue
+		}
+		suffix := name[len(envVersionedKeyPrefix):]
+		n, err := strconv.Atoi(suffix)
+		if err != nil || n < 1 || n > 255 {
+			continue
+		}
+		val := kv[eq+1:]
+		if val == "" {
+			// Empty value is treated as not-set. Allows tests to clear a
+			// versioned key with t.Setenv("ENCRYPTION_KEY_V1", "").
+			continue
+		}
+		out[byte(n)] = val
+	}
+	return out
+}
+
+// writeVersionFromEnv parses ENCRYPTION_WRITE_VERSION as a decimal byte.
+func writeVersionFromEnv() (byte, error) {
+	raw := os.Getenv(envWriteVersion)
+	if raw == "" {
+		return 0, fmt.Errorf("%s is required when using %sN keys", envWriteVersion, envVersionedKeyPrefix)
+	}
+	n, err := strconv.Atoi(raw)
+	if err != nil {
+		return 0, fmt.Errorf("%s=%q is not a valid integer: %w", envWriteVersion, raw, err)
+	}
+	if n < 1 || n > 255 {
+		return 0, fmt.Errorf("%s=%d out of range (must be 1..255)", envWriteVersion, n)
+	}
+	return byte(n), nil
+}
+
+// decodeAndValidate decodes a base64-encoded key and validates it is
+// exactly 32 bytes (AES-256). Accepts both standard and URL-safe base64
+// to be tolerant of secret-store conventions.
+func decodeAndValidate(b64 string) ([]byte, error) {
+	b64 = strings.TrimSpace(b64)
+	key, err := base64.StdEncoding.DecodeString(b64)
+	if err != nil {
+		// Try URL-safe encoding before giving up.
+		key, err = base64.URLEncoding.DecodeString(b64)
+		if err != nil {
+			return nil, fmt.Errorf("base64 decode: %w", err)
+		}
+	}
+	if len(key) != keyLen {
+		return nil, fmt.Errorf("%w: got %d bytes", ErrInvalidKeyLength, len(key))
+	}
+	return key, nil
+}

--- a/internal/cryptox/key_test.go
+++ b/internal/cryptox/key_test.go
@@ -97,6 +97,15 @@ func TestLoadKeySetFromEnv_Errors(t *testing.T) {
 			errSub: "ENCRYPTION_WRITE_VERSION",
 		},
 		{
+			name: "versioned with empty write_version",
+			setup: func(t *testing.T) {
+				t.Helper()
+				t.Setenv(envVersionedKeyPrefix+"1", b64Key(0x01))
+				t.Setenv(envWriteVersion, "")
+			},
+			errSub: "is required",
+		},
+		{
 			name: "write_version refers to missing key",
 			setup: func(t *testing.T) {
 				t.Helper()

--- a/internal/cryptox/key_test.go
+++ b/internal/cryptox/key_test.go
@@ -1,0 +1,196 @@
+package cryptox
+
+import (
+	"encoding/base64"
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+)
+
+// b64Key returns a base64-encoded 32-byte key with byte i = seed for tests.
+func b64Key(seed byte) string {
+	key := make([]byte, keyLen)
+	for i := range key {
+		key[i] = seed
+	}
+	return base64.StdEncoding.EncodeToString(key)
+}
+
+func TestLoadKeySetFromEnv_SingleKey(t *testing.T) {
+	t.Setenv(envSingleKey, b64Key(0xAB))
+
+	ks, err := LoadKeySetFromEnv()
+	if err != nil {
+		t.Fatalf("LoadKeySetFromEnv: %v", err)
+	}
+	if ks.WriteVersion() != versionV1 {
+		t.Fatalf("writeVersion = %d, want %d", ks.WriteVersion(), versionV1)
+	}
+	if !ks.HasVersion(versionV1) {
+		t.Fatal("expected v1 to be readable")
+	}
+}
+
+func TestLoadKeySetFromEnv_VersionedShape(t *testing.T) {
+	t.Setenv(envVersionedKeyPrefix+"1", b64Key(0x01))
+	t.Setenv(envVersionedKeyPrefix+"2", b64Key(0x02))
+	t.Setenv(envWriteVersion, "2")
+
+	ks, err := LoadKeySetFromEnv()
+	if err != nil {
+		t.Fatalf("LoadKeySetFromEnv: %v", err)
+	}
+	if ks.WriteVersion() != 2 {
+		t.Fatalf("writeVersion = %d, want 2", ks.WriteVersion())
+	}
+	if !ks.HasVersion(1) || !ks.HasVersion(2) {
+		t.Fatal("expected v1 and v2 to be readable")
+	}
+}
+
+func TestLoadKeySetFromEnv_Errors(t *testing.T) {
+	tests := []struct {
+		name   string
+		setup  func(t *testing.T)
+		errSub string
+	}{
+		{
+			name: "neither shape set",
+			setup: func(t *testing.T) {
+				t.Helper()
+			},
+			errSub: "neither",
+		},
+		{
+			name: "both shapes set",
+			setup: func(t *testing.T) {
+				t.Helper()
+				t.Setenv(envSingleKey, b64Key(0xAA))
+				t.Setenv(envVersionedKeyPrefix+"1", b64Key(0xBB))
+				t.Setenv(envWriteVersion, "1")
+			},
+			errSub: "pick one shape",
+		},
+		{
+			name: "single key wrong length",
+			setup: func(t *testing.T) {
+				t.Helper()
+				t.Setenv(envSingleKey, base64.StdEncoding.EncodeToString([]byte("too short")))
+			},
+			errSub: "32 bytes",
+		},
+		{
+			name: "single key not base64",
+			setup: func(t *testing.T) {
+				t.Helper()
+				t.Setenv(envSingleKey, "!!!not-base64!!!")
+			},
+			errSub: "base64",
+		},
+		{
+			name: "versioned without write_version",
+			setup: func(t *testing.T) {
+				t.Helper()
+				t.Setenv(envVersionedKeyPrefix+"1", b64Key(0x01))
+			},
+			errSub: "ENCRYPTION_WRITE_VERSION",
+		},
+		{
+			name: "write_version refers to missing key",
+			setup: func(t *testing.T) {
+				t.Helper()
+				t.Setenv(envVersionedKeyPrefix+"1", b64Key(0x01))
+				t.Setenv(envWriteVersion, "5")
+			},
+			errSub: "no ENCRYPTION_KEY_V5",
+		},
+		{
+			name: "write_version not an integer",
+			setup: func(t *testing.T) {
+				t.Helper()
+				t.Setenv(envVersionedKeyPrefix+"1", b64Key(0x01))
+				t.Setenv(envWriteVersion, "two")
+			},
+			errSub: "not a valid integer",
+		},
+		{
+			name: "write_version out of byte range",
+			setup: func(t *testing.T) {
+				t.Helper()
+				t.Setenv(envVersionedKeyPrefix+"1", b64Key(0x01))
+				t.Setenv(envWriteVersion, "256")
+			},
+			errSub: "out of range",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Clear the relevant env vars (empty value = treated as not-set
+			// by the loader, see key.go).
+			t.Setenv(envSingleKey, "")
+			t.Setenv(envWriteVersion, "")
+			t.Setenv(envVersionedKeyPrefix+"1", "")
+			t.Setenv(envVersionedKeyPrefix+"2", "")
+			tt.setup(t)
+
+			_, err := LoadKeySetFromEnv()
+			if err == nil {
+				t.Fatalf("expected error containing %q, got nil", tt.errSub)
+			}
+			if !strings.Contains(err.Error(), tt.errSub) {
+				t.Fatalf("error %q does not contain %q", err.Error(), tt.errSub)
+			}
+		})
+	}
+}
+
+func TestKeySet_StringIsRedacted(t *testing.T) {
+	t.Setenv(envSingleKey, b64Key(0xAB))
+
+	ks, err := LoadKeySetFromEnv()
+	if err != nil {
+		t.Fatalf("LoadKeySetFromEnv: %v", err)
+	}
+
+	// Default %v formatting calls String — must not leak key material.
+	got := fmt.Sprintf("%v", ks)
+	if strings.Contains(got, "0xAB") || strings.Contains(got, b64Key(0xAB)) {
+		t.Fatalf("KeySet String() leaked key material: %q", got)
+	}
+	if !strings.Contains(got, "redacted") {
+		t.Fatalf("KeySet String() should mention 'redacted', got %q", got)
+	}
+
+	// Nil receiver must not panic.
+	var nilKs *KeySet
+	if got := nilKs.String(); !strings.Contains(got, "nil") {
+		t.Fatalf("nil KeySet String should mention nil, got %q", got)
+	}
+}
+
+func TestDecodeAndValidate_URLSafeBase64(t *testing.T) {
+	// Build a key whose standard base64 contains '+' or '/' to confirm the
+	// URL-safe fallback works. Use a key seeded to produce '+' in std b64.
+	key := make([]byte, keyLen)
+	for i := range key {
+		key[i] = 0xFF
+	}
+	urlSafe := base64.URLEncoding.EncodeToString(key)
+	got, err := decodeAndValidate(urlSafe)
+	if err != nil {
+		t.Fatalf("decodeAndValidate(URL-safe): %v", err)
+	}
+	if len(got) != keyLen {
+		t.Fatalf("decoded length = %d, want %d", len(got), keyLen)
+	}
+}
+
+func TestDecodeAndValidate_LengthError(t *testing.T) {
+	bad := base64.StdEncoding.EncodeToString(make([]byte, 16)) // 128-bit, not 256
+	_, err := decodeAndValidate(bad)
+	if !errors.Is(err, ErrInvalidKeyLength) {
+		t.Fatalf("expected ErrInvalidKeyLength, got %v", err)
+	}
+}


### PR DESCRIPTION
## Summary

- Adds the `internal/cryptox` package: AES-256-GCM primitives, versioned ciphertext, `KeySet` rotation, public `Encryptor` interface.
- Wires `cryptox.LoadKeySetFromEnv` + `NewEncryptor` at startup so the binary fails-fast on missing/invalid `ENCRYPTION_KEY`.
- Adds the `docs/contracts/key-rotation.md` contract doc and updates `data-classification.md` §3.3 + the contracts README index.

## Why foundation-only

Every P1 column requiring encryption per `data-classification.md` §3 lives in the **Prisma-owned schema in `../my-robo-taxi/`** (Account.access_token / refresh_token / id_token, Vehicle GPS columns, Drive.routePoints). Per CLAUDE.md the telemetry server cannot modify Prisma-owned tables; the actual column flips need cross-repo Prisma migrations + symmetric encrypt/decrypt on both sides + backfill + plaintext drop. That's a 3+ PR sequence across 2 repos. This PR ships the single-repo foundation; per-column rollouts will land as follow-on Linear issues (one per migration unit: OAuth tokens, Vehicle GPS coords, route blobs, plus a key-rotation production drill).

**No P1 column is yet encrypted on disk** — the `Encryptor` is constructed at startup but discarded with `_ = encryptor` per the architect's design memo (no dead constructor params).

## Decisions recorded in the contract docs

- **500 ms window kept** is a separate, unrelated decision in MYR-14. This PR's rotation contract is in `key-rotation.md`.
- **Ciphertext format:** `[1B version][12B nonce][N B ct + 16B GCM tag]`, base64-encoded for `Text` storage. Version `0x01` only emitted; `0x00` reserved as `ErrInvalidVersion`.
- **KeySet rotation:** active write version + 0..N retired-but-readable versions; decrypt fans out by version byte at position 0. Two env-var shapes (`ENCRYPTION_KEY` shorthand, or `ENCRYPTION_KEY_V{N}` + `ENCRYPTION_WRITE_VERSION`); both shapes set is an error.
- **Defense-in-depth:** `KeySet.String()` and `keySetEncryptor.LogValue()` both redact, so `slog.Any(...)` accidents never leak key material.

## Operational impact

- **`ENCRYPTION_KEY` is now a required env var** at server startup. CI excludes `/cmd/` from tests, so test gates aren't affected. `docker-compose.test.yml`, `.env.example`, and `fly.toml` all updated to document the new requirement.
- **Do NOT execute the rotation procedure in production yet** — `cryptox_decrypt_total{version=N}` is not yet wired (lands with the first column rollout PR). Step 6 of the rotation procedure cannot be safely completed without it. Status callout added at the top of `key-rotation.md`.

## Pre-PR gates

- `go vet ./...` — clean
- `golangci-lint run ./...` — 0 issues
- `go test ./...` — green (incl. new `TestEncryptor_*`, `TestLoadKeySetFromEnv_*`, `TestEncryptGCM_*`, `FuzzDecryptString` seed corpus)
- `security` review — PASS with two must-fixes applied (empty-string sentinel doc + explicit empty-`ENCRYPTION_WRITE_VERSION` test) and three defense-in-depth additions (`LogValue` redaction, fuzz seed corpus, nonce-space rotation guidance)
- `contract-guard` — PASS (after fixing one stale "eight contract documents" heading)
- `ux-audit` — PASS with three deployment-config gaps closed (`docker-compose.test.yml`, `.env.example`, `fly.toml`) + two doc clarifications
- `sdk-architect` final review — APPROVED

## Test plan

- [x] `go test ./internal/cryptox/...` — round-trip, nonce uniqueness (N=1000), tampered ct/tag, wrong key, short input, invalid key sizes, version-byte routing across V1/V2, unknown-version error path, KeySet redaction, env-var error matrix
- [x] `go test ./...` — full suite green; no other package affected
- [x] `golangci-lint run ./...` — 0 issues
- [x] Manual: confirmed binary refuses to start without `ENCRYPTION_KEY` (fail-fast)
- [ ] Manual smoke before merge: deploy to staging with a real `ENCRYPTION_KEY` and confirm `encryptor initialized write_version=1` appears in logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)