### PR TITLE
MYR-60 Reconcile hasVehicle empty-slice semantics with NoopAuthenticator docs

### DIFF
--- a/docs/contracts/websocket-protocol.md
+++ b/docs/contracts/websocket-protocol.md
@@ -284,7 +284,7 @@ The Linear AC for MYR-11 calls for a "type discriminator, sequence, timestamp" e
 
 Rationale for not shipping `seq`/`ts` in v1.0:
 
-1. The current server has no per-connection sequence counter ([`client.go:Client`](../../internal/ws/client.go) struct has `userID`, `vehicleIDs`, `send`, `remoteAddr`, `hub`, `logger` -- no `nextSeq`).
+1. The current server has no per-connection sequence counter — the [`client.go:Client`](../../internal/ws/client.go) struct does not carry a `nextSeq` field, and adding one would touch every broadcast hot-path.
 2. Reconnect-resume is currently implemented entirely client-side via REST snapshot fetch (see [`state-machine.md`](state-machine.md) §5), which establishes a consistent baseline without needing wire-level sequence numbers. The trade-off: clients cannot detect dropped frames within a single connection.
 3. Adding `seq` is a coordinated server + SDK + fixture change. It is a v1.x extension, not a v1.0 ship blocker.
 
@@ -621,7 +621,7 @@ Per [`state-machine.md`](state-machine.md) §4.2, `connectivity` does NOT direct
 
 > **Anchored:** NFR-3.21.
 
-`Hub.Broadcast(vehicleID, msg)` ([`internal/ws/hub.go`](../../internal/ws/hub.go) line 70) iterates every connected client and calls `client.hasVehicle(vehicleID)`. Only clients whose `vehicleIDs` slice (populated at handshake time from `Authenticator.GetUserVehicles`) contains the target vehicle ID receive the frame. Clients with an empty vehicle list (the `NoopAuthenticator` dev mode) receive **all** broadcasts -- this is explicit in [`client.go:hasVehicle`](../../internal/ws/client.go) line 120 and is intentional for local development.
+`Hub.Broadcast(vehicleID, msg)` ([`internal/ws/hub.go`](../../internal/ws/hub.go) line 70) iterates every connected client and calls `client.hasVehicle(vehicleID)`. Only clients whose `vehicleIDs` slice (populated at handshake time from `Authenticator.GetUserVehicles`) contains the target vehicle ID receive the frame. The dev-mode `NoopAuthenticator` returns the `WildcardVehicleID` sentinel ([`auth.go`](../../internal/ws/auth.go)) from `GetUserVehicles`; the handshake translates that into `Client.allVehicles = true` and `hasVehicle` short-circuits to `true` for those clients. Production `Authenticator` implementations MUST NOT emit the sentinel, so `allVehicles` is always `false` on production: an empty `vehicleIDs` slice means deny-all per NFR-3.21.
 
 The SDK can rely on the following contract: **an authenticated production client will NEVER receive a `vehicle_update`, `drive_started`, `drive_ended`, or `connectivity` frame for a vehicle it does not own at handshake time.**
 

--- a/internal/ws/auth.go
+++ b/internal/ws/auth.go
@@ -6,6 +6,17 @@ import (
 	"github.com/tnando/my-robo-taxi-telemetry/internal/auth"
 )
 
+// WildcardVehicleID is the sentinel value the dev-mode NoopAuthenticator
+// returns from GetUserVehicles to convey "this client is authorized for
+// every vehicle" without overloading the empty-slice case (which a
+// production authenticator uses to mean deny-all per NFR-3.21).
+//
+// Production Authenticator implementations MUST NOT return this value.
+// The handshake (handler.go authenticateClient) intercepts it, sets
+// Client.allVehicles=true, and excludes it from Client.vehicleIDs and
+// the per-vehicle role-resolution loop.
+const WildcardVehicleID = "*"
+
 // Authenticator validates session tokens and retrieves the vehicles a user
 // is authorized to view. Defined at the consumer site (this package);
 // implemented by a real Supabase adapter or NoopAuthenticator for testing.
@@ -30,15 +41,18 @@ type Authenticator interface {
 	ResolveRole(ctx context.Context, userID, vehicleID string) (auth.Role, error)
 }
 
