### PR TITLE
MYR-70 Add Go AuditRepo with append-only contract + integration test

### DIFF
--- a/.claude/agents/contract-guard.md
+++ b/.claude/agents/contract-guard.md
@@ -72,6 +72,14 @@ If the PR modifies encryption (adds/removes encrypted columns, changes the key m
 - `docs/contracts/data-classification.md`
 - Encryption contract docs (when they exist)
 
+### Rule 9: AuditRepo cross-repo column-list drift (CG-DL-8)
+If the PR modifies `internal/store/audit_repo.go`, you MUST verify:
+- The `CROSS-REPO COUPLING` header comment block is still present at the top of the file (it points future engineers at the Prisma schema authority in `../my-robo-taxi/prisma/schema.prisma`).
+- Every column declared in `docs/contracts/data-lifecycle.md` §4.1 / the Prisma `AuditLog` model — `id`, `userId`, `timestamp`, `action`, `targetType`, `targetId`, `initiator`, `metadata`, `createdAt` — appears as a quoted identifier (e.g., `"userId"`) in `internal/store/audit_repo.go`. A missing column literal signals drift between Prisma and the Go writer.
+- If the Prisma `AuditLog` schema is being changed, the `internal/store/audit_repo.go` side MUST be updated in the same PR (or in a tightly-coordinated pair of cross-repo PRs).
+
+The CI step is `.github/workflows/contract-guard.yml` → "Rule CG-DL-8 — AuditRepo cross-repo coupling intact". See `docs/contracts/data-lifecycle.md` §7 Rule CG-DL-8 for the full spec.
+
 ## How You Run
 
 ### Session-time mode (fast feedback)

--- a/.github/workflows/contract-guard.yml
+++ b/.github/workflows/contract-guard.yml
@@ -132,6 +132,50 @@ jobs:
             echo "✓ No message type changes detected in WS package"
           fi
 
+      - name: Rule CG-DL-8 — AuditRepo cross-repo coupling intact
+        if: contains(steps.changed.outputs.files, 'internal/store/audit_repo.go')
+        run: |
+          # MYR-70: the AuditLog table is owned by the sibling Next.js repo's
+          # Prisma schema. Any change to audit_repo.go MUST keep the
+          # CROSS-REPO COUPLING comment block intact so future engineers
+          # discover the Prisma authority before introducing column drift.
+          # See docs/contracts/data-lifecycle.md §7 Rule CG-DL-8.
+          FILE="internal/store/audit_repo.go"
+          if [ ! -f "$FILE" ]; then
+            echo "::error::$FILE was changed but is no longer present — file delete is not a permitted operation for this Prisma-coupled file."
+            exit 1
+          fi
+          if ! grep -q 'CROSS-REPO COUPLING' "$FILE"; then
+            echo "::error::$FILE is missing the CROSS-REPO COUPLING header comment."
+            echo ""
+            echo "audit_repo.go mirrors the AuditLog model in the Next.js repo's"
+            echo "prisma/schema.prisma. The header comment block names the Prisma"
+            echo "file, the migration file, and the column-by-column cross-walk."
+            echo "Restore the comment block before this PR can merge."
+            echo "See docs/contracts/data-lifecycle.md §7 Rule CG-DL-8."
+            exit 1
+          fi
+          # Spot-check that every column from the data-lifecycle.md §4.1
+          # canonical schema appears in the Go file. If a column is
+          # renamed or removed in Prisma, the Go side MUST be updated in
+          # the same PR — a missing column here surfaces the drift.
+          MISSING=""
+          for col in id userId timestamp action targetType targetId initiator metadata createdAt; do
+            if ! grep -q "\"$col\"" "$FILE"; then
+              MISSING="$MISSING $col"
+            fi
+          done
+          if [ -n "$MISSING" ]; then
+            echo "::error::$FILE is missing AuditLog column reference(s):$MISSING"
+            echo ""
+            echo "Every column declared in data-lifecycle.md §4.1 / prisma/schema.prisma"
+            echo "model AuditLog must be referenced (as a quoted column name) in audit_repo.go."
+            echo "If a column was renamed or removed in Prisma, update both repos in the same PR."
+            echo "See docs/contracts/data-lifecycle.md §7 Rule CG-DL-8."
+            exit 1
+          fi
+          echo "✓ AuditRepo cross-repo coupling header and column list intact"
+
       - name: Summary
         if: always()
         run: |
@@ -141,3 +185,4 @@ jobs:
           echo "  - Contract docs reference FRs/NFRs: ${{ steps.changed.outputs.has_contract_docs }}"
           echo "  - Store field classification: ${{ steps.changed.outputs.has_store_changes }}"
           echo "  - WS protocol sync: ${{ steps.changed.outputs.has_ws_changes }}"
+          echo "  - AuditRepo cross-repo coupling (CG-DL-8): scoped to internal/store/audit_repo.go changes"

--- a/docs/contracts/data-lifecycle.md
+++ b/docs/contracts/data-lifecycle.md
@@ -575,6 +575,25 @@ The `contract-guard` agent/CI check enforces the following rules derived from th
 
 **Fix:** Keep `userId` as an unlinked TEXT column. See Section 4.5 for rationale.
 
+### Rule CG-DL-8: AuditRepo cross-repo column-list drift
+
+**Trigger:** Any PR that modifies `internal/store/audit_repo.go` in the telemetry repo.
+
+**Check:** The Go `AuditEntry` struct and `queryAuditInsert` SQL in `audit_repo.go` mirror the Prisma `AuditLog` model in the Next.js repo (`../my-robo-taxi/prisma/schema.prisma`). The two MUST stay in lock-step. Specifically:
+
+1. The `CROSS-REPO COUPLING` header comment block in `internal/store/audit_repo.go` MUST be present (it tells future engineers where the schema authority lives).
+2. Every column named in §4.1 (and in the Prisma model) MUST appear as a quoted identifier in `audit_repo.go` — `"id"`, `"userId"`, `"timestamp"`, `"action"`, `"targetType"`, `"targetId"`, `"initiator"`, `"metadata"`, `"createdAt"`. A missing column reference is a column-list drift signal: either a column was removed from Prisma (in which case the schema doc must be updated) or the Go side was not updated alongside a Prisma change (in which case both must be updated in the same PR).
+3. If a Prisma migration adds, renames, or removes a column on `AuditLog`, the same PR MUST update `internal/store/audit_repo.go` (or, more precisely, the cross-repo coupling MUST be acknowledged by a same-PR Go-side update, even if the Go column list is intentionally narrower in some hypothetical future).
+
+CI enforcement lives in `.github/workflows/contract-guard.yml` under the step "Rule CG-DL-8 — AuditRepo cross-repo coupling intact". The check fires only when `internal/store/audit_repo.go` is in the PR diff.
+
+**Violation examples:**
+- Removing the `CROSS-REPO COUPLING` header comment from `audit_repo.go` (loses the pointer to the Prisma authority).
+- Renaming a column in Prisma without updating the corresponding column literal in `queryAuditInsert`.
+- Adding a new column to Prisma without adding it to `AuditEntry` and `queryAuditInsert`.
+
+**Fix:** Restore the cross-repo coupling header comment and ensure every Prisma `AuditLog` column appears (as a quoted identifier) in `internal/store/audit_repo.go`. If the Prisma side has not been updated yet, hold this PR until the cross-repo PR is merged (or open them as a coordinated pair).
+
 ---
 
 ## 8. Cross-references

--- a/internal/store/audit_repo.go
+++ b/internal/store/audit_repo.go
@@ -18,7 +18,7 @@ package store
 // declared in AuditEntry below MUST mirror the Prisma model exactly. Any
 // change to either side (column add/rename/retype, classification tier,
 // nullability) requires updating BOTH files in the SAME PR. contract-guard
-// rule CG-DL-7 enforces this on every PR (see .github/workflows/
+// rule CG-DL-8 enforces this on every PR (see .github/workflows/
 // contract-guard.yml and .claude/agents/contract-guard.md). Drift is a
 // contract violation that blocks merge.
 //
@@ -145,6 +145,15 @@ const queryAuditInsert = `INSERT INTO "AuditLog" (
 // document containing only P0 values (see §4.4 / CG-DL-5); pass
 // json.RawMessage("{}") when there is no metadata.
 //
+// Zero-time fallback: if Timestamp or CreatedAt is the zero value
+// (time.Time{}), it is replaced with time.Now().UTC() at insert time.
+// This guards against silent data-quality bugs where a caller forgets
+// to set the timestamp and Postgres would otherwise write
+// 0001-01-01T00:00:00Z. The Prisma model declares @default(now()) on
+// these columns, but because this writer always passes them as bind
+// parameters that DB-side default never fires — the Go-side fallback
+// is what enforces the non-zero invariant.
+//
 // This is the only mutation method on AuditRepo by design — see the
 // append-only invariant note at the top of this file.
 func (r *AuditRepo) InsertAuditLog(ctx context.Context, entry AuditEntry) error {
@@ -153,16 +162,26 @@ func (r *AuditRepo) InsertAuditLog(ctx context.Context, entry AuditEntry) error 
 		metadata = json.RawMessage("{}")
 	}
 
+	now := time.Now().UTC()
+	timestamp := entry.Timestamp
+	if timestamp.IsZero() {
+		timestamp = now
+	}
+	createdAt := entry.CreatedAt
+	if createdAt.IsZero() {
+		createdAt = now
+	}
+
 	_, err := r.pool.Exec(ctx, queryAuditInsert,
 		entry.ID,
 		entry.UserID,
-		entry.Timestamp,
+		timestamp,
 		string(entry.Action),
 		entry.TargetType,
 		entry.TargetID,
 		entry.Initiator,
 		metadata,
-		entry.CreatedAt,
+		createdAt,
 	)
 	if err != nil {
 		return fmt.Errorf("store.AuditRepo.InsertAuditLog: %w", err)

--- a/internal/store/audit_repo.go
+++ b/internal/store/audit_repo.go
@@ -1,0 +1,171 @@
+package store
+
+// CROSS-REPO COUPLING — READ BEFORE EDITING
+// =========================================
+// The AuditLog table is owned by the Next.js app's Prisma schema at
+//
+//   ../my-robo-taxi/prisma/schema.prisma  (model AuditLog)
+//
+// and provisioned by migration
+//
+//   ../my-robo-taxi/prisma/migrations/20260508211924_auditlog_table_and_append_only_triggers/
+//
+// per docs/contracts/data-lifecycle.md §1.4 / §4 (FR-10.2, NFR-3.29). The
+// telemetry server holds Insert-only access to this table for system-
+// initiated rows: drives_pruned, mask_applied, tokens_refreshed.
+//
+// Authority: the Prisma model is the schema source of truth. The columns
+// declared in AuditEntry below MUST mirror the Prisma model exactly. Any
+// change to either side (column add/rename/retype, classification tier,
+// nullability) requires updating BOTH files in the SAME PR. contract-guard
+// rule CG-DL-7 enforces this on every PR (see .github/workflows/
+// contract-guard.yml and .claude/agents/contract-guard.md). Drift is a
+// contract violation that blocks merge.
+//
+// Append-only invariant (NFR-3.29 / CG-DL-2):
+//   * The DB enforces this via the prevent_audit_log_mutation() function
+//     and the prevent_audit_log_update / prevent_audit_log_delete triggers
+//     installed by the Phase 1 migration. Any UPDATE / DELETE raises
+//     "AuditLog rows are append-only".
+//   * This Go type ALSO refuses to expose mutation methods: AuditRepo
+//     intentionally has only InsertAuditLog. Do NOT add Update / Delete /
+//     Get / List methods here. If a query path is ever needed, callers
+//     should read AuditLog through Prisma (the owner) — not by extending
+//     this repo.
+//
+// IDs:
+//   * Callers MUST supply a cuid-format id on every entry. This matches
+//     the convention used by DriveRepo.Create / VehicleRepo upsert paths
+//     elsewhere in this package (Go-side id generation, never relying on
+//     Prisma's @default(cuid()) DB-side fallback). Generating the id at
+//     the call site means the audit row's id is known to the caller for
+//     downstream correlation (e.g., logging the inserted audit id in the
+//     same transaction that mutated the affected entity).
+//
+// Classification:
+//   * All columns are P0 per data-lifecycle.md §4.4. The metadata JSONB
+//     MUST contain only opaque IDs / counts / enum values — never P1
+//     values like coordinates, addresses, names, tokens, or emails.
+//     contract-guard rule CG-DL-5 enforces this on every PR.
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+// AuditAction is the enum-like string written to the AuditLog.action column.
+// The full enum is defined by docs/contracts/data-lifecycle.md §4.2; the
+// constants below cover the actions emitted by the Go telemetry server.
+// User-initiated actions (account_deleted, vehicle_deleted, drive_deleted,
+// invite_revoked) are emitted by the Next.js app inside its Prisma
+// $transaction and are intentionally NOT exposed here.
+type AuditAction string
+
+const (
+	// AuditActionAccountDeleted records a user-initiated account deletion
+	// per FR-10.1. Emitted by the Next.js app, NOT by the Go telemetry
+	// server. Defined here for symmetry with the contract enum and so
+	// downstream Go consumers (e.g., metric labels) can use the same
+	// constant set.
+	AuditActionAccountDeleted AuditAction = "account_deleted"
+
+	// AuditActionMaskApplied records a 1%-sampled event in which a
+	// role-based field mask removed at least one field from a REST
+	// response or WebSocket broadcast. See rest-api.md §5.3.
+	AuditActionMaskApplied AuditAction = "mask_applied"
+
+	// AuditActionTokensRefreshed records a Tesla OAuth2 token rotation
+	// initiated by the Go telemetry server's auto-refresh path.
+	AuditActionTokensRefreshed AuditAction = "tokens_refreshed"
+
+	// AuditActionDrivesPruned records a batch of drives deleted by the
+	// NFR-3.27 retention pruning job.
+	AuditActionDrivesPruned AuditAction = "drives_pruned"
+)
+
+// AuditEntry mirrors the AuditLog table one-to-one. Every field maps to a
+// Prisma column of the same case-folded name. See the cross-repo coupling
+// note at the top of this file before changing anything here.
+//
+// Field-by-field cross-walk to prisma/schema.prisma model AuditLog:
+//
+//	ID         -> id          @id @default(cuid())   -- caller-provided cuid
+//	UserID     -> userId      String                 -- NOT a FK to User (§4.5)
+//	Timestamp  -> timestamp   DateTime @default(now())
+//	Action     -> action      String                 -- enum-like, see §4.2
+//	TargetType -> targetType  String                 -- enum-like, see §4.2
+//	TargetID   -> targetId    String
+//	Initiator  -> initiator   String                 -- enum-like, see §4.2
+//	Metadata   -> metadata    Json @default("{}")    -- P0 only (CG-DL-5)
+//	CreatedAt  -> createdAt   DateTime @default(now())
+type AuditEntry struct {
+	ID         string
+	UserID     string
+	Timestamp  time.Time
+	Action     AuditAction
+	TargetType string
+	TargetID   string
+	Initiator  string
+	Metadata   json.RawMessage // valid JSON; pass json.RawMessage("{}") when empty
+	CreatedAt  time.Time
+}
+
+// AuditRepo provides Insert-only access to the Prisma-owned AuditLog
+// table. The append-only invariant is enforced both at the database level
+// (Phase 1 migration triggers) and at the API surface (this type exposes
+// only InsertAuditLog). See the cross-repo coupling note at the top of
+// this file.
+type AuditRepo struct {
+	pool *pgxpool.Pool
+}
+
+// NewAuditRepo creates an AuditRepo backed by the given connection pool.
+func NewAuditRepo(pool *pgxpool.Pool) *AuditRepo {
+	return &AuditRepo{pool: pool}
+}
+
+// queryAuditInsert names every column explicitly so column-order changes
+// in the Prisma migration would break this query loudly rather than
+// silently writing into the wrong column. The column list mirrors the
+// Phase 1 CREATE TABLE statement.
+const queryAuditInsert = `INSERT INTO "AuditLog" (
+	"id", "userId", "timestamp", "action", "targetType",
+	"targetId", "initiator", "metadata", "createdAt"
+) VALUES (
+	$1, $2, $3, $4, $5,
+	$6, $7, $8, $9
+)`
+
+// InsertAuditLog appends a single audit entry. Callers MUST supply a
+// caller-generated cuid id. The metadata field MUST be a valid JSON
+// document containing only P0 values (see §4.4 / CG-DL-5); pass
+// json.RawMessage("{}") when there is no metadata.
+//
+// This is the only mutation method on AuditRepo by design — see the
+// append-only invariant note at the top of this file.
+func (r *AuditRepo) InsertAuditLog(ctx context.Context, entry AuditEntry) error {
+	metadata := entry.Metadata
+	if len(metadata) == 0 {
+		metadata = json.RawMessage("{}")
+	}
+
+	_, err := r.pool.Exec(ctx, queryAuditInsert,
+		entry.ID,
+		entry.UserID,
+		entry.Timestamp,
+		string(entry.Action),
+		entry.TargetType,
+		entry.TargetID,
+		entry.Initiator,
+		metadata,
+		entry.CreatedAt,
+	)
+	if err != nil {
+		return fmt.Errorf("store.AuditRepo.InsertAuditLog: %w", err)
+	}
+	return nil
+}

--- a/internal/store/audit_repo_test.go
+++ b/internal/store/audit_repo_test.go
@@ -24,7 +24,7 @@ import (
 // duplicated here verbatim. The cross-repo coupling note at the top of
 // internal/store/audit_repo.go applies to this constant too: any change
 // to the Prisma migration MUST be mirrored here in the same PR, and
-// contract-guard CG-DL-7 enforces it on every PR. The exception text
+// contract-guard CG-DL-8 enforces it on every PR. The exception text
 // "AuditLog rows are append-only" is asserted on by the trigger tests
 // below — keep the strings in sync.
 const auditSchemaSQL = `
@@ -310,6 +310,13 @@ func TestAuditRepo_NotNullColumnsRejectMissingValues(t *testing.T) {
 				  VALUES ($1, 'user_001', 'drives_pruned', NULL, 'veh_001', 'system_pruner')`,
 			args:    []any{"audit_null_target_type"},
 			wantSub: "targetType",
+		},
+		{
+			name: "NULL targetId is rejected",
+			sql: `INSERT INTO "AuditLog" ("id","userId","action","targetType","targetId","initiator")
+				  VALUES ($1, 'user_001', 'drives_pruned', 'drive', NULL, 'system_pruner')`,
+			args:    []any{"audit_null_target_id"},
+			wantSub: "targetId",
 		},
 		{
 			name: "NULL initiator is rejected",

--- a/internal/store/audit_repo_test.go
+++ b/internal/store/audit_repo_test.go
@@ -1,0 +1,334 @@
+package store_test
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/tnando/my-robo-taxi-telemetry/internal/store"
+)
+
+// auditSchemaSQL re-creates the AuditLog table, indexes, and append-only
+// triggers installed by the Phase 1 Prisma migration:
+//
+//	../my-robo-taxi/prisma/migrations/20260508211924_auditlog_table_and_append_only_triggers/migration.sql
+//
+// This duplication is intentional. Reading the sibling repo's migration
+// file at test time would couple this test to a sibling-repo path layout
+// (CI may not even check that repo out). Instead, the canonical SQL is
+// duplicated here verbatim. The cross-repo coupling note at the top of
+// internal/store/audit_repo.go applies to this constant too: any change
+// to the Prisma migration MUST be mirrored here in the same PR, and
+// contract-guard CG-DL-7 enforces it on every PR. The exception text
+// "AuditLog rows are append-only" is asserted on by the trigger tests
+// below — keep the strings in sync.
+const auditSchemaSQL = `
+CREATE TABLE "AuditLog" (
+    "id" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "timestamp" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "action" TEXT NOT NULL,
+    "targetType" TEXT NOT NULL,
+    "targetId" TEXT NOT NULL,
+    "initiator" TEXT NOT NULL,
+    "metadata" JSONB NOT NULL DEFAULT '{}',
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "AuditLog_pkey" PRIMARY KEY ("id")
+);
+
+CREATE INDEX "AuditLog_userId_idx" ON "AuditLog"("userId");
+CREATE INDEX "AuditLog_action_idx" ON "AuditLog"("action");
+CREATE INDEX "AuditLog_timestamp_idx" ON "AuditLog"("timestamp");
+
+CREATE OR REPLACE FUNCTION prevent_audit_log_mutation()
+RETURNS TRIGGER AS $$
+BEGIN
+    RAISE EXCEPTION 'AuditLog rows are append-only';
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER prevent_audit_log_update
+    BEFORE UPDATE ON "AuditLog"
+    FOR EACH ROW
+    EXECUTE FUNCTION prevent_audit_log_mutation();
+
+CREATE TRIGGER prevent_audit_log_delete
+    BEFORE DELETE ON "AuditLog"
+    FOR EACH ROW
+    EXECUTE FUNCTION prevent_audit_log_mutation();
+`
+
+// auditSchemaOnce ensures the AuditLog DDL is applied exactly once per
+// test process even if multiple AuditRepo tests run concurrently or
+// before TestMain's createSchema is amended. The shared testPool from
+// db_test.go is reused.
+var auditSchemaOnce sync.Once
+
+// ensureAuditSchema applies auditSchemaSQL to the shared testPool.
+// Idempotent across repeated test invocations within one go test process
+// because of the sync.Once guard.
+func ensureAuditSchema(t *testing.T) {
+	t.Helper()
+	auditSchemaOnce.Do(func() {
+		ctx := context.Background()
+		if _, err := testPool.Exec(ctx, auditSchemaSQL); err != nil {
+			t.Fatalf("apply AuditLog schema: %v", err)
+		}
+	})
+}
+
+// cleanAuditLog removes all rows from AuditLog using a TRUNCATE that
+// disables the BEFORE DELETE trigger. Per the migration's operator
+// notes, TRUNCATE bypasses the row-level trigger by design — exactly
+// what we need for cross-test cleanup. NFR-3.29 forbids TRUNCATE in
+// production at the policy level; the test-only use here is within
+// the policy carve-out for ephemeral test databases.
+func cleanAuditLog(t *testing.T, pool *pgxpool.Pool) {
+	t.Helper()
+	ctx := context.Background()
+	if _, err := pool.Exec(ctx, `TRUNCATE TABLE "AuditLog"`); err != nil {
+		t.Fatalf("truncate AuditLog: %v", err)
+	}
+}
+
+// validEntry returns a fully-populated AuditEntry for use in happy-path
+// tests. Sub-tests override the fields they want to vary.
+func validEntry(id string) store.AuditEntry {
+	now := time.Date(2026, 5, 9, 12, 0, 0, 0, time.UTC)
+	return store.AuditEntry{
+		ID:         id,
+		UserID:     "user_001",
+		Timestamp:  now,
+		Action:     store.AuditActionDrivesPruned,
+		TargetType: "drive",
+		TargetID:   "veh_001",
+		Initiator:  "system_pruner",
+		Metadata:   json.RawMessage(`{"driveCount":7}`),
+		CreatedAt:  now,
+	}
+}
+
+func TestAuditRepo_InsertAuditLog(t *testing.T) {
+	if !dockerAvailable {
+		t.Skip("Docker not available; skipping AuditLog integration test")
+	}
+	ensureAuditSchema(t)
+	cleanAuditLog(t, testPool)
+
+	repo := store.NewAuditRepo(testPool)
+	ctx := context.Background()
+
+	tests := []struct {
+		name    string
+		entry   store.AuditEntry
+		wantErr bool
+	}{
+		{
+			name:    "valid entry inserts successfully",
+			entry:   validEntry("audit_001"),
+			wantErr: false,
+		},
+		{
+			name: "empty metadata is normalized to empty object",
+			entry: func() store.AuditEntry {
+				e := validEntry("audit_002")
+				e.Metadata = nil
+				return e
+			}(),
+			wantErr: false,
+		},
+		{
+			name: "duplicate primary key fails",
+			entry: func() store.AuditEntry {
+				e := validEntry("audit_001") // same ID as first test
+				e.TargetID = "veh_002"
+				return e
+			}(),
+			wantErr: true,
+		},
+		{
+			name: "mask_applied action is accepted",
+			entry: func() store.AuditEntry {
+				e := validEntry("audit_003")
+				e.Action = store.AuditActionMaskApplied
+				e.TargetType = "ws_broadcast"
+				e.Initiator = "system_auth"
+				return e
+			}(),
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := repo.InsertAuditLog(ctx, tt.entry)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			// Verify the row is queryable and persisted as written.
+			var (
+				gotAction     string
+				gotTargetType string
+				gotMetadata   json.RawMessage
+			)
+			row := testPool.QueryRow(ctx,
+				`SELECT "action", "targetType", "metadata"
+				 FROM "AuditLog" WHERE "id" = $1`,
+				tt.entry.ID)
+			if err := row.Scan(&gotAction, &gotTargetType, &gotMetadata); err != nil {
+				t.Fatalf("readback failed: %v", err)
+			}
+			if gotAction != string(tt.entry.Action) {
+				t.Errorf("action: got %q, want %q", gotAction, tt.entry.Action)
+			}
+			if gotTargetType != tt.entry.TargetType {
+				t.Errorf("targetType: got %q, want %q", gotTargetType, tt.entry.TargetType)
+			}
+			if len(gotMetadata) == 0 {
+				t.Errorf("metadata: got empty, want non-empty (default '{}')")
+			}
+		})
+	}
+}
+
+func TestAuditRepo_AppendOnlyTriggers(t *testing.T) {
+	if !dockerAvailable {
+		t.Skip("Docker not available; skipping AuditLog integration test")
+	}
+	ensureAuditSchema(t)
+	cleanAuditLog(t, testPool)
+
+	repo := store.NewAuditRepo(testPool)
+	ctx := context.Background()
+
+	// Seed one row that the trigger tests will try to mutate.
+	if err := repo.InsertAuditLog(ctx, validEntry("audit_trigger_001")); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	tests := []struct {
+		name    string
+		mutate  func(ctx context.Context) error
+		wantSub string
+	}{
+		{
+			name: "raw UPDATE is blocked by trigger",
+			mutate: func(ctx context.Context) error {
+				_, err := testPool.Exec(ctx,
+					`UPDATE "AuditLog" SET "action" = 'tampered'
+					 WHERE "id" = 'audit_trigger_001'`)
+				return err
+			},
+			wantSub: "append-only",
+		},
+		{
+			name: "raw DELETE is blocked by trigger",
+			mutate: func(ctx context.Context) error {
+				_, err := testPool.Exec(ctx,
+					`DELETE FROM "AuditLog" WHERE "id" = 'audit_trigger_001'`)
+				return err
+			},
+			wantSub: "append-only",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.mutate(ctx)
+			if err == nil {
+				t.Fatal("expected trigger exception, got nil")
+			}
+			if !strings.Contains(err.Error(), tt.wantSub) {
+				t.Fatalf("error %q does not contain %q", err.Error(), tt.wantSub)
+			}
+		})
+	}
+
+	// Sanity: the seeded row is still present after both rejected
+	// mutations. Append-only means UPDATE / DELETE are not just refused
+	// loudly but also leave the row unchanged.
+	var stillThere int
+	row := testPool.QueryRow(ctx,
+		`SELECT COUNT(*) FROM "AuditLog" WHERE "id" = 'audit_trigger_001'`)
+	if err := row.Scan(&stillThere); err != nil {
+		t.Fatalf("count query: %v", err)
+	}
+	if stillThere != 1 {
+		t.Fatalf("expected seeded row to survive failed mutations, got count=%d", stillThere)
+	}
+}
+
+func TestAuditRepo_NotNullColumnsRejectMissingValues(t *testing.T) {
+	if !dockerAvailable {
+		t.Skip("Docker not available; skipping AuditLog integration test")
+	}
+	ensureAuditSchema(t)
+	cleanAuditLog(t, testPool)
+
+	ctx := context.Background()
+
+	// Drive the NOT NULL constraints directly with raw SQL so the test is
+	// independent of any normalization the Go layer might do. Each
+	// statement omits or NULLs one required column. Postgres returns a
+	// "null value in column \"X\"" error for NOT NULL violations.
+	tests := []struct {
+		name    string
+		sql     string
+		args    []any
+		wantSub string
+	}{
+		{
+			name: "NULL userId is rejected",
+			sql: `INSERT INTO "AuditLog" ("id","userId","action","targetType","targetId","initiator")
+				  VALUES ($1, NULL, 'drives_pruned', 'drive', 'veh_001', 'system_pruner')`,
+			args:    []any{"audit_null_user"},
+			wantSub: "userId",
+		},
+		{
+			name: "NULL action is rejected",
+			sql: `INSERT INTO "AuditLog" ("id","userId","action","targetType","targetId","initiator")
+				  VALUES ($1, 'user_001', NULL, 'drive', 'veh_001', 'system_pruner')`,
+			args:    []any{"audit_null_action"},
+			wantSub: "action",
+		},
+		{
+			name: "NULL targetType is rejected",
+			sql: `INSERT INTO "AuditLog" ("id","userId","action","targetType","targetId","initiator")
+				  VALUES ($1, 'user_001', 'drives_pruned', NULL, 'veh_001', 'system_pruner')`,
+			args:    []any{"audit_null_target_type"},
+			wantSub: "targetType",
+		},
+		{
+			name: "NULL initiator is rejected",
+			sql: `INSERT INTO "AuditLog" ("id","userId","action","targetType","targetId","initiator")
+				  VALUES ($1, 'user_001', 'drives_pruned', 'drive', 'veh_001', NULL)`,
+			args:    []any{"audit_null_initiator"},
+			wantSub: "initiator",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := testPool.Exec(ctx, tt.sql, tt.args...)
+			if err == nil {
+				t.Fatal("expected NOT NULL violation, got nil")
+			}
+			if !strings.Contains(err.Error(), tt.wantSub) {
+				t.Fatalf("error %q does not mention column %q", err.Error(), tt.wantSub)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Phase 2 of MYR-70. Adds the Go side of the AuditLog table that Phase 1 (Next.js Prisma migration, cross-repo PR [#252](https://github.com/tnando/my-robo-taxi/pull/252)) provisioned. The Go telemetry server holds **Insert-only** access for system-initiated rows: `drives_pruned`, `mask_applied`, `tokens_refreshed`. User-initiated rows (e.g., `account_deleted` per FR-10.1) are written by the Next.js app inside its Prisma `$transaction`.

- `internal/store/audit_repo.go` — `AuditRepo` exposes only `InsertAuditLog`. No `Update` / `Delete` / `Get` / `List` methods exist by design. `AuditEntry` mirrors `prisma/schema.prisma` model `AuditLog` one-to-one. `AuditAction` typed-string constants for the four enum values the Go server emits.
- `internal/store/audit_repo_test.go` — testcontainers integration test. Embeds the AuditLog DDL inline (intentional duplicate of the Phase 1 `migration.sql`; documented in-line). Tests happy-path inserts, raw `UPDATE` blocked by trigger, raw `DELETE` blocked by trigger, and `NOT NULL` violations on every required column.
- `docs/contracts/data-lifecycle.md` §7 Rule **CG-DL-8** — new contract-guard rule for cross-repo column-list drift between the Prisma owner and the Go writer.
- `.github/workflows/contract-guard.yml` — CI step that fires when `internal/store/audit_repo.go` is in the diff: verifies the `CROSS-REPO COUPLING` header comment is intact and every Prisma column appears as a quoted identifier in the Go file.
- `.claude/agents/contract-guard.md` — Rule 9 added so the session-time agent reports drift in its pass/fail output.

## Cross-repo note

This PR is **independent** of the Phase 1 Prisma PR ([#252](https://github.com/tnando/my-robo-taxi/pull/252)). Phase 1 has already deployed the AuditLog table + indexes + append-only triggers to the dev DB (per the issue brief). This Phase 2 PR does NOT touch `../my-robo-taxi/`. The two PRs may merge in either order.

The append-only invariant is enforced at **two** layers:

1. **DB layer:** Phase 1's `prevent_audit_log_mutation()` + `prevent_audit_log_update` / `prevent_audit_log_delete` triggers raise `AuditLog rows are append-only` on any `UPDATE` or `DELETE`.
2. **Go API surface:** `AuditRepo` intentionally has no mutation methods. Adding one would require consciously editing the locked module — the cross-repo header comment makes the constraint discoverable.

## Test plan

- [x] `go vet ./...` — clean
- [x] `golangci-lint run ./...` — 0 issues
- [x] `go test ./...` — all packages pass (the AuditRepo integration tests skip locally because Docker isn't available; CI runs them)
- [x] `go build ./cmd/...` — clean
- [ ] CI: testcontainers-backed AuditRepo tests pass in GitHub Actions
- [ ] CI: contract-guard CG-DL-8 passes (header comment + column literals present)

## Contract Adherence

- **Contract docs touched:**
  - `docs/contracts/data-lifecycle.md` §7 — added Rule CG-DL-8 (cross-repo column-list drift).
- **Anchored requirements:** FR-10.2 (audit log completeness), NFR-3.29 (audit immutability and append-only enforcement).
- **Data classification:** all AuditLog columns are P0 per §4.4; the `metadata` JSONB has the §4.4 / CG-DL-5 P0-only constraint documented in the Go file's header comment.
- **Atomic groups:** N/A — AuditLog is a flat row, no atomic-group fields.
- **Cross-repo coupling:** authoritative schema lives in `tnando/my-robo-taxi` `prisma/schema.prisma`. The Go file's header comment names that file, the migration directory, and the column-by-column cross-walk; CG-DL-8 enforces this on every PR.
- **Append-only enforcement:** preserved at DB level (Phase 1 triggers) and API level (no mutation methods on `AuditRepo`).

## Out of scope (deferred to follow-on issues)

- Wiring the existing `mask_applied` audit-insert TODOs in `internal/ws/hub.go`, `internal/mask/audit.go`, and `internal/telemetry/vehicle_status_mask.go` — that's MYR-71's scope. This PR confirms the `AuditRepo` shape is usable from those call sites but does NOT modify them.
- Metadata-shape validation (CG-DL-5 runtime enforcement) — the brief calls this out as a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)