### PR TITLE
MYR-58 Replace structToMap JSON round-trip with typed ToMaskMap helper

### DIFF
--- a/internal/telemetry/vehicle_status_handler.go
+++ b/internal/telemetry/vehicle_status_handler.go
@@ -70,6 +70,38 @@ type vehicleStatusResponse struct {
 	ConnectedSince *string `json:"connected_since"`
 }
 
+// ToMaskMap returns a map[string]any keyed by JSON wire name, suitable
+// for projection through the role-based field mask in internal/mask.
+// Replaces the encoding/json round-trip previously used by
+// writeMaskedResponse, removing one Marshal/Unmarshal allocation pair
+// per masked REST response (MYR-58).
+//
+// Pointer-typed fields (LastMessageAt, ConnectedSince) are flattened to
+// their pointed-to value or nil — preserving the same key set the JSON
+// round-trip produced. The mask matrix only inspects keys, so value
+// type fidelity (int64 vs float64) is irrelevant; we use native Go
+// types here.
+func (r vehicleStatusResponse) ToMaskMap() map[string]any {
+	m := make(map[string]any, 5)
+	m["vin"] = r.VIN
+	m["connected"] = r.Connected
+	m["last_message_at"] = derefOrNil(r.LastMessageAt)
+	m["message_count"] = r.MessageCount
+	m["connected_since"] = derefOrNil(r.ConnectedSince)
+	return m
+}
+
+// derefOrNil returns *p as an any, or untyped nil if p is nil. The
+// untyped-nil return is what json.Marshal of a nil pointer produces
+// after the Unmarshal-to-map round-trip — keeping the post-mask JSON
+// output byte-identical to the pre-MYR-58 implementation.
+func derefOrNil[T any](p *T) any {
+	if p == nil {
+		return nil
+	}
+	return *p
+}
+
 // vehicleStatusErrorResponse is the JSON body returned on errors.
 type vehicleStatusErrorResponse struct {
 	Error string `json:"error"`

--- a/internal/telemetry/vehicle_status_handler_test.go
+++ b/internal/telemetry/vehicle_status_handler_test.go
@@ -269,39 +269,105 @@ func (s *stubVehicleIDLookup) GetVehicleIDByVIN(_ context.Context, _ string) (st
 	return s.id, nil
 }
 
-// maskedResponseWithSynthetic is a tiny response shape that mirrors
-// vehicleStatusResponse but adds a forward-looking `licensePlate`
-// field. The actual vehicleStatusResponse doesn't carry licensePlate
-// in v1 — this struct exercises the mask plumbing using a synthetic
-// payload, validating that ANY licensePlate-bearing response would be
-// projected correctly.
-type maskedResponseWithSynthetic struct {
-	VIN          string `json:"vin"`
-	Connected    bool   `json:"connected"`
-	LicensePlate string `json:"licensePlate"`
-	Speed        int    `json:"speed"`
-}
+// TestVehicleStatusResponse_ToMaskMap_PreservesWireNames verifies the
+// typed projection returns a map keyed by JSON wire names — the same
+// keys the mask matrix uses. Replaces the structToMap round-trip test
+// removed in MYR-58.
+func TestVehicleStatusResponse_ToMaskMap_PreservesWireNames(t *testing.T) {
+	lastMsg := "2026-04-30T12:00:00Z"
+	connSince := "2026-04-30T11:00:00Z"
+	in := vehicleStatusResponse{
+		VIN:            "5YJ3E1EA1PF000001",
+		Connected:      true,
+		LastMessageAt:  &lastMsg,
+		MessageCount:   42,
+		ConnectedSince: &connSince,
+	}
+	got := in.ToMaskMap()
 
-// TestStructToMap_PreservesWireNames verifies the JSON round-trip used
-// by writeMaskedResponse produces a map keyed by JSON wire names — the
-// same keys the mask matrix uses.
-func TestStructToMap_PreservesWireNames(t *testing.T) {
-	in := maskedResponseWithSynthetic{
-		VIN:          "ABC",
-		Connected:    true,
-		LicensePlate: "XYZ-789",
-		Speed:        65,
-	}
-	got, err := structToMap(in)
-	if err != nil {
-		t.Fatalf("structToMap: %v", err)
-	}
-	wantKeys := []string{"vin", "connected", "licensePlate", "speed"}
+	wantKeys := []string{"vin", "connected", "last_message_at", "message_count", "connected_since"}
 	for _, k := range wantKeys {
 		if _, ok := got[k]; !ok {
 			t.Errorf("missing key %q in %v", k, got)
 		}
 	}
+	if len(got) != len(wantKeys) {
+		t.Errorf("unexpected keys: got %v, want exactly %v", got, wantKeys)
+	}
+
+	// Pointer-typed fields flatten to their pointed-to value.
+	if got["last_message_at"] != lastMsg {
+		t.Errorf("last_message_at: got %v, want %q", got["last_message_at"], lastMsg)
+	}
+	if got["connected_since"] != connSince {
+		t.Errorf("connected_since: got %v, want %q", got["connected_since"], connSince)
+	}
+}
+
+// TestVehicleStatusResponse_ToMaskMap_NilPointersFlattenToNil verifies
+// that nil pointer fields produce a `nil` map value (not the absence
+// of the key) — this matches the post-Marshal/Unmarshal shape the old
+// structToMap helper produced, so the projected JSON output stays
+// byte-identical to the pre-MYR-58 implementation.
+func TestVehicleStatusResponse_ToMaskMap_NilPointersFlattenToNil(t *testing.T) {
+	in := vehicleStatusResponse{
+		VIN:       "5YJ3E1EA1PF000001",
+		Connected: false,
+	}
+	got := in.ToMaskMap()
+
+	if v, ok := got["last_message_at"]; !ok || v != nil {
+		t.Errorf("last_message_at: got (%v, ok=%v), want (nil, ok=true)", v, ok)
+	}
+	if v, ok := got["connected_since"]; !ok || v != nil {
+		t.Errorf("connected_since: got (%v, ok=%v), want (nil, ok=true)", v, ok)
+	}
+	if got["message_count"] != int64(0) {
+		t.Errorf("message_count zero: got %v (%T), want int64(0)", got["message_count"], got["message_count"])
+	}
+}
+
+// BenchmarkVehicleStatusResponse_ToMaskMap_VsJSONRoundTrip is the
+// MYR-58 baseline → post-fix comparison. The "JSONRoundTrip" sub-bench
+// reproduces the pre-MYR-58 structToMap implementation inline so the
+// regression target stays self-contained even after the helper is
+// removed. The "ToMaskMap" sub-bench measures the typed alternative.
+//
+// Acceptance criterion: ToMaskMap allocs ≤ 70% of JSONRoundTrip allocs.
+// Run with: go test ./internal/telemetry -run=^$ -bench=ToMaskMap_VsJSONRoundTrip -benchmem
+func BenchmarkVehicleStatusResponse_ToMaskMap_VsJSONRoundTrip(b *testing.B) {
+	lastMsg := "2026-04-30T12:00:00Z"
+	connSince := "2026-04-30T11:00:00Z"
+	in := vehicleStatusResponse{
+		VIN:            "5YJ3E1EA1PF000001",
+		Connected:      true,
+		LastMessageAt:  &lastMsg,
+		MessageCount:   42,
+		ConnectedSince: &connSince,
+	}
+
+	b.Run("JSONRoundTrip", func(b *testing.B) {
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			encoded, err := json.Marshal(in)
+			if err != nil {
+				b.Fatal(err)
+			}
+			out := make(map[string]any)
+			if err := json.Unmarshal(encoded, &out); err != nil {
+				b.Fatal(err)
+			}
+			_ = out
+		}
+	})
+
+	b.Run("ToMaskMap", func(b *testing.B) {
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			out := in.ToMaskMap()
+			_ = out
+		}
+	})
 }
 
 // TestVehicleStatusHandler_MaskedResponse_RoleResolverError verifies