-// NoopAuthenticator accepts any non-empty token and returns a fixed user
-// with all-vehicle access. Use it for local development and testing only.
+// NoopAuthenticator accepts any non-empty token and returns a fixed user.
+// Use it for local development and testing only.
 type NoopAuthenticator struct {
 	// UserID is returned for every successful validation. Defaults to
 	// "test-user" if empty.
 	UserID string
 
-	// VehicleIDs is returned by GetUserVehicles. An empty slice means
-	// the user is not authorized for any vehicles.
+	// VehicleIDs is returned by GetUserVehicles. A nil or empty slice
+	// is interpreted as "dev-mode all-vehicle access" and is expanded to
+	// the WildcardVehicleID sentinel by GetUserVehicles. To restrict the
+	// dev user to a specific list of vehicles, populate VehicleIDs
+	// explicitly.
 	VehicleIDs []string
 }
 
@@ -56,8 +70,16 @@ func (a *NoopAuthenticator) ValidateToken(_ context.Context, token string) (stri
 	return "test-user", nil
 }
 
-// GetUserVehicles returns the configured VehicleIDs slice.
+// GetUserVehicles returns the configured VehicleIDs slice. If unset, it
+// returns the single-element WildcardVehicleID sentinel so the handshake
+// knows to grant dev-mode all-vehicle access. This is what makes empty
+// VehicleIDs unambiguously mean "all-access" for NoopAuthenticator while
+// still meaning deny-all for any production Authenticator (which never
+// emits the sentinel).
 func (a *NoopAuthenticator) GetUserVehicles(_ context.Context, _ string) ([]string, error) {
+	if len(a.VehicleIDs) == 0 {
+		return []string{WildcardVehicleID}, nil
+	}
 	return a.VehicleIDs, nil
 }
 

--- a/internal/ws/client.go
+++ b/internal/ws/client.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"slices"
 	"time"
 
 	"github.com/coder/websocket"
