### PR TITLE
MYR-66 Dev-mode BroadcastMasked owner-projection fallback

### DIFF
--- a/internal/ws/client.go
+++ b/internal/ws/client.go
@@ -45,6 +45,17 @@ type Client struct {
 	// known mid-connection refresh gap (role downgrade requires
 	// reconnect).
 	vehicleRoles map[string]auth.Role
+	// defaultRole is the fallback role consulted ONLY when allVehicles=true
+	// and the per-vehicle vehicleRoles map has no entry for the requested
+	// vehicleID. Set by the handshake to auth.RoleOwner for the dev-mode
+	// NoopAuthenticator path (whose ResolveRole returns RoleOwner
+	// unconditionally) so dev-mode clients receive role-projected frames
+	// for every vehicle the server is broadcasting for, instead of the
+	// empty Role("") deny-all sentinel that left them silently filtered
+	// out (MYR-66). Production clients have allVehicles=false; defaultRole
+	// is never consulted, so the fail-closed deny-all posture for clients
+	// without an explicit vehicleRoles entry is preserved.
+	defaultRole auth.Role
 	// subscribed tracks which of the client's owned vehicles are
 	// currently active subscriptions. Initialized at handshake from
 	// vehicleIDs (so a client that never sends subscribe/unsubscribe
@@ -74,15 +85,24 @@ func newClient(conn *websocket.Conn, hub *Hub, logger *slog.Logger) *Client {
 	}
 }
 
-// roleFor returns the role this client holds against vehicleID, or the
-// empty Role("") sentinel if no role was resolved at handshake time.
-// The empty sentinel is the fail-closed "unknown" value the mask layer
-// in internal/mask interprets as deny-all.
+// roleFor returns the role this client holds against vehicleID. Resolution
+// order: (1) the per-vehicle vehicleRoles map populated at handshake; (2)
+// for clients with allVehicles=true that lack a per-vehicle entry, the
+// defaultRole set at handshake (the dev-mode NoopAuthenticator path);
+// (3) the empty Role("") fail-closed sentinel, which the mask layer in
+// internal/mask interprets as deny-all. Production clients (allVehicles=
+// false) skip step 2, so a missing vehicleRoles entry stays deny-all.
 func (c *Client) roleFor(vehicleID string) auth.Role {
 	if c == nil {
 		return auth.Role("")
 	}
-	return c.vehicleRoles[vehicleID]
+	if role, ok := c.vehicleRoles[vehicleID]; ok {
+		return role
+	}
+	if c.allVehicles {
+		return c.defaultRole
+	}
+	return auth.Role("")
 }
 
 // writePump reads messages from the send channel and writes them to the

--- a/internal/ws/handler.go
+++ b/internal/ws/handler.go
@@ -13,6 +13,7 @@ import (
 	"github.com/coder/websocket"
 	"golang.org/x/sync/errgroup"
 
+	authpkg "github.com/tnando/my-robo-taxi-telemetry/internal/auth"
 	"github.com/tnando/my-robo-taxi-telemetry/internal/wserrors"
 )
 
@@ -190,6 +191,17 @@ func (h *Hub) authenticateClient(ctx context.Context, client *Client, auth Authe
 			continue
 		}
 		concreteIDs = append(concreteIDs, vid)
+	}
+
+	// When the wildcard sentinel sets allVehicles=true, seed defaultRole so
+	// the broadcast-time roleFor lookup falls back to a sensible role for
+	// vehicles that have no entry in vehicleRoles. RoleOwner matches
+	// NoopAuthenticator.ResolveRole's unconditional return, which is the
+	// only Authenticator that emits the wildcard sentinel today. Without
+	// this fallback, dev-mode wildcard clients silently fail per-role
+	// projection in BroadcastMasked (MYR-66).
+	if client.allVehicles {
+		client.defaultRole = authpkg.RoleOwner
 	}
 
 	client.userID = userID

--- a/internal/ws/hub_test.go
+++ b/internal/ws/hub_test.go
@@ -406,6 +406,57 @@ func TestHub_NoopAuth_WildcardSetsAllVehicles(t *testing.T) {
 	}
 }
 