--- a/internal/telemetry/vehicle_status_mask.go
+++ b/internal/telemetry/vehicle_status_mask.go
@@ -2,7 +2,6 @@ package telemetry
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"log/slog"
 	"net/http"
@@ -67,13 +66,12 @@ func WithMask(resource mask.ResourceType, roles roleResolver, idLookup vehicleID
 // is encoded directly — equivalent to RoleOwner allow-all behavior for
 // v1 callers (the only non-owner path is 403'd by verifyOwnership).
 //
-// The map round-trip through json.Marshal/Unmarshal is intentional: the
-// mask matrix is keyed by JSON field name, so we materialize the
-// struct's wire shape as a map[string]any and project that map. The
-// trade-off is one extra allocation per request; the matrix-keyed
-// design is the same one used by the WebSocket per-role projection
-// (websocket-protocol.md §4.6) — keeping both transports on a single
-// source-of-truth is worth the marginal cost.
+// Each maskable response struct provides a typed ToMaskMap() method
+// that builds a wire-name-keyed map directly (no json.Marshal/Unmarshal
+// round-trip). The mask matrix is keyed by JSON field name, so the
+// helper hand-mirrors the struct's `json:"..."` tags — the same
+// matrix-keyed design used by the WebSocket per-role projection
+// (websocket-protocol.md §4.6).
 //
 // TODO(MYR-XX audit-log): when AuditLog table exists, if
 // len(fieldsMasked) > 0 AND mask.ShouldAuditREST(userID, requestID,
@@ -110,19 +108,7 @@ func (h *VehicleStatusHandler) writeMaskedResponse(
 		return
 	}
 
-	// Round-trip through JSON to materialize the response as a
-	// schema-less map[string]any keyed by wire field name. The mask
-	// matrix is keyed the same way — see internal/mask/tables.go.
-	asMap, err := structToMap(resp)
-	if err != nil {
-		h.logger.Error("vehicle status: encode-for-mask failed",
-			slog.String("error", err.Error()),
-		)
-		h.writeError(w, http.StatusInternalServerError, "internal error")
-		return
-	}
-
-	projected, fieldsMasked := mask.Apply(asMap, mask.For(h.maskResource, role))
+	projected, fieldsMasked := mask.Apply(resp.ToMaskMap(), mask.For(h.maskResource, role))
 	_ = fieldsMasked // see TODO(MYR-XX audit-log) above
 
 	h.writeJSON(w, http.StatusOK, projected)
@@ -141,19 +127,4 @@ func (h *VehicleStatusHandler) resolveCallerRole(ctx context.Context, vin, userI
 		return auth.Role(""), fmt.Errorf("resolveCallerRole: %w", err)
 	}
 	return role, nil
-}
-
-// structToMap encodes v as JSON and decodes it back into a
-// map[string]any, producing a wire-name-keyed map suitable for the
-// mask layer.
-func structToMap(v any) (map[string]any, error) {
-	encoded, err := json.Marshal(v)
-	if err != nil {
-		return nil, fmt.Errorf("structToMap: marshal: %w", err)
-	}
-	out := make(map[string]any)
-	if err := json.Unmarshal(encoded, &out); err != nil {
-		return nil, fmt.Errorf("structToMap: unmarshal: %w", err)
-	}
-	return out, nil
 }


