### PR TITLE
MYR-67 Persist fsdMilesSinceReset per-frame from telemetry

### DIFF
--- a/docs/contracts/fixtures/rest/snapshot_completeness.json
+++ b/docs/contracts/fixtures/rest/snapshot_completeness.json
@@ -140,12 +140,11 @@
       "comment": "DB INT NOT NULL DEFAULT 0. Test asserts non-zero."
     },
     "fsdMilesSinceReset": {
-      "category": "expected_failure",
+      "category": "telemetry",
       "atomicGroup": "",
       "synthetic": { "kind": "vehicleUpdate", "field": "FsdMilesSinceReset", "value": 412.7 },
       "nullableInSteadyState": false,
-      "linearIssue": "MYR-67",
-      "comment": "DOCUMENTED GAP: schema declares fsdMilesSinceReset as a non-nullable telemetry field; ws/field_mapping.go passes it through to the WS broadcast (telemetry.FieldFSDMiles = \"fsdMilesSinceReset\"); but VehicleUpdate has NO FsdMilesSinceReset pointer and field_mapper.go has NO applier for telemetry.FieldFSDMiles. Result: WS clients see the value live, but the DB row keeps the seeded value forever. Cold page reload via REST /snapshot will not reflect FSD-miles-since-reset changes that occurred while the user was offline. Tracked in MYR-67 (https://linear.app/myrobotaxi/issue/MYR-67); category=expected_failure surfaces the gap as a t.Logf warning so the test stays green. The closing PR for MYR-67 re-categorizes this row to category=telemetry and the assertion becomes hard. The test seeds a non-zero baseline so the steady-state DB read returns it."
+      "comment": "Per-frame telemetry field. DB DOUBLE PRECISION NOT NULL DEFAULT 0. VehicleUpdate.FsdMilesSinceReset is plumbed through field_mapper.applyFloat → buildTelemetryUpdate → writer_coalesce so per-frame Tesla telemetry (telemetry.FieldFSDMiles) updates the column. Test asserts non-zero (per fixture)."
     },
     "destinationName": {
       "category": "telemetry",

--- a/internal/store/field_mapper.go
+++ b/internal/store/field_mapper.go
@@ -26,6 +26,7 @@ var fieldAppliers = map[telemetry.FieldName]fieldApplier{
 	telemetry.FieldInsideTemp:      applyFloatAsInt(func(u *VehicleUpdate) **int { return &u.InteriorTemp }),
 	telemetry.FieldOutsideTemp:     applyFloatAsInt(func(u *VehicleUpdate) **int { return &u.ExteriorTemp }),
 	telemetry.FieldOdometer:        applyFloatAsInt(func(u *VehicleUpdate) **int { return &u.OdometerMiles }),
+	telemetry.FieldFSDMiles:        applyFloat(func(u *VehicleUpdate) **float64 { return &u.FsdMilesSinceReset }),
 	telemetry.FieldGear:            applyString(func(u *VehicleUpdate) **string { return &u.GearPosition }),
 	telemetry.FieldLocation:        applyLocation,
 	telemetry.FieldDestinationName: applyString(func(u *VehicleUpdate) **string { return &u.DestinationName }),

--- a/internal/store/field_mapper_test.go
+++ b/internal/store/field_mapper_test.go
@@ -210,6 +210,20 @@ func TestMapTelemetryToUpdate(t *testing.T) {
 				}
 			},
 		},