+// TestHub_NoopAuth_BroadcastMaskedDeliversOwnerProjection covers MYR-66:
+// a dev-mode client (NoopAuthenticator with no explicit VehicleIDs) must
+// receive role-projected vehicle_update frames from BroadcastMasked, not
+// silently fall through the deny-all path. Pre-fix, the wildcard handshake
+// stripped the sentinel out of vehicleIDs and the role-resolution loop
+// iterated the empty concreteIDs slice, leaving vehicleRoles empty —
+// which made roleFor return Role("") and BroadcastMasked filter the dev
+// client out of every per-role projection. The fix seeds defaultRole =
+// auth.RoleOwner on wildcard handshake so roleFor returns RoleOwner for
+// any vehicleID. The mask is still applied — dev-mode is not a bypass.
+func TestHub_NoopAuth_BroadcastMaskedDeliversOwnerProjection(t *testing.T) {
+	hub := newTestHub(t)
+	t.Cleanup(hub.Stop)
+
+	auth := &NoopAuthenticator{} // VehicleIDs unset → wildcard expansion
+	srv := newTestServer(t, hub, auth)
+	t.Cleanup(srv.Close)
+
+	conn := dialAndAuth(t, srv.URL, "token")
+	defer conn.Close(websocket.StatusNormalClosure, "")
+
+	waitForClients(t, hub, 1)
+
+	hub.BroadcastMasked(
+		"v-arbitrary",
+		mask.ResourceVehicleState,
+		time.Now().UTC().Format(time.RFC3339),
+		map[string]any{
+			"speed":        65,
+			"licensePlate": "ABC-123",
+		},
+	)
+
+	got := readMessage(t, conn)
+	if got.Type != msgTypeVehicleUpdate {
+		t.Fatalf("expected %q, got %q", msgTypeVehicleUpdate, got.Type)
+	}
+	var pl vehicleUpdatePayload
+	if err := json.Unmarshal(got.Payload, &pl); err != nil {
+		t.Fatalf("unmarshal payload: %v", err)
+	}
+	// Owner projection keeps every field (matches
+	// TestHub_BroadcastMasked_OwnerKeepsAllFields).
+	if pl.Fields["speed"] != float64(65) {
+		t.Errorf("speed missing or wrong: %v", pl.Fields["speed"])
+	}
+	if pl.Fields["licensePlate"] != "ABC-123" {
+		t.Errorf("dev-mode owner projection missing licensePlate: %v", pl.Fields)
+	}
+}
+
 func TestHub_Heartbeat(t *testing.T) {
 	hub := newTestHub(t)
 	t.Cleanup(hub.Stop)


### PR DESCRIPTION
## Summary

- Adds `Client.defaultRole auth.Role`, consulted only when `allVehicles=true` and the per-vehicle `vehicleRoles` entry is missing.
- Handshake seeds `defaultRole = auth.RoleOwner` when the `WildcardVehicleID` sentinel is observed (the dev-mode `NoopAuthenticator` path).
- Adds a regression test: `NoopAuthenticator{}` → `BroadcastMasked` → dev client receives the owner-projected vehicle_update frame.

## Why

[MYR-66](https://linear.app/myrobotaxi/issue/MYR-66) — pre-fix, the dev-mode wildcard handshake stripped the sentinel out of `concreteIDs` so the role-resolution loop iterated an empty slice and left `vehicleRoles` empty. `BroadcastMasked` then resolved `roleFor(vehicleID)` to the empty `Role("")` sentinel, which projects to deny-all and filtered the dev client out of every per-role frame. Dev clients received `drive_started`/`drive_ended`/`connectivity` over the raw `Broadcast` path but nothing on `vehicle_update`. The empty-role gap pre-existed since [MYR-57](https://linear.app/myrobotaxi/issue/MYR-57) introduced per-role projection.

## Production posture (unchanged)

`defaultRole` is consulted only when `allVehicles=true`. Production `Authenticator` implementations never set `allVehicles=true` (they never emit the `WildcardVehicleID` sentinel), so production clients still fail-closed deny-all on a missing `vehicleRoles` entry.

## Tests

- [x] New: `TestHub_NoopAuth_BroadcastMaskedDeliversOwnerProjection` — dev-mode end-to-end on `BroadcastMasked` keeps `licensePlate` (owner mask).
- [x] All MYR-60 tests still pass: `TestHub_ProductionClient_EmptyVehicleIDs_DenyAll`, `TestHub_NoopAuth_WildcardSetsAllVehicles`.
- [x] All existing per-role projection tests still pass.
- [x] `go vet ./...`, `go test ./...`, `golangci-lint run ./...` all clean.

## Anchored

- NFR-3.21 — vehicle ownership enforced (production posture unchanged)
- NFR-3.19 — per-role projection at broadcast (mask still applied; not bypassed)
- FR-5.4 — owner/viewer roles

🤖 Generated with [Claude Code](https://claude.com/claude-code)