@@ -27,6 +28,13 @@ type Client struct {
 	conn       *websocket.Conn
 	userID     string
 	vehicleIDs []string // vehicles this user is authorized to see
+	// allVehicles is the explicit "this client is authorized for every
+	// vehicle" flag. It is set ONLY by the handshake when GetUserVehicles
+	// returns the WildcardVehicleID sentinel (dev-mode NoopAuthenticator).
+	// Production authenticators MUST NOT return that sentinel, so on
+	// production this field stays false and an empty vehicleIDs slice
+	// means deny-all per NFR-3.21.
+	allVehicles bool
 	// vehicleRoles maps vehicleID -> role for this client. Populated at
 	// handshake time alongside vehicleIDs (handler.go authenticateClient).
 	// Per websocket-protocol.md §4.6, the hub looks up the role here to
@@ -137,18 +145,15 @@ func (c *Client) enqueue(msg []byte) bool {
 }
 
 // hasVehicle reports whether this client is authorized to receive updates
-// for the given vehicle ID. A nil/empty vehicleIDs slice grants access to
-// all vehicles (used by NoopAuthenticator in dev mode).
+// for the given vehicle ID. allVehicles=true grants access to every
+// vehicle and is reserved for the dev-mode NoopAuthenticator; otherwise
+// the vehicleID must be present in vehicleIDs. An empty vehicleIDs slice
+// with allVehicles=false means deny-all (NFR-3.21).
 func (c *Client) hasVehicle(vehicleID string) bool {
-	if len(c.vehicleIDs) == 0 {
+	if c.allVehicles {
 		return true
 	}
-	for _, id := range c.vehicleIDs {
-		if id == vehicleID {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(c.vehicleIDs, vehicleID)
 }
 
 // writeMessage writes a single message to the WebSocket with a timeout.

--- a/internal/ws/handler.go
+++ b/internal/ws/handler.go
@@ -165,8 +165,22 @@ func (h *Hub) authenticateClient(ctx context.Context, client *Client, auth Authe
 		return fmt.Errorf("hub.authenticateClient: get vehicles(user=%s): %w", userID, err)
 	}
 
+	// Strip the dev-mode WildcardVehicleID sentinel out of the slice and
+	// translate it to the explicit allVehicles flag so downstream code
+	// (hasVehicle, role resolution, auth_ok VehicleCount) only sees real
+	// vehicle IDs. Production Authenticator implementations never emit
+	// the sentinel, so on production this loop is a no-op.
+	concreteIDs := make([]string, 0, len(vehicleIDs))
+	for _, vid := range vehicleIDs {
+		if vid == WildcardVehicleID {
+			client.allVehicles = true
+			continue
+		}
+		concreteIDs = append(concreteIDs, vid)
+	}
+
 	client.userID = userID
-	client.vehicleIDs = vehicleIDs
+	client.vehicleIDs = concreteIDs
 
 	// Per websocket-protocol.md §4.6 / rest-api.md §5, resolve the
 	// caller's role for each authorized vehicle so the hub can
@@ -175,7 +189,7 @@ func (h *Hub) authenticateClient(ctx context.Context, client *Client, auth Authe
 	// Role("") sentinel at broadcast time, which yields a deny-all
 	// projection — the client connects but receives no payload for
 	// that vehicle until a successful re-handshake.
-	for _, vid := range vehicleIDs {
+	for _, vid := range concreteIDs {
 		role, roleErr := auth.ResolveRole(authCtx, userID, vid)
 		if roleErr != nil {
 			h.logger.Warn("ResolveRole failed; vehicle will be deny-all masked",

--- a/internal/ws/hub_test.go
+++ b/internal/ws/hub_test.go
@@ -301,6 +301,110 @@ func TestHub_Broadcast_AuthorizedOnly(t *testing.T) {
 	}
 }
 
+// TestHub_ProductionClient_EmptyVehicleIDs_DenyAll covers the MYR-60
+// regression: pre-fix, a production Authenticator that returned an empty
+// vehicleIDs slice would leak every vehicle to the client because
+// hasVehicle treated empty as "all access". Post-fix, an empty slice
+// without the dev-mode WildcardVehicleID sentinel must deny-all on every
+// broadcast path. Exercises both Broadcast (raw fan-out) and
+// BroadcastMasked (per-role projection) to prove neither path leaks.
+func TestHub_ProductionClient_EmptyVehicleIDs_DenyAll(t *testing.T) {
+	hub := newTestHub(t)
+	t.Cleanup(hub.Stop)
+
+	// Real-world pattern: testAuth (stand-in for JWTAuthenticator) returns
+	// the empty slice when the user owns no vehicles.
+	auth := &testAuth{userID: "user-no-vehicles", vehicleIDs: []string{}}
+	srv := newTestServer(t, hub, auth)
+	t.Cleanup(srv.Close)
+
+	conn := dialAndAuth(t, srv.URL, "token")
+	defer conn.Close(websocket.StatusNormalClosure, "")
+
+	waitForClients(t, hub, 1)
+
+	// The hub sees the client; sanity-check the deny-all posture.
+	hub.mu.RLock()
+	var got *Client
+	for c := range hub.clients {
+		got = c
+	}
+	hub.mu.RUnlock()
+	if got == nil {
+		t.Fatal("expected a registered client")
+	}
+	if got.allVehicles {
+		t.Fatal("production client must not have allVehicles=true")
+	}
+	if len(got.vehicleIDs) != 0 {
+		t.Fatalf("expected empty vehicleIDs, got %v", got.vehicleIDs)
+	}
+
+	// Broadcast (raw) for some vehicle the user does NOT own. The user
+	// owns no vehicle, so this MUST NOT reach them.
+	rawMsg := mustMarshalTest(t, wsMessage{
+		Type: msgTypeDriveStarted,
+		Payload: mustMarshalRaw(t, map[string]any{
+			"vehicleId": "v-leaked",
+		}),
+	})
+	hub.Broadcast("v-leaked", rawMsg)
+
+	// BroadcastMasked path with a non-empty payload + valid resource.
+	hub.BroadcastMasked(
+		"v-leaked",
+		mask.ResourceVehicleState,
+		time.Now().Format(time.RFC3339),
+		map[string]any{"speed": 65},
+	)
+
+	// Confirm nothing was delivered. Read with a short deadline; the
+	// only acceptable outcome is timeout.
+	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+	defer cancel()
+	if _, _, err := conn.Read(ctx); err == nil {
+		t.Fatal("client with empty vehicleIDs received a broadcast — deny-all violated")
+	}
+}
+
+// TestHub_NoopAuth_WildcardSetsAllVehicles verifies the dev-mode escape
+// hatch: NoopAuthenticator with no explicit VehicleIDs returns the
+// WildcardVehicleID sentinel from GetUserVehicles, which the handshake
+// translates to Client.allVehicles=true while stripping the sentinel out
+// of Client.vehicleIDs.
+func TestHub_NoopAuth_WildcardSetsAllVehicles(t *testing.T) {
+	hub := newTestHub(t)
+	t.Cleanup(hub.Stop)
+
+	auth := &NoopAuthenticator{} // VehicleIDs unset → wildcard expansion
+	srv := newTestServer(t, hub, auth)
+	t.Cleanup(srv.Close)
+
+	conn := dialAndAuth(t, srv.URL, "token")
+	defer conn.Close(websocket.StatusNormalClosure, "")
+
+	waitForClients(t, hub, 1)
+
+	hub.mu.RLock()
+	var got *Client
+	for c := range hub.clients {
+		got = c
+	}
+	hub.mu.RUnlock()
+	if got == nil {
+		t.Fatal("expected a registered client")
+	}
+	if !got.allVehicles {
+		t.Fatal("NoopAuthenticator handshake must set allVehicles=true")
+	}
+	if len(got.vehicleIDs) != 0 {
+		t.Fatalf("wildcard sentinel must be stripped from vehicleIDs, got %v", got.vehicleIDs)
+	}
+	if !got.hasVehicle("any-vehicle") {
+		t.Fatal("hasVehicle must return true for allVehicles=true client")
+	}
+}
+
 func TestHub_Heartbeat(t *testing.T) {
 	hub := newTestHub(t)
 	t.Cleanup(hub.Stop)
@@ -449,10 +553,11 @@ func TestHub_Handler_NonWSRequest(t *testing.T) {
 
 func TestClient_HasVehicle(t *testing.T) {
 	tests := []struct {
-		name       string
-		vehicleIDs []string
-		query      string
-		want       bool
+		name        string
+		vehicleIDs  []string
+		allVehicles bool
+		query       string
+		want        bool
 	}{
 		{
 			name:       "vehicle in list",
@@ -467,22 +572,41 @@ func TestClient_HasVehicle(t *testing.T) {
 			want:       false,
 		},
 		{
-			name:       "nil list grants all-vehicle access",
+			// Production posture: no vehicles authorized = deny-all.
+			// Pre-MYR-60 this was implicit "all access"; now it is
+			// explicit deny-all per NFR-3.21.
+			name:       "nil vehicleIDs without allVehicles -> deny",
 			vehicleIDs: nil,
 			query:      "v-1",
-			want:       true,
+			want:       false,
 		},
 		{
-			name:       "empty slice grants all-vehicle access",
+			name:       "empty vehicleIDs without allVehicles -> deny",
 			vehicleIDs: []string{},
 			query:      "v-1",
-			want:       true,
+			want:       false,
+		},
+		{
+			// Dev-mode escape hatch: allVehicles flag grants access
+			// to every vehicle regardless of vehicleIDs contents.
+			name:        "allVehicles=true grants access",
+			vehicleIDs:  nil,
+			allVehicles: true,
+			query:       "v-anything",
+			want:        true,
+		},
+		{
+			name:        "allVehicles=true with explicit list also grants access",
+			vehicleIDs:  []string{"v-1"},
+			allVehicles: true,
+			query:       "v-2",
+			want:        true,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			c := &Client{vehicleIDs: tt.vehicleIDs}
+			c := &Client{vehicleIDs: tt.vehicleIDs, allVehicles: tt.allVehicles}
 			if got := c.hasVehicle(tt.query); got != tt.want {
 				t.Fatalf("hasVehicle(%q) = %v, want %v", tt.query, got, tt.want)
 			}
@@ -556,6 +680,28 @@ func TestNoopAuthenticator(t *testing.T) {
 		}
 		if len(ids) != 2 {
 			t.Fatalf("expected 2 vehicle IDs, got %d", len(ids))
+		}
+	})
+
+	t.Run("nil VehicleIDs returns wildcard sentinel", func(t *testing.T) {
+		auth := &NoopAuthenticator{}
+		ids, err := auth.GetUserVehicles(context.Background(), "any")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(ids) != 1 || ids[0] != WildcardVehicleID {
+			t.Fatalf("expected single-element wildcard, got %v", ids)
+		}
+	})
+
+	t.Run("empty VehicleIDs returns wildcard sentinel", func(t *testing.T) {
+		auth := &NoopAuthenticator{VehicleIDs: []string{}}
+		ids, err := auth.GetUserVehicles(context.Background(), "any")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(ids) != 1 || ids[0] != WildcardVehicleID {
+			t.Fatalf("expected single-element wildcard, got %v", ids)
 		}
 	})
 }


### PR DESCRIPTION
## Summary

Resolves the documentation/behavior contradiction in `internal/ws/` flagged by the PR #195 review:

- `Client.hasVehicle()` previously treated an empty `vehicleIDs` slice as "grants access to all vehicles" (the dev-mode escape hatch).
- `NoopAuthenticator.VehicleIDs` was documented as "An empty slice means the user is not authorized for any vehicles."

A future engineer reading only the `Authenticator` interface would assume empty = denied and be wrong. Worse, on production a real authenticator returning an empty slice would have **leaked every vehicle** to that client — the opposite of the NFR-3.21 ownership guarantee.

This PR picks Option 1 from the issue (the issue calls it cleaner): make the all-access intent explicit.

- New `WildcardVehicleID = "*"` sentinel exposed by `internal/ws/auth.go`.
- `NoopAuthenticator.GetUserVehicles` now returns `["*"]` when `VehicleIDs` is unset/empty so the dev-mode all-access intent is no longer implicit-via-empty-slice.
- New `Client.allVehicles bool` flag. The handshake sets it only when `GetUserVehicles` returned the sentinel, and strips the sentinel out of `client.vehicleIDs` before role resolution / `auth_ok` count.
- `hasVehicle()` is now `c.allVehicles || slices.Contains(c.vehicleIDs, vehicleID)` — the empty-slice special case is gone, so production clients with no authorized vehicles correctly deny-all.
- `Authenticator` interface shape unchanged (issue's "Out of scope" rule).
- No wire-format changes. `auth_ok.vehicleCount` reports `len(client.vehicleIDs)` after the wildcard strip, which is `0` for dev-mode all-access — matches the existing §2.3 "informational" wording.

## Acceptance Criteria

- [x] No more contradiction between `hasVehicle` behavior and `NoopAuthenticator` doc.
- [x] Empty `vehicleIDs` in production = deny access (matches the doc string and reviewer expectation).
- [x] All existing tests pass (`go test ./...` clean — one unrelated pre-existing flake in `TestReceiver_GracefulShutdown` confirmed transient by re-run).
- [x] Test specifically for "production client with empty vehicleIDs sees no broadcasts" lands (`TestHub_ProductionClient_EmptyVehicleIDs_DenyAll` covers both `Broadcast` and `BroadcastMasked`).
- [x] `golangci-lint run ./...` — 0 issues.

## Anchored

- NFR-3.21 — vehicle ownership enforced on every subscription (now actually enforced for the empty-slice production case).

## Contract changes

`docs/contracts/websocket-protocol.md` updated in two spots flagged by `contract-guard`:
- §3.3 — narrowed the Client-struct field enumeration to focus on the actual point (no `nextSeq`) so it stops drifting as the struct evolves.
- §4.5 — replaced the stale "empty vehicle list grants all broadcasts" wording with the new explicit-flag description.

No AsyncAPI / JSON Schema / fixture changes — wire format is unchanged.

## Test plan

- [x] `go test ./...` passes (one unrelated flake)
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `golangci-lint run ./...`
- [ ] CI green
- [ ] `contract-guard` CI check passes
- [ ] Claude Review addressed

🤖 Generated with [Claude Code](https://claude.com/claude-code)