### PR TITLE
MYR-17 WebSocket origin allow-list (NFR-3.22): fail-closed prod, localhost dev

### DIFF
--- a/cmd/telemetry-server/adapters.go
+++ b/cmd/telemetry-server/adapters.go
@@ -62,6 +62,54 @@ func resolveDebugFieldsGate(devMode bool, token string) (debugFieldsGate, error)
 	}
 }
 
+// devLocalhostOriginPatterns is the localhost-friendly fallback used when
+// --dev is set and the operator has not configured an explicit origin
+// allow-list. Hostname-only patterns match any scheme (http/ws), and the
+// "localhost:*" / "127.0.0.1:*" forms admit any port (Next.js typically
+// dials from :3000 or :3001 during local development).
+var devLocalhostOriginPatterns = []string{
+	"localhost",
+	"localhost:*",
+	"127.0.0.1",
+	"127.0.0.1:*",
+	"[::1]",
+	"[::1]:*",
+}
+
+// resolveWSOriginPatterns folds the operator-configured allow-list and
+// the --dev flag into the final OriginPatterns slice passed to the
+// coder/websocket Accept call. Rules per NFR-3.22 / MYR-17:
+//
+//   - configured AllowedOrigins takes precedence in every mode.
+//   - empty config + --dev: localhost defaults so a dev workstation
+//     can dial without ceremony (still fails-closed for any other
+//     cross-origin host).
+//   - empty config + production: empty slice. coder/websocket's
+//     authenticateOrigin permits same-origin and empty-Origin requests
+//     and rejects all cross-origin dials with HTTP 403. A loud Warn
+//     reminds the operator to set websocket.allowed_origins or
+//     WEBSOCKET_ALLOWED_ORIGINS rather than rely on this fallback.
+func resolveWSOriginPatterns(configured []string, devMode bool, logger *slog.Logger) []string {
+	if len(configured) > 0 {
+		logger.Info("websocket allowed origins configured",
+			slog.Int("count", len(configured)),
+			slog.Any("patterns", configured),
+		)
+		return configured
+	}
+	if devMode {
+		logger.Warn("websocket allowed origins not configured; --dev fallback admits localhost only",
+			slog.Any("patterns", devLocalhostOriginPatterns),
+		)
+		// Return a copy so callers cannot mutate the package-level slice.
+		out := make([]string, len(devLocalhostOriginPatterns))
+		copy(out, devLocalhostOriginPatterns)
+		return out
+	}
+	logger.Warn("websocket allowed origins not configured in production mode — all cross-origin connections will be rejected with HTTP 403; set websocket.allowed_origins or WEBSOCKET_ALLOWED_ORIGINS to admit a browser app")
+	return nil
+}
+
 // vinResolverAdapter adapts store.VINCache to the ws.VINResolver interface
 // (returns vehicleID string). Backing the WS broadcaster path with the cache
 // avoids fetching the full Vehicle row (including the heavy navRouteCoordinates

--- a/cmd/telemetry-server/adapters_test.go
+++ b/cmd/telemetry-server/adapters_test.go
@@ -58,6 +58,67 @@ func TestProxyHTTPClient(t *testing.T) {
 	}
 }
 