### PR DESCRIPTION
## Summary

Replaces the `json.Marshal` → `json.Unmarshal` round-trip used by `writeMaskedResponse` with a typed `(vehicleStatusResponse).ToMaskMap()` method. Per the MYR-58 follow-up flagged in PR #195's review of MYR-57, this removes the per-request marshal/unmarshal allocation pair on the masked REST response path.

## What changed

- New `vehicleStatusResponse.ToMaskMap() map[string]any` that hand-mirrors the struct's `json:"..."` tags and flattens pointer-typed fields to their pointed-to value or untyped nil. Output stays byte-identical to the previous JSON round-trip after `mask.Apply` + `writeJSON`.
- `writeMaskedResponse` now calls `resp.ToMaskMap()` directly. The `structToMap` helper is gone, the `encoding/json` import in `internal/telemetry/vehicle_status_mask.go` along with it.
- `derefOrNil[T]` generic helper for the pointer flattening, kept next to the struct so future maskable response types (per the issue: `VehicleSnapshot`, `DriveSummary`, `DriveDetail`, `DriveRoute`) can reuse it.

## Performance

Local benchmark on Apple M5 Pro:

```
BenchmarkVehicleStatusResponse_ToMaskMap_VsJSONRoundTrip/JSONRoundTrip-15   1151023   1032 ns/op   992 B/op   26 allocs/op
BenchmarkVehicleStatusResponse_ToMaskMap_VsJSONRoundTrip/ToMaskMap-15      20724045    58 ns/op    48 B/op    3 allocs/op
```

- **18× faster**, **20× fewer bytes**, **8.7× fewer allocs** (26 → 3).
- Comfortably above the ≥30% allocs-reduction acceptance bar in the issue.

## Acceptance Criteria

- [x] `vehicleStatusResponse.ToMaskMap()` implemented; benchmark shows ≥30% lower allocs (88% lower in practice).
- [x] `internal/telemetry/vehicle_status_mask.go` no longer imports `encoding/json` for the projection step.
- [x] All existing `vehicle_status_handler_test.go` tests pass unchanged (only the now-defunct `TestStructToMap_PreservesWireNames` was retired and replaced with two equivalent tests on the real type).
- [x] When future REST endpoints (`/snapshot`, `/drives`, etc.) ship, they ship with their own `ToMaskMap()` methods rather than calling a removed round-trip helper.

## Anchored

- NFR-3.20 — REST responses projected through caller's role mask
- NFR-3.6 — server scale targets

## No contract impact

- No wire-format change. The masked JSON body is byte-identical because the typed map carries the same wire-name keys and the mask layer only inspects keys.
- `docs/contracts/` untouched.
- `Authenticator` / `roleResolver` interfaces unchanged.

## Test plan

- [x] `go test ./...` passes
- [x] `go vet ./...`
- [x] `golangci-lint run ./...` — 0 issues
- [x] `go build ./...`
- [x] Benchmark shows ≥30% allocs reduction
- [ ] CI green
- [ ] `contract-guard` CI check passes
- [ ] Claude Review addressed

🤖 Generated with [Claude Code](https://claude.com/claude-code)