+		{
+			name: "fsdMilesSinceReset mapped from float",
+			fields: map[string]events.TelemetryValue{
+				string(telemetry.FieldFSDMiles): {FloatVal: floatPtr(412.7)},
+			},
+			check: func(t *testing.T, u *VehicleUpdate) {
+				if u == nil {
+					t.Fatal("expected non-nil update")
+				}
+				if u.FsdMilesSinceReset == nil || *u.FsdMilesSinceReset != 412.7 {
+					t.Errorf("FsdMilesSinceReset = %v, want 412.7", ptrVal(u.FsdMilesSinceReset))
+				}
+			},
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/store/queries.go
+++ b/internal/store/queries.go
@@ -116,6 +116,7 @@ func updateColumns(u VehicleUpdate) []updateColumn {
 		{"interiorTemp", derefInt(u.InteriorTemp), ""},
 		{"exteriorTemp", derefInt(u.ExteriorTemp), ""},
 		{"odometerMiles", derefInt(u.OdometerMiles), ""},
+		{"fsdMilesSinceReset", derefFloat(u.FsdMilesSinceReset), ""},
 		{"locationName", derefString(u.LocationName), ""},
 		{"locationAddress", derefString(u.LocationAddr), ""},
 		{"destinationName", derefString(u.DestinationName), ""},

--- a/internal/store/snapshot_completeness_test.go
+++ b/internal/store/snapshot_completeness_test.go
@@ -147,16 +147,15 @@ func loadCompletenessFixture(t *testing.T, root string) fixtureRoot {
 // completenessSeedCatalog is the catalog values used by every scenario
 // in TestSnapshotCompleteness. Identity fields are seeded with non-default
 // values so the read-back asserts the column survived the round trip.
-// fsdMilesSinceReset is seeded > 0 so the expected_failure row for the
-// missing writer-pipeline applier surfaces a non-zero baseline (the test
-// asserts non-null/non-zero on read).
+// fsdMilesSinceReset is seeded as 0 so the steady-state assertion validates
+// the writer pipeline wrote the synthetic 412.7 (vs. the seed surviving).
 var completenessSeedCatalog = catalogFields{
 	model:              "Model 3",
 	year:               2024,
 	color:              "Midnight Silver Metallic",
 	locationName:       "",
 	locationAddress:    "",
-	fsdMilesSinceReset: 412.7,
+	fsdMilesSinceReset: 0,
 	destinationAddress: nil,
 }
 
@@ -742,7 +741,8 @@ func applyValueToUpdate(u *store.VehicleUpdate, fieldName string, raw json.RawMe
 		return nil
 	case "TimeToFull", "Latitude", "Longitude",
 		"DestinationLatitude", "DestinationLongitude",
-		"OriginLatitude", "OriginLongitude", "TripDistRemaining":
+		"OriginLatitude", "OriginLongitude", "TripDistRemaining",
+		"FsdMilesSinceReset":
 		var n float64
 		if err := json.Unmarshal(raw, &n); err != nil {
 			return fmt.Errorf("decode float64 for %s: %w", fieldName, err)

--- a/internal/store/types.go
+++ b/internal/store/types.go
@@ -74,6 +74,7 @@ type VehicleUpdate struct {
 	InteriorTemp         *int
 	ExteriorTemp         *int
 	OdometerMiles        *int
+	FsdMilesSinceReset   *float64
 	LocationName         *string
 	LocationAddr         *string
 	DestinationName      *string

--- a/internal/store/writer_coalesce.go
+++ b/internal/store/writer_coalesce.go
@@ -40,6 +40,7 @@ func mergeUpdate(dst, src *VehicleUpdate) {
 	dst.InteriorTemp = mergePtr(dst.InteriorTemp, src.InteriorTemp)
 	dst.ExteriorTemp = mergePtr(dst.ExteriorTemp, src.ExteriorTemp)
 	dst.OdometerMiles = mergePtr(dst.OdometerMiles, src.OdometerMiles)
+	dst.FsdMilesSinceReset = mergePtr(dst.FsdMilesSinceReset, src.FsdMilesSinceReset)
 	dst.LocationName = mergePtr(dst.LocationName, src.LocationName)
 	dst.LocationAddr = mergePtr(dst.LocationAddr, src.LocationAddr)
 	dst.DestinationName = mergePtr(dst.DestinationName, src.DestinationName)

--- a/internal/store/writer_test.go
+++ b/internal/store/writer_test.go
@@ -1024,6 +1024,60 @@ func TestWriter_ChargeAtomicGroupCoalesceOrdering(t *testing.T) {
 	}
 }
 
+// TestMergeUpdate_FsdMiles guards MYR-67: per-frame fsdMilesSinceReset
+// updates must survive coalescing the same way every other pointer field
+// in VehicleUpdate does.
+func TestMergeUpdate_FsdMiles(t *testing.T) {
+	t1 := time.Date(2026, 5, 6, 14, 0, 0, 0, time.UTC)
+	t2 := time.Date(2026, 5, 6, 14, 0, 5, 0, time.UTC)
+
+	tests := []struct {
+		name string
+		dst  *VehicleUpdate
+		src  *VehicleUpdate
+		want *float64
+	}{
+		{
+			name: "src value overwrites dst (last-write-wins)",
+			dst: &VehicleUpdate{
+				FsdMilesSinceReset: floatPtr(412.7),
+				LastUpdated:        t1,
+			},
+			src: &VehicleUpdate{
+				FsdMilesSinceReset: floatPtr(420.4),
+				LastUpdated:        t2,
+			},
+			want: floatPtr(420.4),
+		},
+		{
+			name: "dst preserved when src has no value",
+			dst: &VehicleUpdate{
+				FsdMilesSinceReset: floatPtr(412.7),
+				LastUpdated:        t1,
+			},
+			src: &VehicleUpdate{
+				Speed:       intPtr(72),
+				LastUpdated: t2,
+			},
+			want: floatPtr(412.7),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mergeUpdate(tt.dst, tt.src)
+			switch {
+			case tt.want == nil && tt.dst.FsdMilesSinceReset != nil:
+				t.Errorf("FsdMilesSinceReset = %v, want nil", *tt.dst.FsdMilesSinceReset)
+			case tt.want != nil && tt.dst.FsdMilesSinceReset == nil:
+				t.Errorf("FsdMilesSinceReset = nil, want %v", *tt.want)
+			case tt.want != nil && *tt.dst.FsdMilesSinceReset != *tt.want:
+				t.Errorf("FsdMilesSinceReset = %v, want %v", *tt.dst.FsdMilesSinceReset, *tt.want)
+			}
+		})
+	}
+}
+
 func TestMergeUpdate_OlderTimestampPreserved(t *testing.T) {
 	t1 := time.Date(2026, 3, 17, 14, 0, 5, 0, time.UTC) // later
 	t2 := time.Date(2026, 3, 17, 14, 0, 0, 0, time.UTC) // earlier


### PR DESCRIPTION
## Summary

- Plumbs `FsdMilesSinceReset *float64` through `VehicleUpdate` → `field_mapper.applyFloat` → `buildTelemetryUpdate` → `writer_coalesce` so per-frame Tesla telemetry events update the `Vehicle.fsdMilesSinceReset` column.
- Flips `docs/contracts/fixtures/rest/snapshot_completeness.json` row from `expected_failure` → `telemetry`. The closing PR for [MYR-67](https://linear.app/myrobotaxi/issue/MYR-67); steady-state assertion is now hard-fail on regressions.
- Drops the seeded baseline (412.7 → 0) so the steady-state assertion validates the writer wrote the synthetic value rather than the seed surviving.

## Why

[MYR-48](https://linear.app/myrobotaxi/issue/MYR-48)'s `TestSnapshotCompleteness` surfaced the writer-pipeline gap: the schema declares `fsdMilesSinceReset` as a non-nullable telemetry field, the WS broadcaster passes it through (`telemetry.FieldFSDMiles = "fsdMilesSinceReset"`), but `VehicleUpdate` had no Go field and `field_mapper.go` had no applier. WS clients saw live values during a drive, but a cold REST `/snapshot` reload returned the seeded value forever (NFR-3.5 / NFR-3.7 violation). Drive-completion paths still update the column; per-frame telemetry now also updates it — no data loss.

## Test plan

- [x] `go vet ./...` clean
- [x] `go build ./...` clean
- [x] `go test ./...` all green (Docker-gated `TestSnapshotCompleteness` skips locally; CI will run it)
- [x] `golangci-lint run ./...` reports 0 issues
- [x] New unit tests:
  - `TestMapTelemetryToUpdate` — adds the `fsdMilesSinceReset mapped from float` case
  - `TestMergeUpdate_FsdMiles` — verifies last-write-wins overwrite + dst preservation
- [ ] CI `TestSnapshotCompleteness` flips the row to a hard assertion (no longer t.Logf)

## Anchored

- NFR-3.5 — snapshot completeness for cold load
- NFR-3.7 — event-driven freshness; cold-load reads from snapshot
- FR-1.1 — telemetry fields delivered live AND persisted

🤖 Generated with [Claude Code](https://claude.com/claude-code)