+func TestResolveWSOriginPatterns(t *testing.T) {
+	tests := []struct {
+		name       string
+		configured []string
+		devMode    bool
+		want       []string
+	}{
+		{
+			name:       "configured wins in production",
+			configured: []string{"https://myrobotaxi.app", "https://www.myrobotaxi.app"},
+			devMode:    false,
+			want:       []string{"https://myrobotaxi.app", "https://www.myrobotaxi.app"},
+		},
+		{
+			name:       "configured wins under --dev",
+			configured: []string{"https://staging.myrobotaxi.app"},
+			devMode:    true,
+			want:       []string{"https://staging.myrobotaxi.app"},
+		},
+		{
+			name:       "empty config + production fails closed",
+			configured: nil,
+			devMode:    false,
+			want:       nil,
+		},
+		{
+			name:       "empty config + --dev admits localhost",
+			configured: []string{},
+			devMode:    true,
+			want:       devLocalhostOriginPatterns,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := resolveWSOriginPatterns(tt.configured, tt.devMode, testLogger())
+			if len(got) != len(tt.want) {
+				t.Fatalf("len: got %d (%v), want %d (%v)", len(got), got, len(tt.want), tt.want)
+			}
+			for i := range got {
+				if got[i] != tt.want[i] {
+					t.Errorf("[%d]: got %q, want %q", i, got[i], tt.want[i])
+				}
+			}
+		})
+	}
+
+	// The dev-mode fallback must not alias the package-level slice — a
+	// caller mutating it should not poison subsequent calls.
+	t.Run("dev fallback returns a defensive copy", func(t *testing.T) {
+		got := resolveWSOriginPatterns(nil, true, testLogger())
+		if len(got) == 0 {
+			t.Fatal("expected non-empty dev fallback")
+		}
+		got[0] = "evil.example.com"
+		if devLocalhostOriginPatterns[0] == "evil.example.com" {
+			t.Error("resolveWSOriginPatterns leaked the package-level slice; caller mutation poisoned the constant")
+		}
+	})
+}
+
 func TestResolveDebugFieldsGate(t *testing.T) {
 	longToken := strings.Repeat("a", debugFieldsMinTokenLen)
 

--- a/cmd/telemetry-server/main.go
+++ b/cmd/telemetry-server/main.go
@@ -186,10 +186,7 @@ func run() error { //nolint:funlen // composition root — sequential dependency
 
 	// --- HTTP server + route registration ---
 	srv := server.New(cfg.Server(), logger, db, reg, cfg.TeslaPublicKey())
-	originPatterns := cfg.WebSocket().AllowedOrigins
-	if len(originPatterns) == 0 {
-		originPatterns = []string{"*"} // default: allow all (restrict in production config)
-	}
+	originPatterns := resolveWSOriginPatterns(cfg.WebSocket().AllowedOrigins, *devMode, logger)
 	setupHTTPHandlers(httpRouteDeps{
 		cfg:            cfg,
 		srv:            srv,

--- a/configs/fly.json
+++ b/configs/fly.json
@@ -31,7 +31,11 @@
     "heartbeat_interval": "15s",
     "write_timeout": "10s",
     "max_connections_per_user": 5,
-    "read_limit": 4096
+    "read_limit": 4096,
+    "allowed_origins": [
+      "https://myrobotaxi.app",
+      "https://www.myrobotaxi.app"
+    ]
   },
   "auth": {
     "token_issuer": "myrobotaxi",

--- a/docs/contracts/websocket-protocol.md
+++ b/docs/contracts/websocket-protocol.md
@@ -80,6 +80,8 @@ The allow-list resolves at startup per [`cmd/telemetry-server/adapters.go:resolv
 
 Pattern matching follows the `coder/websocket` `authenticateOrigin` rules: a pattern containing `://` is matched against `<scheme>://<host>` of the `Origin` header (so `https://myrobotaxi.app` rejects an `http://myrobotaxi.app` Origin); a pattern without `://` is matched against `<host>` only (so `localhost:*` admits any scheme on any port). Patterns use `path.Match` glob semantics — `*.myrobotaxi.app` admits one subdomain level. Same-origin requests (Origin host == request host) and requests without an `Origin` header are always admitted.
 
+Operator escape hatches for non-localhost dev workflows: `WEBSOCKET_ALLOWED_ORIGINS=https://*.ngrok.io` admits ngrok tunnels; `https://*.trycloudflare.com` admits Cloudflare tunnels. The env var fully replaces the JSON-config allow-list so the operator must include any other origins (e.g. `https://*.ngrok.io,https://myrobotaxi.app`) in the same value.
+
 ### 1.3 Connection limits
 
 v1 enforces **two** concurrent-connection caps with asymmetric policies:

--- a/docs/contracts/websocket-protocol.md
+++ b/docs/contracts/websocket-protocol.md
@@ -67,12 +67,18 @@ Every FR/NFR listed here is anchored in at least one section of this doc. The ta
 
 ### 1.2 Origin enforcement
 
-The server passes `HandlerConfig.OriginPatterns` (populated from `WebSocketConfig.AllowedOrigins`) to `websocket.AcceptOptions.OriginPatterns`. Requests from origins not in the allow-list are rejected with `HTTP 403` **before** the WebSocket upgrade completes. There is no in-band error frame for this case -- the client receives an HTTP error response on the upgrade attempt.
+The server passes `HandlerConfig.OriginPatterns` (populated from `WebSocketConfig.AllowedOrigins`) to `websocket.AcceptOptions.OriginPatterns`. Requests from origins not in the allow-list are rejected with `HTTP 403` **before** the WebSocket upgrade completes. There is no in-band error frame for this case -- the client receives an HTTP error response on the upgrade attempt; the server logs a `slog.Warn` with the rejected `Origin`, the `remote_addr`, and the request `host` so an operator chasing "why is my browser blocked?" sees the failure inline.
 
-| Mode | Default | Source |
-|------|---------|--------|
-| Production | Configured allow-list (e.g. `https://app.myrobotaxi.com`) | `cfg.WebSocket().AllowedOrigins` via env / `config.json` |
-| Dev | `["*"]` (allow all) | [`cmd/telemetry-server/main.go`](../../cmd/telemetry-server/main.go) fallback when `AllowedOrigins` is empty |
+The allow-list resolves at startup per [`cmd/telemetry-server/adapters.go:resolveWSOriginPatterns`](../../cmd/telemetry-server/adapters.go) — operator-configured patterns always take precedence; the dev/prod split only governs the empty-config fallback (per NFR-3.22 and MYR-17):
+
+| Mode | When `AllowedOrigins` is set | Empty-config fallback |
+|------|------------------------------|------------------------|
+| Production (no `--dev`) | Use the configured slice verbatim. Production ships `["https://myrobotaxi.app", "https://www.myrobotaxi.app"]` in [`configs/fly.json`](../../configs/fly.json). | Empty slice — **fail-closed**. `coder/websocket` admits same-origin and empty-`Origin` requests; every cross-origin dial is rejected with HTTP 403. A `slog.Warn` at startup reminds the operator to set `websocket.allowed_origins` or `WEBSOCKET_ALLOWED_ORIGINS`. |
+| Dev (`--dev` flag) | Use the configured slice verbatim. | Localhost defaults: `localhost`, `localhost:*`, `127.0.0.1`, `127.0.0.1:*`, `[::1]`, `[::1]:*` (any scheme, any port). |
+
+`WEBSOCKET_ALLOWED_ORIGINS` is the env-var override for `websocket.allowed_origins`. It accepts a comma-separated list (whitespace around each entry is trimmed; entirely-empty input signals fail-closed). The env var, when set, fully replaces the JSON-config allow-list rather than appending to it.
+
+Pattern matching follows the `coder/websocket` `authenticateOrigin` rules: a pattern containing `://` is matched against `<scheme>://<host>` of the `Origin` header (so `https://myrobotaxi.app` rejects an `http://myrobotaxi.app` Origin); a pattern without `://` is matched against `<host>` only (so `localhost:*` admits any scheme on any port). Patterns use `path.Match` glob semantics — `*.myrobotaxi.app` admits one subdomain level. Same-origin requests (Origin host == request host) and requests without an `Origin` header are always admitted.
 
 ### 1.3 Connection limits
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -272,6 +272,86 @@ func TestLoad_TLSEnvOverrides(t *testing.T) {
 	}
 }
 
+func TestLoad_WebSocketAllowedOriginsEnvOverride(t *testing.T) {
+	tests := []struct {
+		name     string
+		fileVal  []string
+		envValue string
+		envSet   bool
+		want     []string
+	}{
+		{
+			name:    "JSON value used when env unset",
+			fileVal: []string{"https://myrobotaxi.app"},
+			envSet:  false,
+			want:    []string{"https://myrobotaxi.app"},
+		},
+		{
+			name:     "env override replaces JSON allow-list",
+			fileVal:  []string{"https://myrobotaxi.app"},
+			envValue: "https://staging.myrobotaxi.app, https://www.myrobotaxi.app",
+			envSet:   true,
+			want:     []string{"https://staging.myrobotaxi.app", "https://www.myrobotaxi.app"},
+		},
+		{
+			name:     "env single entry, no comma",
+			envValue: "https://myrobotaxi.app",
+			envSet:   true,
+			want:     []string{"https://myrobotaxi.app"},
+		},
+		{
+			name:     "env empty signals fail-closed",
+			fileVal:  []string{"https://myrobotaxi.app"},
+			envValue: "",
+			envSet:   true,
+			want:     nil,
+		},
+		{
+			name:     "env whitespace-only signals fail-closed",
+			fileVal:  []string{"https://myrobotaxi.app"},
+			envValue: "  ,  ",
+			envSet:   true,
+			want:     nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := t.TempDir()
+			overrides := map[string]any{}
+			if tt.fileVal != nil {
+				overrides["websocket"] = map[string]any{
+					"heartbeat_interval":       "15s",
+					"write_timeout":            "10s",
+					"max_connections_per_user": 5,
+					"read_limit":               4096,
+					"allowed_origins":          tt.fileVal,
+				}
+			}
+			path := writeTestConfig(t, dir, overrides)
+			setRequiredEnv(t)
+			if tt.envSet {
+				t.Setenv("WEBSOCKET_ALLOWED_ORIGINS", tt.envValue)
+			}
+
+			cfg, err := Load(path)
+			if err != nil {
+				t.Fatalf("Load(): %v", err)
+			}
+
+			got := cfg.WebSocket().AllowedOrigins
+			if len(got) != len(tt.want) {
+				t.Fatalf("AllowedOrigins len: got %d (%v), want %d (%v)", len(got), got, len(tt.want), tt.want)
+			}
+			for i := range got {
+				if got[i] != tt.want[i] {
+					t.Errorf("AllowedOrigins[%d]: got %q, want %q", i, got[i], tt.want[i])
+				}
+			}
+		})
+	}
+}
+
 func TestLoad_MapboxTokenOptional(t *testing.T) {
 	dir := t.TempDir()
 	path := writeTestConfig(t, dir, nil)

--- a/internal/config/load.go
+++ b/internal/config/load.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"strings"
 )
 
 // fileConfig mirrors the JSON structure for unmarshaling. All duration
@@ -147,10 +148,35 @@ func applyEnvOverrides(fc *fileConfig) error {
 		fc.TLS.CAFile = v
 	}
 
+	// WEBSOCKET_ALLOWED_ORIGINS overrides websocket.allowed_origins.
+	// Comma-separated list of origin patterns matched against the Origin
+	// header by coder/websocket — patterns containing "://" are matched
+	// against scheme+host, otherwise against host only. Each entry is
+	// trimmed of surrounding whitespace; empty entries are dropped. Set
+	// to a single space (or any string with no non-empty entries) to
+	// signal "explicitly empty" (fail-closed). Per NFR-3.22 and MYR-17.
+	if v, ok := os.LookupEnv("WEBSOCKET_ALLOWED_ORIGINS"); ok {
+		fc.WebSocket.AllowedOrigins = parseOriginList(v)
+	}
+
 	if len(missing) > 0 {
 		return fmt.Errorf("config.Load: %w: %v", ErrMissingRequired, missing)
 	}
 	return nil
+}
+
+// parseOriginList splits a comma-separated origin pattern list, trims
+// whitespace, and drops empty entries. A bare "*" is preserved (callers
+// decide whether to allow it).
+func parseOriginList(raw string) []string {
+	parts := strings.Split(raw, ",")
+	out := make([]string, 0, len(parts))
+	for _, p := range parts {
+		if t := strings.TrimSpace(p); t != "" {
+			out = append(out, t)
+		}
+	}
+	return out
 }
 
 // buildConfig converts the intermediate fileConfig into an immutable Config.

--- a/internal/ws/handler.go
+++ b/internal/ws/handler.go
@@ -72,9 +72,16 @@ func (h *Hub) handleUpgrade(w http.ResponseWriter, r *http.Request, auth Authent
 		OriginPatterns: cfg.OriginPatterns,
 	})
 	if err != nil {
-		h.logger.Error("websocket accept failed",
+		// Origin rejections (NFR-3.22) are the most common cause here —
+		// coder/websocket has already written HTTP 403 to w with the
+		// failure reason in the body. Log Origin + remote IP at Warn so
+		// an operator chasing "why is my browser blocked?" sees both
+		// without grepping for the library's verbose error string.
+		h.logger.Warn("websocket accept failed",
 			slog.Any("error", err),
 			slog.String("remote_addr", clientIP),
+			slog.String("origin", r.Header.Get("Origin")),
+			slog.String("host", r.Host),
 		)
 		return
 	}

--- a/internal/ws/handler_origin_test.go
+++ b/internal/ws/handler_origin_test.go
@@ -1,0 +1,198 @@
+package ws
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/coder/websocket"
+)
+
+// TestHub_OriginRestriction verifies the NFR-3.22 origin allow-list is
+// enforced at the WebSocket handler. The coder/websocket library does
+// the matching; this test pins the contract end-to-end so a future
+// refactor cannot silently weaken it (MYR-17).
+//
+// Matching semantics (per coder/websocket authenticateOrigin):
+//   - empty Origin header: accepted (same-origin or non-browser client).
+//   - Origin host == request host: accepted (same-origin).
+//   - pattern with "://": matched against scheme+host.
+//   - pattern without "://": matched against host only (admits any scheme).
+//   - cross-origin without a matching pattern: HTTP 403.
+func TestHub_OriginRestriction(t *testing.T) {
+	tests := []struct {
+		name           string
+		patterns       []string
+		origin         string
+		wantStatusCode int
+	}{
+		{
+			name:           "exact production origin admitted",
+			patterns:       []string{"https://myrobotaxi.app", "https://www.myrobotaxi.app"},
+			origin:         "https://myrobotaxi.app",
+			wantStatusCode: http.StatusSwitchingProtocols,
+		},
+		{
+			name:           "production www origin admitted",
+			patterns:       []string{"https://myrobotaxi.app", "https://www.myrobotaxi.app"},
+			origin:         "https://www.myrobotaxi.app",
+			wantStatusCode: http.StatusSwitchingProtocols,
+		},
+		{
+			name:           "scheme mismatch rejected",
+			patterns:       []string{"https://myrobotaxi.app"},
+			origin:         "http://myrobotaxi.app",
+			wantStatusCode: http.StatusForbidden,
+		},
+		{
+			name:           "evil host rejected",
+			patterns:       []string{"https://myrobotaxi.app"},
+			origin:         "https://evil.example.com",
+			wantStatusCode: http.StatusForbidden,
+		},
+		{
+			name:           "subdomain not implicitly admitted by exact pattern",
+			patterns:       []string{"https://myrobotaxi.app"},
+			origin:         "https://staging.myrobotaxi.app",
+			wantStatusCode: http.StatusForbidden,
+		},
+		{
+			name:           "wildcard subdomain admitted by glob pattern",
+			patterns:       []string{"https://*.myrobotaxi.app"},
+			origin:         "https://staging.myrobotaxi.app",
+			wantStatusCode: http.StatusSwitchingProtocols,
+		},
+		{
+			name:           "localhost dev pattern admits any port",
+			patterns:       []string{"localhost:*"},
+			origin:         "http://localhost:3000",
+			wantStatusCode: http.StatusSwitchingProtocols,
+		},
+		{
+			name:           "127.0.0.1 dev pattern admits any port",
+			patterns:       []string{"127.0.0.1:*"},
+			origin:         "http://127.0.0.1:8080",
+			wantStatusCode: http.StatusSwitchingProtocols,
+		},
+		{
+			name:           "empty Origin header accepted (same-origin / non-browser)",
+			patterns:       []string{"https://myrobotaxi.app"},
+			origin:         "",
+			wantStatusCode: http.StatusSwitchingProtocols,
+		},
+		{
+			name:           "fail-closed: no patterns rejects cross-origin",
+			patterns:       nil,
+			origin:         "https://evil.example.com",
+			wantStatusCode: http.StatusForbidden,
+		},
+		{
+			name:           "fail-closed: no patterns still admits empty Origin",
+			patterns:       nil,
+			origin:         "",
+			wantStatusCode: http.StatusSwitchingProtocols,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			hub := newTestHub(t)
+			t.Cleanup(hub.Stop)
+
+			auth := &testAuth{userID: "user-1", vehicleIDs: []string{"v-1"}}
+			handler := hub.Handler(auth, HandlerConfig{
+				OriginPatterns: tt.patterns,
+				AuthTimeout:    200 * time.Millisecond,
+				WriteTimeout:   500 * time.Millisecond,
+			})
+			srv := httptest.NewServer(handler)
+			t.Cleanup(srv.Close)
+
+			ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+			defer cancel()
+
+			req, err := http.NewRequestWithContext(ctx, http.MethodGet, srv.URL+"/api/ws", nil)
+			if err != nil {
+				t.Fatalf("build request: %v", err)
+			}
+			// Synthetic WS upgrade headers so the request reaches
+			// websocket.Accept's origin check; we never finish the
+			// handshake (no need — the origin check runs first).
+			req.Header.Set("Connection", "Upgrade")
+			req.Header.Set("Upgrade", "websocket")
+			req.Header.Set("Sec-WebSocket-Version", "13")
+			req.Header.Set("Sec-WebSocket-Key", "dGhlIHNhbXBsZSBub25jZQ==")
+			if tt.origin != "" {
+				req.Header.Set("Origin", tt.origin)
+			}
+
+			resp, err := http.DefaultClient.Do(req)
+			if err != nil {
+				t.Fatalf("do request: %v", err)
+			}
+			defer resp.Body.Close()
+
+			if resp.StatusCode != tt.wantStatusCode {
+				body, _ := io.ReadAll(resp.Body)
+				t.Fatalf("status: got %d, want %d (body: %q)", resp.StatusCode, tt.wantStatusCode, body)
+			}
+
+			// On rejection, verify the body carries a clear reason so
+			// an operator chasing "why is my browser blocked?" sees the
+			// failure inline rather than only in server logs.
+			if tt.wantStatusCode == http.StatusForbidden {
+				body, _ := io.ReadAll(resp.Body)
+				if !strings.Contains(strings.ToLower(string(body)), "origin") {
+					t.Errorf("403 body should mention origin; got %q", body)
+				}
+			}
+		})
+	}
+}
+
+// TestHub_OriginRestriction_FullDial walks one allowed origin all the
+// way through the handshake to prove origin acceptance does not break
+// the auth flow. The other cases above stop at the upgrade response.
+func TestHub_OriginRestriction_FullDial(t *testing.T) {
+	hub := newTestHub(t)
+	t.Cleanup(hub.Stop)
+
+	auth := &testAuth{userID: "user-1", vehicleIDs: []string{"v-1"}}
+	handler := hub.Handler(auth, HandlerConfig{
+		OriginPatterns: []string{"https://myrobotaxi.app"},
+		AuthTimeout:    500 * time.Millisecond,
+		WriteTimeout:   500 * time.Millisecond,
+	})
+	srv := httptest.NewServer(handler)
+	t.Cleanup(srv.Close)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	wsURL := strings.Replace(srv.URL, "http://", "ws://", 1) + "/api/ws"
+	conn, dialResp, err := websocket.Dial(ctx, wsURL, &websocket.DialOptions{
+		HTTPHeader: http.Header{"Origin": []string{"https://myrobotaxi.app"}},
+	})
+	if err != nil {
+		t.Fatalf("dial allowed origin: %v", err)
+	}
+	if dialResp != nil && dialResp.Body != nil {
+		_ = dialResp.Body.Close()
+	}
+	t.Cleanup(func() { _ = conn.Close(websocket.StatusNormalClosure, "") })
+
+	authMsg := mustMarshalTest(t, wsMessage{
+		Type:    msgTypeAuth,
+		Payload: mustMarshalRaw(t, authPayload{Token: "token"}),
+	})
+	if err := conn.Write(ctx, websocket.MessageText, authMsg); err != nil {
+		t.Fatalf("write auth: %v", err)
+	}
+	if _, _, err := conn.Read(ctx); err != nil {
+		t.Fatalf("read auth_ok: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary
- Replaces the unsafe `originPatterns = []string{\"*\"}` fallback in \`cmd/telemetry-server/main.go\` with \`resolveWSOriginPatterns(configured, devMode, logger)\`. Configured allow-list always wins; empty config + \`--dev\` returns localhost defaults; empty config + production returns \`nil\` so coder/websocket admits only same-origin / empty-Origin requests and rejects every cross-origin dial with HTTP 403. A startup \`slog.Warn\` flags the production fail-closed branch so operators don't ship that state by accident.
- Adds \`WEBSOCKET_ALLOWED_ORIGINS\` env-var override (comma-separated; whitespace trimmed; all-empty signals fail-closed). The env value, when present, fully replaces the JSON config rather than appending — the operator declares the complete allow-list in one place.
- Ships the production allow-list \`[\"https://myrobotaxi.app\", \"https://www.myrobotaxi.app\"]\` in \`configs/fly.json\` so the Fly deploy doesn't depend on the new fail-closed default.
- Promotes the \`websocket accept failed\` log from \`Error\` to \`Warn\` (origin rejection is operational, not a server fault) and attaches \`origin\` + \`host\` so an operator chasing \"why is my browser blocked?\" sees the failure inline.
- Rewrites \`docs/contracts/websocket-protocol.md §1.2\`: documents the new fallback semantics, the env var, the coder/websocket pattern-matching rules (\`://\` patterns match scheme+host, bare-host patterns match host only), the same-origin / empty-Origin always-admit rule, and an ngrok/Cloudflare-tunnel escape-hatch example.

## Tests

- \`internal/ws/handler_origin_test.go\`:
  - \`TestHub_OriginRestriction\` — 11-row table covering exact match, scheme mismatch, evil host, subdomain pattern, wildcard subdomain, localhost dev pattern, 127.0.0.1 dev pattern, empty Origin, and the fail-closed empty-pattern cases.
  - \`TestHub_OriginRestriction_FullDial\` — full handshake through \`auth_ok\` with an admitted origin.
- \`cmd/telemetry-server/adapters_test.go\`:
  - \`TestResolveWSOriginPatterns\` — 4-row table covering configured-wins, dev fallback, prod fail-closed, plus a defensive-copy invariant test so callers can't poison the package-level constant.
- \`internal/config/config_test.go\`:
  - \`TestLoad_WebSocketAllowedOriginsEnvOverride\` — 5-row table covering JSON-only, env-replaces-JSON, single-entry, empty-string-fail-closed, whitespace-only-fail-closed.

## Acceptance criteria

- [x] Allowed origins configurable via environment variable or config (\`WEBSOCKET_ALLOWED_ORIGINS\` / \`websocket.allowed_origins\`).
- [x] Production: only \`https://myrobotaxi.app\`, \`https://www.myrobotaxi.app\` (shipped in \`configs/fly.json\`).
- [x] Development: also allow localhost variants (any scheme, any port).
- [x] Reject with 403 + clear error message (coder/websocket emits 403 with the unauthorized-origin body; server logs Warn with origin + host).
- [x] Test: connection from allowed vs disallowed origin (\`TestHub_OriginRestriction\` covers both).

## Gates

- \`go vet\`, \`go test ./...\`, \`golangci-lint run ./...\` all clean.
- \`contract-guard\` PASS — Rule 1 (WS protocol drift) verified against §1.2 doc rewrite; no DB / SDK / atomic-group / encryption surface changes.
- \`security\` PASS — fail-closed default verified; defensive-copy invariant verified; no secrets in logs; production allow-list values match spec exactly.
- \`ux-audit\` PASS — Next.js end-user path preserved; operator Warn copy is actionable; ngrok/Cloudflare escape hatch now documented.

## Test plan
- [x] go test ./... — green
- [x] go vet ./... — clean
- [x] golangci-lint run ./... — 0 issues
- [ ] CI confirms tests run and stay green
- [ ] Post-merge: verify the Fly deploy reads the allow-list from \`configs/fly.json\` (or set \`WEBSOCKET_ALLOWED_ORIGINS\` as a Fly secret if env-var-only is preferred).

🤖 Generated with [Claude Code](https://claude.com/claude-code)