### PR TITLE
MYR-71 Wire mask_applied AuditLog inserts at WS + REST mask paths

### DIFF
--- a/cmd/telemetry-server/main.go
+++ b/cmd/telemetry-server/main.go
@@ -21,6 +21,7 @@ import (
 	"github.com/tnando/my-robo-taxi-telemetry/internal/drives"
 	"github.com/tnando/my-robo-taxi-telemetry/internal/events"
 	"github.com/tnando/my-robo-taxi-telemetry/internal/geocode"
+	"github.com/tnando/my-robo-taxi-telemetry/internal/mask"
 	"github.com/tnando/my-robo-taxi-telemetry/internal/server"
 	"github.com/tnando/my-robo-taxi-telemetry/internal/store"
 	"github.com/tnando/my-robo-taxi-telemetry/internal/telemetry"
@@ -142,6 +143,17 @@ func run() error { //nolint:funlen // composition root — sequential dependency
 	vehicleRepo := store.NewVehicleRepo(db.Pool(), store.NoopMetrics{})
 	driveRepo := store.NewDriveRepo(db.Pool(), store.NoopMetrics{})
 	accountRepo := store.NewAccountRepo(db.Pool())
+	auditRepo := store.NewAuditRepo(db.Pool())
+
+	// --- Mask-audit emitter (MYR-71, rest-api.md §5.3) ---
+	// MaskAuditEmitter adapts AuditRepo to the mask.AuditEmitter
+	// interface so the hub and any future REST mask paths can fire
+	// non-blocking audit rows. Prometheus counters
+	// telemetry_audit_log_writes_total{action,target} and
+	// telemetry_audit_log_write_failures_total{action,target} make
+	// the 1% sample rate observable in prod.
+	auditEmitter := store.NewMaskAuditEmitter(auditRepo)
+	auditMetrics := mask.NewPrometheusAuditMetrics(reg)
 
 	// --- Geocoder (optional — requires MAPBOX_TOKEN) ---
 	geo := newGeocoder(cfg.MapboxToken(), cfg.Drives().GeocodeTimeout, logger)
@@ -161,7 +173,15 @@ func run() error { //nolint:funlen // composition root — sequential dependency
 	defer func() { _ = writer.Stop() }()
 
 	// --- WebSocket hub + broadcaster ---
-	hub := ws.NewHub(logger.With(slog.String("component", "ws")), ws.NoopHubMetrics{})
+	// WithMaskAudit wires the per-(vehicleID, role, frame) mask audit
+	// emit at the hub layer per rest-api.md §5.3. The hub itself uses
+	// a per-vehicle in-process counter as frameSeq until DV-02 ships
+	// envelope sequence numbers.
+	hub := ws.NewHub(
+		logger.With(slog.String("component", "ws")),
+		ws.NoopHubMetrics{},
+		ws.WithMaskAudit(auditEmitter, auditMetrics),
+	)
 	defer hub.Stop()
 
 	// Shared VIN → (vehicleID, userID) cache backing the broadcaster and

--- a/internal/mask/audit.go
+++ b/internal/mask/audit.go
@@ -3,31 +3,14 @@ package mask
 import (
 	"context"
 	"crypto/rand"
-	"encoding/binary"
 	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
-	"hash/fnv"
-	"io"
-	"log/slog"
-	"strconv"
 	"time"
 
 	"github.com/tnando/my-robo-taxi-telemetry/internal/auth"
 )
-
-// Sampling rate for the mask audit log. Per docs/contracts/rest-api.md
-// §5.3, every masked response (REST or WS) MUST be audit-logged at a
-// 1% deterministic rate computed by hash modulo 100.
-const auditSampleModulus uint64 = 100
-
-// auditInsertTimeout caps the time a fire-and-forget Emit goroutine
-// will wait on an InsertAuditLog call. The hot path (BroadcastMasked
-// fan-out, REST response write) MUST NOT block on this; the goroutine
-// uses a detached context with this timeout so a stuck DB pool cannot
-// pile up audit goroutines forever.
-const auditInsertTimeout = 2 * time.Second
 
 // AuditChannel labels the audit row's transport. The set is closed at
 // the two transports a v1 mask projection can flow through.
@@ -224,91 +207,6 @@ func BuildEntry(
 	}, nil
 }
 
-// EmitAsync is the fire-and-forget wrapper around AuditEmitter.
-// Invariants required by the mask audit pipeline (rest-api.md §5.3,
-// data-lifecycle.md §4):
-//
-//   - Hot-path non-blocking: failures MUST NOT drop the masked frame
-//     or the REST response. EmitAsync returns immediately to the
-//     caller; the actual insert runs on a spawned goroutine.
-//   - Detached context: the caller's request context may be canceled
-//     mid-write (e.g., the HTTP client closes the connection). We
-//     use context.WithoutCancel + a 2 s timeout so the audit row
-//     still lands even after the caller's context dies.
-//   - Bounded latency: the 2 s timeout caps how long a stuck DB pool
-//     can keep an audit goroutine alive. Beyond that we increment the
-//     failure metric, log slog.Warn, and drop the row.
-//   - Metric coverage: every successful insert increments
-//     audit_log_writes_total{action, target}; every failure increments
-//     audit_log_write_failures_total{action, target}. The labels match
-//     the tuple of allow-listed enum values, so cardinality stays
-//     bounded.
-//
-// EmitAsync is a no-op if emitter is nil — the production wiring may
-// pass nil before the AuditRepo is composed (e.g., during dev mode
-// when the writer is intentionally disabled), and a no-op keeps the
-// hot path quiet rather than logging a flood of "audit emitter not
-// configured" warnings.
-func EmitAsync(
-	parent context.Context,
-	emitter AuditEmitter,
-	metrics AuditMetrics,
-	logger *slog.Logger,
-	entry AuditEntry,
-) {
-	if emitter == nil {
-		return
-	}
-	if metrics == nil {
-		metrics = NoopAuditMetrics{}
-	}
-	go emitDetached(parent, emitter, metrics, logger, entry)
-}
-
-// emitDetached runs the actual insert with a detached context. Split
-// out so EmitAsync remains trivial and tests can drive it directly.
-func emitDetached(
-	parent context.Context,
-	emitter AuditEmitter,
-	metrics AuditMetrics,
-	logger *slog.Logger,
-	entry AuditEntry,
-) {
-	defer func() {
-		// Recover from unexpected panics inside the emitter so a buggy
-		// implementation cannot crash the hot path's goroutine.
-		if r := recover(); r != nil {
-			metrics.IncAuditWriteFailure(entry.Action, entry.TargetType)
-			if logger != nil {
-				logger.Warn("mask.EmitAsync: emitter panicked",
-					slog.Any("recover", r),
-					slog.String("action", entry.Action),
-					slog.String("target_type", entry.TargetType),
-				)
-			}
-		}
-	}()
-
-	// Detach from the caller's request context — once we decide to
-	// emit, we follow through even if the caller cancels.
-	ctx := context.WithoutCancel(parent)
-	ctx, cancel := context.WithTimeout(ctx, auditInsertTimeout)
-	defer cancel()
-
-	if err := emitter.InsertAuditLog(ctx, entry); err != nil {
-		metrics.IncAuditWriteFailure(entry.Action, entry.TargetType)
-		if logger != nil {
-			logger.Warn("mask.EmitAsync: insert failed",
-				slog.String("action", entry.Action),
-				slog.String("target_type", entry.TargetType),
-				slog.String("error", err.Error()),
-			)
-		}
-		return
-	}
-	metrics.IncAuditWrite(entry.Action, entry.TargetType)
-}
-
 // auditIDPrefix is the leading character on every mask audit cuid
 // (matches the convention used elsewhere in the project's Prisma
 // tables — every cuid starts with `c`).
@@ -345,49 +243,4 @@ func allowedMetadataKeysIntersect(keys []string) bool {
 		}
 	}
 	return true
-}
-
-// ShouldAuditREST returns true when this REST response should be
-// emitted to the audit log. The decision is deterministic given the
-// inputs — replaying the same userID + requestID + resourceID will
-// always return the same boolean. Per rest-api.md §5.3, the inputs are
-// joined with a separator before hashing to avoid collisions across
-// distinct triples that share a concatenated form.
-func ShouldAuditREST(userID, requestID, resourceID string) bool {
-	h := fnv.New64a()
-	writeField(h, userID)
-	writeField(h, requestID)
-	writeField(h, resourceID)
-	return h.Sum64()%auditSampleModulus == 0
-}
-
-// ShouldAuditWS returns true when this WebSocket frame should be
-// audit-logged. Per rest-api.md §5.3, the WS audit emit is per
-// (vehicleID, role, frame) at the hub layer (NOT per client) — the
-// hash inputs reflect that scope.
-//
-// frameSeq SHOULD be the envelope sequence number once DV-02 lands.
-// Until then, callers can pass a per-vehicle monotonic counter — the
-// determinism only requires that the counter is reproducible during
-// replay.
-func ShouldAuditWS(vehicleID string, role auth.Role, frameSeq uint64) bool {
-	h := fnv.New64a()
-	writeField(h, vehicleID)
-	writeField(h, string(role))
-	var buf [8]byte
-	binary.BigEndian.PutUint64(buf[:], frameSeq)
-	_, _ = h.Write(buf[:])
-	return h.Sum64()%auditSampleModulus == 0
-}
-
-// writeField writes a length-prefixed string into the hash. The length
-// prefix prevents ambiguity between (e.g.) {"abc", "def"} and
-// {"ab", "cdef"} which would otherwise hash to the same byte sequence
-// when concatenated. `hash.Hash64` already implements `io.Writer`, so
-// the hasher is passed in directly without an inline anonymous
-// interface (PR #195 review suggestion #2).
-func writeField(h io.Writer, s string) {
-	_, _ = h.Write([]byte(strconv.Itoa(len(s))))
-	_, _ = h.Write([]byte(":"))
-	_, _ = h.Write([]byte(s))
 }

--- a/internal/mask/audit.go
+++ b/internal/mask/audit.go
@@ -1,10 +1,18 @@
 package mask
 
 import (
+	"context"
+	"crypto/rand"
 	"encoding/binary"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
 	"hash/fnv"
 	"io"
+	"log/slog"
 	"strconv"
+	"time"
 
 	"github.com/tnando/my-robo-taxi-telemetry/internal/auth"
 )
@@ -14,18 +22,337 @@ import (
 // 1% deterministic rate computed by hash modulo 100.
 const auditSampleModulus uint64 = 100
 
+// auditInsertTimeout caps the time a fire-and-forget Emit goroutine
+// will wait on an InsertAuditLog call. The hot path (BroadcastMasked
+// fan-out, REST response write) MUST NOT block on this; the goroutine
+// uses a detached context with this timeout so a stuck DB pool cannot
+// pile up audit goroutines forever.
+const auditInsertTimeout = 2 * time.Second
+
+// AuditChannel labels the audit row's transport. The set is closed at
+// the two transports a v1 mask projection can flow through.
+type AuditChannel string
+
+const (
+	// AuditChannelREST tags audit rows produced by the REST handler
+	// layer (rest-api.md §5.1).
+	AuditChannelREST AuditChannel = "rest"
+
+	// AuditChannelWS tags audit rows produced by the WebSocket hub's
+	// per-role projection (websocket-protocol.md §4.6).
+	AuditChannelWS AuditChannel = "ws"
+)
+
+// TargetType is the value written to AuditEntry.TargetType for a
+// mask_applied audit row. The two values mirror data-lifecycle.md §4.2
+// targetType enum entries paired with action="mask_applied".
+type TargetType string
+
+const (
+	// TargetWSBroadcast labels a WebSocket frame audit row.
+	TargetWSBroadcast TargetType = "ws_broadcast"
+
+	// TargetRESTResponse labels a REST response audit row.
+	TargetRESTResponse TargetType = "rest_response"
+)
+
+// ErrInvalidAuditMetadata is returned by BuildEntry when the supplied
+// metadata would violate the CG-DL-5 P0-only contract (e.g., an
+// unrecognized key that could carry a P1 value, or a fieldsMasked
+// element that contains P1-shaped content). Callers should treat this
+// as a programmer error — the helper guards against accidentally
+// stuffing a coordinate / address / token / email into metadata.
+var ErrInvalidAuditMetadata = errors.New("audit metadata violates P0-only contract")
+
+// AuditAction is the typed action label for a mask audit row. It maps
+// 1:1 onto store.AuditActionMaskApplied; the constant is duplicated
+// here so the mask package can build entries without depending on
+// internal/store (CLAUDE.md "interfaces at consumer site"). The two
+// strings MUST stay in lock-step — drift would only appear in
+// integration tests since the column is opaque text at the DB.
+const auditActionMaskApplied = "mask_applied"
+
+// auditInitiatorUser is the initiator value for mask audit rows.
+// Per data-lifecycle.md §4.2, "user" is the canonical initiator for
+// mask_applied (the consumer's request triggered the response).
+const auditInitiatorUser = "user"
+
+// AuditEntry mirrors store.AuditEntry without depending on it (the
+// mask package sits below store in the dependency rule). The fields
+// are a 1:1 column map of AuditLog per data-lifecycle.md §4.1 and the
+// concrete pgx writer in internal/store/audit_repo.go converts this
+// shape into its own AuditEntry before insertion.
+type AuditEntry struct {
+	ID         string
+	UserID     string
+	Timestamp  time.Time
+	Action     string
+	TargetType string
+	TargetID   string
+	Initiator  string
+	Metadata   json.RawMessage
+	CreatedAt  time.Time
+}
+
+// AuditEmitter is the consumer-site interface the mask package depends
+// on for audit-log persistence. Defined here so internal/mask does not
+// import internal/store; the production wiring in
+// cmd/telemetry-server/main.go provides an adapter that calls
+// store.AuditRepo.InsertAuditLog. Tests pass a fake.
+//
+// Implementations MUST be safe for concurrent use — Emit is invoked
+// from goroutines spawned per audit-sampled frame.
+type AuditEmitter interface {
+	InsertAuditLog(ctx context.Context, entry AuditEntry) error
+}
+
+// AuditMetrics records observability counters for audit-log writes.
+// Wired to Prometheus in production (see metrics.go) and to a no-op
+// in tests.
+type AuditMetrics interface {
+	// IncAuditWrite increments the success counter for an audit
+	// insert keyed by action + targetType.
+	IncAuditWrite(action, target string)
+
+	// IncAuditWriteFailure increments the failure counter for an
+	// audit insert keyed by action + targetType. The error itself
+	// is NOT logged at metric label cardinality — error labels are
+	// high-cardinality and would blow up Prometheus storage.
+	IncAuditWriteFailure(action, target string)
+}
+
+// NoopAuditMetrics is a zero-cost AuditMetrics that drops every call.
+// Use it in tests or when Prometheus is not configured.
+type NoopAuditMetrics struct{}
+
+var _ AuditMetrics = NoopAuditMetrics{}
+
+// IncAuditWrite implements AuditMetrics.
+func (NoopAuditMetrics) IncAuditWrite(string, string) {}
+
+// IncAuditWriteFailure implements AuditMetrics.
+func (NoopAuditMetrics) IncAuditWriteFailure(string, string) {}
+
+// allowedMetadataKeys is the cheap allow-list enforced by BuildEntry
+// before encoding metadata to JSON. CG-DL-5 forbids P1 values in
+// metadata; restricting the key set to a closed enum makes it
+// impossible for a future caller to add e.g. a `userEmail` or
+// `homeAddress` field without an explicit contract update here. The
+// shape mirrors the metadata example in rest-api.md §5.3.
+var allowedMetadataKeys = map[string]struct{}{
+	"role":         {},
+	"channel":      {},
+	"fieldsMasked": {},
+	"endpoint":     {},
+}
+
+// auditMetadata is the strict shape written to AuditEntry.Metadata.
+// Marshaling through this struct (rather than a free-form map[string]
+// any) means CG-DL-5 violations like accidentally embedding a
+// coordinate or address in metadata cannot compile. The JSON tags
+// mirror the rest-api.md §5.3 example exactly.
+type auditMetadata struct {
+	Role         string   `json:"role"`
+	Channel      string   `json:"channel"`
+	FieldsMasked []string `json:"fieldsMasked"`
+	Endpoint     string   `json:"endpoint,omitempty"`
+}
+
+// BuildEntry constructs an AuditEntry for a mask_applied row. The
+// caller supplies the per-event details; this helper handles ID
+// generation, timestamp population, metadata marshaling, and the
+// CG-DL-5 P0-only metadata invariant.
+//
+// Field semantics:
+//   - userID: for REST, the authenticated caller. For WS, an empty
+//     string — the WS audit emit is per (vehicleID, role, frame) at
+//     the hub, not per client (rest-api.md §5.3). NOT NULL is satisfied
+//     by Postgres; an empty string is the correct sentinel.
+//   - target: TargetWSBroadcast or TargetRESTResponse.
+//   - targetID: the vehicleID (or driveID) whose response was masked.
+//   - role: the role for which the projection ran.
+//   - channel: AuditChannelREST or AuditChannelWS.
+//   - fieldsMasked: the list of removed field names (P0 — names only,
+//     never values).
+//   - endpoint: optional — for REST, a route pattern like
+//     "/api/vehicles/{vehicleId}/snapshot" (NOT a substituted URL,
+//     which would carry a vehicleID into metadata when targetID
+//     already covers that). For WS, leave empty.
+//
+// The empty fieldsMasked is rejected — the contract only emits an
+// audit row when the mask removed at least one field.
+func BuildEntry(
+	userID string,
+	target TargetType,
+	targetID string,
+	role auth.Role,
+	channel AuditChannel,
+	fieldsMasked []string,
+	endpoint string,
+) (AuditEntry, error) {
+	if len(fieldsMasked) == 0 {
+		return AuditEntry{}, fmt.Errorf("mask.BuildEntry: %w: fieldsMasked is empty", ErrInvalidAuditMetadata)
+	}
+	for _, name := range fieldsMasked {
+		if name == "" {
+			return AuditEntry{}, fmt.Errorf("mask.BuildEntry: %w: fieldsMasked contains empty entry", ErrInvalidAuditMetadata)
+		}
+	}
+
+	meta := auditMetadata{
+		Role:         string(role),
+		Channel:      string(channel),
+		FieldsMasked: fieldsMasked,
+		Endpoint:     endpoint,
+	}
+	encoded, err := json.Marshal(meta)
+	if err != nil {
+		return AuditEntry{}, fmt.Errorf("mask.BuildEntry: marshal metadata: %w", err)
+	}
+
+	now := time.Now().UTC()
+	return AuditEntry{
+		ID:         newAuditID(),
+		UserID:     userID,
+		Timestamp:  now,
+		Action:     auditActionMaskApplied,
+		TargetType: string(target),
+		TargetID:   targetID,
+		Initiator:  auditInitiatorUser,
+		Metadata:   encoded,
+		CreatedAt:  now,
+	}, nil
+}
+
+// EmitAsync is the fire-and-forget wrapper around AuditEmitter.
+// Invariants required by the mask audit pipeline (rest-api.md §5.3,
+// data-lifecycle.md §4):
+//
+//   - Hot-path non-blocking: failures MUST NOT drop the masked frame
+//     or the REST response. EmitAsync returns immediately to the
+//     caller; the actual insert runs on a spawned goroutine.
+//   - Detached context: the caller's request context may be canceled
+//     mid-write (e.g., the HTTP client closes the connection). We
+//     use context.WithoutCancel + a 2 s timeout so the audit row
+//     still lands even after the caller's context dies.
+//   - Bounded latency: the 2 s timeout caps how long a stuck DB pool
+//     can keep an audit goroutine alive. Beyond that we increment the
+//     failure metric, log slog.Warn, and drop the row.
+//   - Metric coverage: every successful insert increments
+//     audit_log_writes_total{action, target}; every failure increments
+//     audit_log_write_failures_total{action, target}. The labels match
+//     the tuple of allow-listed enum values, so cardinality stays
+//     bounded.
+//
+// EmitAsync is a no-op if emitter is nil — the production wiring may
+// pass nil before the AuditRepo is composed (e.g., during dev mode
+// when the writer is intentionally disabled), and a no-op keeps the
+// hot path quiet rather than logging a flood of "audit emitter not
+// configured" warnings.
+func EmitAsync(
+	parent context.Context,
+	emitter AuditEmitter,
+	metrics AuditMetrics,
+	logger *slog.Logger,
+	entry AuditEntry,
+) {
+	if emitter == nil {
+		return
+	}
+	if metrics == nil {
+		metrics = NoopAuditMetrics{}
+	}
+	go emitDetached(parent, emitter, metrics, logger, entry)
+}
+
+// emitDetached runs the actual insert with a detached context. Split
+// out so EmitAsync remains trivial and tests can drive it directly.
+func emitDetached(
+	parent context.Context,
+	emitter AuditEmitter,
+	metrics AuditMetrics,
+	logger *slog.Logger,
+	entry AuditEntry,
+) {
+	defer func() {
+		// Recover from unexpected panics inside the emitter so a buggy
+		// implementation cannot crash the hot path's goroutine.
+		if r := recover(); r != nil {
+			metrics.IncAuditWriteFailure(entry.Action, entry.TargetType)
+			if logger != nil {
+				logger.Warn("mask.EmitAsync: emitter panicked",
+					slog.Any("recover", r),
+					slog.String("action", entry.Action),
+					slog.String("target_type", entry.TargetType),
+				)
+			}
+		}
+	}()
+
+	// Detach from the caller's request context — once we decide to
+	// emit, we follow through even if the caller cancels.
+	ctx := context.WithoutCancel(parent)
+	ctx, cancel := context.WithTimeout(ctx, auditInsertTimeout)
+	defer cancel()
+
+	if err := emitter.InsertAuditLog(ctx, entry); err != nil {
+		metrics.IncAuditWriteFailure(entry.Action, entry.TargetType)
+		if logger != nil {
+			logger.Warn("mask.EmitAsync: insert failed",
+				slog.String("action", entry.Action),
+				slog.String("target_type", entry.TargetType),
+				slog.String("error", err.Error()),
+			)
+		}
+		return
+	}
+	metrics.IncAuditWrite(entry.Action, entry.TargetType)
+}
+
+// auditIDPrefix is the leading character on every mask audit cuid
+// (matches the convention used elsewhere in the project's Prisma
+// tables — every cuid starts with `c`).
+const auditIDPrefix = "c"
+
+// auditIDRandomBytes is the number of random bytes hex-encoded into
+// the cuid suffix. 16 bytes -> 32 hex chars + 1 "c" prefix = 33-char
+// id, which is within the typical cuid length envelope and
+// collision-free at our event volume.
+const auditIDRandomBytes = 16
+
+// newAuditID generates a caller-provided cuid for a mask audit row.
+// Crypto-strong randomness avoids predictable IDs; the "c" prefix
+// matches the cuid mental model documented at the top of
+// internal/store/audit_repo.go.
+func newAuditID() string {
+	b := make([]byte, auditIDRandomBytes)
+	if _, err := rand.Read(b); err != nil {
+		// Crypto/rand only fails when the OS RNG is unavailable, which
+		// is unrecoverable. Fall back to a timestamp-derived ID rather
+		// than panic — the audit row is still useful.
+		return fmt.Sprintf("%s%x", auditIDPrefix, time.Now().UnixNano())
+	}
+	return auditIDPrefix + hex.EncodeToString(b)
+}
+
+// allowedMetadataKeysIntersect reports whether decoded keys is a
+// subset of allowedMetadataKeys. Used by tests to assert no unknown
+// keys leak into a built entry.
+func allowedMetadataKeysIntersect(keys []string) bool {
+	for _, k := range keys {
+		if _, ok := allowedMetadataKeys[k]; !ok {
+			return false
+		}
+	}
+	return true
+}
+
 // ShouldAuditREST returns true when this REST response should be
 // emitted to the audit log. The decision is deterministic given the
 // inputs — replaying the same userID + requestID + resourceID will
 // always return the same boolean. Per rest-api.md §5.3, the inputs are
 // joined with a separator before hashing to avoid collisions across
 // distinct triples that share a concatenated form.
-//
-// CALLERS: this is a pure helper today. The audit-log emit pipeline is
-// deferred (no AuditLog table in Prisma yet — see data-lifecycle.md §4
-// and the TODOs in internal/ws/hub.go and internal/telemetry/
-// vehicle_status_handler.go). Wire this up the moment the migration
-// lands.
 func ShouldAuditREST(userID, requestID, resourceID string) bool {
 	h := fnv.New64a()
 	writeField(h, userID)

--- a/internal/mask/audit_emit.go
+++ b/internal/mask/audit_emit.go
@@ -1,0 +1,99 @@
+package mask
+
+import (
+	"context"
+	"log/slog"
+	"time"
+)
+
+// auditInsertTimeout caps the time a fire-and-forget Emit goroutine
+// will wait on an InsertAuditLog call. The hot path (BroadcastMasked
+// fan-out, REST response write) MUST NOT block on this; the goroutine
+// uses a detached context with this timeout so a stuck DB pool cannot
+// pile up audit goroutines forever.
+const auditInsertTimeout = 2 * time.Second
+
+// EmitAsync is the fire-and-forget wrapper around AuditEmitter.
+// Invariants required by the mask audit pipeline (rest-api.md §5.3,
+// data-lifecycle.md §4):
+//
+//   - Hot-path non-blocking: failures MUST NOT drop the masked frame
+//     or the REST response. EmitAsync returns immediately to the
+//     caller; the actual insert runs on a spawned goroutine.
+//   - Detached context: the caller's request context may be canceled
+//     mid-write (e.g., the HTTP client closes the connection). We
+//     use context.WithoutCancel + a 2 s timeout so the audit row
+//     still lands even after the caller's context dies.
+//   - Bounded latency: the 2 s timeout caps how long a stuck DB pool
+//     can keep an audit goroutine alive. Beyond that we increment the
+//     failure metric, log slog.Warn, and drop the row.
+//   - Metric coverage: every successful insert increments
+//     audit_log_writes_total{action, target}; every failure increments
+//     audit_log_write_failures_total{action, target}. The labels match
+//     the tuple of allow-listed enum values, so cardinality stays
+//     bounded.
+//
+// EmitAsync is a no-op if emitter is nil — the production wiring may
+// pass nil before the AuditRepo is composed (e.g., during dev mode
+// when the writer is intentionally disabled), and a no-op keeps the
+// hot path quiet rather than logging a flood of "audit emitter not
+// configured" warnings.
+func EmitAsync(
+	parent context.Context,
+	emitter AuditEmitter,
+	metrics AuditMetrics,
+	logger *slog.Logger,
+	entry AuditEntry,
+) {
+	if emitter == nil {
+		return
+	}
+	if metrics == nil {
+		metrics = NoopAuditMetrics{}
+	}
+	go emitDetached(parent, emitter, metrics, logger, entry)
+}
+
+// emitDetached runs the actual insert with a detached context. Split
+// out so EmitAsync remains trivial and tests can drive it directly.
+func emitDetached(
+	parent context.Context,
+	emitter AuditEmitter,
+	metrics AuditMetrics,
+	logger *slog.Logger,
+	entry AuditEntry,
+) {
+	defer func() {
+		// Recover from unexpected panics inside the emitter so a buggy
+		// implementation cannot crash the hot path's goroutine.
+		if r := recover(); r != nil {
+			metrics.IncAuditWriteFailure(entry.Action, entry.TargetType)
+			if logger != nil {
+				logger.Warn("mask.EmitAsync: emitter panicked",
+					slog.Any("recover", r),
+					slog.String("action", entry.Action),
+					slog.String("target_type", entry.TargetType),
+				)
+			}
+		}
+	}()
+
+	// Detach from the caller's request context — once we decide to
+	// emit, we follow through even if the caller cancels.
+	ctx := context.WithoutCancel(parent)
+	ctx, cancel := context.WithTimeout(ctx, auditInsertTimeout)
+	defer cancel()
+
+	if err := emitter.InsertAuditLog(ctx, entry); err != nil {
+		metrics.IncAuditWriteFailure(entry.Action, entry.TargetType)
+		if logger != nil {
+			logger.Warn("mask.EmitAsync: insert failed",
+				slog.String("action", entry.Action),
+				slog.String("target_type", entry.TargetType),
+				slog.String("error", err.Error()),
+			)
+		}
+		return
+	}
+	metrics.IncAuditWrite(entry.Action, entry.TargetType)
+}

--- a/internal/mask/audit_sampling.go
+++ b/internal/mask/audit_sampling.go
@@ -1,0 +1,60 @@
+package mask
+
+import (
+	"encoding/binary"
+	"hash/fnv"
+	"io"
+	"strconv"
+
+	"github.com/tnando/my-robo-taxi-telemetry/internal/auth"
+)
+
+// Sampling rate for the mask audit log. Per docs/contracts/rest-api.md
+// §5.3, every masked response (REST or WS) MUST be audit-logged at a
+// 1% deterministic rate computed by hash modulo 100.
+const auditSampleModulus uint64 = 100
+
+// ShouldAuditREST returns true when this REST response should be
+// emitted to the audit log. The decision is deterministic given the
+// inputs — replaying the same userID + requestID + resourceID will
+// always return the same boolean. Per rest-api.md §5.3, the inputs are
+// joined with a separator before hashing to avoid collisions across
+// distinct triples that share a concatenated form.
+func ShouldAuditREST(userID, requestID, resourceID string) bool {
+	h := fnv.New64a()
+	writeField(h, userID)
+	writeField(h, requestID)
+	writeField(h, resourceID)
+	return h.Sum64()%auditSampleModulus == 0
+}
+
+// ShouldAuditWS returns true when this WebSocket frame should be
+// audit-logged. Per rest-api.md §5.3, the WS audit emit is per
+// (vehicleID, role, frame) at the hub layer (NOT per client) — the
+// hash inputs reflect that scope.
+//
+// frameSeq SHOULD be the envelope sequence number once DV-02 lands.
+// Until then, callers can pass a per-vehicle monotonic counter — the
+// determinism only requires that the counter is reproducible during
+// replay.
+func ShouldAuditWS(vehicleID string, role auth.Role, frameSeq uint64) bool {
+	h := fnv.New64a()
+	writeField(h, vehicleID)
+	writeField(h, string(role))
+	var buf [8]byte
+	binary.BigEndian.PutUint64(buf[:], frameSeq)
+	_, _ = h.Write(buf[:])
+	return h.Sum64()%auditSampleModulus == 0
+}
+
+// writeField writes a length-prefixed string into the hash. The length
+// prefix prevents ambiguity between (e.g.) {"abc", "def"} and
+// {"ab", "cdef"} which would otherwise hash to the same byte sequence
+// when concatenated. `hash.Hash64` already implements `io.Writer`, so
+// the hasher is passed in directly without an inline anonymous
+// interface (PR #195 review suggestion #2).
+func writeField(h io.Writer, s string) {
+	_, _ = h.Write([]byte(strconv.Itoa(len(s))))
+	_, _ = h.Write([]byte(":"))
+	_, _ = h.Write([]byte(s))
+}

--- a/internal/mask/audit_test.go
+++ b/internal/mask/audit_test.go
@@ -1,8 +1,16 @@
 package mask
 
 import (
+	"context"
+	"encoding/json"
+	"errors"
 	"fmt"
+	"log/slog"
+	"strings"
+	"sync"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/tnando/my-robo-taxi-telemetry/internal/auth"
 )
@@ -98,5 +106,349 @@ func TestShouldAuditREST_DiffersAcrossInputs(t *testing.T) {
 	}
 	if hits == 0 || misses == 0 {
 		t.Errorf("expected both true and false outcomes; hits=%d misses=%d", hits, misses)
+	}
+}
+
+func TestBuildEntry_HappyPath(t *testing.T) {
+	entry, err := BuildEntry(
+		"user-1",
+		TargetWSBroadcast,
+		"vehicle-1",
+		auth.RoleViewer,
+		AuditChannelWS,
+		[]string{"licensePlate"},
+		"",
+	)
+	if err != nil {
+		t.Fatalf("BuildEntry: %v", err)
+	}
+	if entry.Action != "mask_applied" {
+		t.Errorf("Action = %q, want %q", entry.Action, "mask_applied")
+	}
+	if entry.TargetType != string(TargetWSBroadcast) {
+		t.Errorf("TargetType = %q, want %q", entry.TargetType, TargetWSBroadcast)
+	}
+	if entry.TargetID != "vehicle-1" {
+		t.Errorf("TargetID = %q, want vehicle-1", entry.TargetID)
+	}
+	if entry.UserID != "user-1" {
+		t.Errorf("UserID = %q, want user-1", entry.UserID)
+	}
+	if entry.Initiator != "user" {
+		t.Errorf("Initiator = %q, want user", entry.Initiator)
+	}
+	if entry.ID == "" {
+		t.Error("ID must be populated")
+	}
+	if !strings.HasPrefix(entry.ID, "c") {
+		t.Errorf("ID = %q, want cuid-shaped (c<hex>)", entry.ID)
+	}
+	if entry.Timestamp.IsZero() || entry.CreatedAt.IsZero() {
+		t.Error("Timestamp and CreatedAt must be populated")
+	}
+
+	var meta map[string]any
+	if err := json.Unmarshal(entry.Metadata, &meta); err != nil {
+		t.Fatalf("unmarshal metadata: %v", err)
+	}
+	for k := range meta {
+		if _, ok := allowedMetadataKeys[k]; !ok {
+			t.Errorf("metadata key %q is NOT in the allow-list — CG-DL-5 risk", k)
+		}
+	}
+	if meta["role"] != string(auth.RoleViewer) {
+		t.Errorf("metadata.role = %v, want %q", meta["role"], auth.RoleViewer)
+	}
+	if meta["channel"] != string(AuditChannelWS) {
+		t.Errorf("metadata.channel = %v, want %q", meta["channel"], AuditChannelWS)
+	}
+}
+
+func TestBuildEntry_RejectsEmptyFieldsMasked(t *testing.T) {
+	tests := []struct {
+		name    string
+		fields  []string
+		wantErr error
+	}{
+		{name: "nil fieldsMasked", fields: nil, wantErr: ErrInvalidAuditMetadata},
+		{name: "empty fieldsMasked", fields: []string{}, wantErr: ErrInvalidAuditMetadata},
+		{name: "empty entry inside fieldsMasked", fields: []string{"licensePlate", ""}, wantErr: ErrInvalidAuditMetadata},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := BuildEntry(
+				"user-1",
+				TargetRESTResponse,
+				"vehicle-1",
+				auth.RoleOwner,
+				AuditChannelREST,
+				tt.fields,
+				"/api/vehicles/{vehicleId}/snapshot",
+			)
+			if !errors.Is(err, tt.wantErr) {
+				t.Fatalf("err = %v, want errors.Is(%v)", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestBuildEntry_RESTEndpointIsRoutePattern(t *testing.T) {
+	// rest-api.md §5.3 example shows the endpoint as a parameterized
+	// route pattern, NOT a substituted URL. Substituting the vehicleId
+	// would put the same opaque ID into both targetId AND metadata,
+	// which is harmless but redundant. The contract example uses
+	// "{vehicleId}". Verify BuildEntry preserves whatever the caller
+	// passed without surprise transformations.
+	entry, err := BuildEntry(
+		"user-1",
+		TargetRESTResponse,
+		"vehicle-cuid",
+		auth.RoleViewer,
+		AuditChannelREST,
+		[]string{"licensePlate"},
+		"/api/vehicles/{vehicleId}/snapshot",
+	)
+	if err != nil {
+		t.Fatalf("BuildEntry: %v", err)
+	}
+
+	var meta map[string]any
+	if err := json.Unmarshal(entry.Metadata, &meta); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if meta["endpoint"] != "/api/vehicles/{vehicleId}/snapshot" {
+		t.Errorf("metadata.endpoint = %v, want route pattern", meta["endpoint"])
+	}
+}
+
+func TestAllowedMetadataKeysIntersect(t *testing.T) {
+	tests := []struct {
+		name string
+		keys []string
+		want bool
+	}{
+		{name: "all allowed", keys: []string{"role", "channel", "fieldsMasked", "endpoint"}, want: true},
+		{name: "subset", keys: []string{"role", "fieldsMasked"}, want: true},
+		{name: "empty", keys: nil, want: true},
+		{name: "unknown key rejected", keys: []string{"role", "userEmail"}, want: false},
+		{name: "p1-shaped key rejected", keys: []string{"latitude"}, want: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := allowedMetadataKeysIntersect(tt.keys); got != tt.want {
+				t.Errorf("allowedMetadataKeysIntersect(%v) = %v, want %v", tt.keys, got, tt.want)
+			}
+		})
+	}
+}
+
+// fakeAuditEmitter is a test AuditEmitter that records calls and can
+// inject errors / panics.
+type fakeAuditEmitter struct {
+	mu      sync.Mutex
+	entries []AuditEntry
+	err     error
+	panicOn bool
+	signal  chan struct{}
+}
+
+func newFakeAuditEmitter() *fakeAuditEmitter {
+	return &fakeAuditEmitter{signal: make(chan struct{}, 16)}
+}
+
+func (f *fakeAuditEmitter) InsertAuditLog(_ context.Context, entry AuditEntry) error {
+	if f.panicOn {
+		panic("simulated emitter panic")
+	}
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.entries = append(f.entries, entry)
+	// Non-blocking signal so the test can wait for completion.
+	select {
+	case f.signal <- struct{}{}:
+	default:
+	}
+	return f.err
+}
+
+func (f *fakeAuditEmitter) snapshot() []AuditEntry {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	out := make([]AuditEntry, len(f.entries))
+	copy(out, f.entries)
+	return out
+}
+
+// fakeAuditMetrics counts successful and failed audit writes.
+type fakeAuditMetrics struct {
+	writes   atomic.Int64
+	failures atomic.Int64
+}
+
+func (f *fakeAuditMetrics) IncAuditWrite(string, string)        { f.writes.Add(1) }
+func (f *fakeAuditMetrics) IncAuditWriteFailure(string, string) { f.failures.Add(1) }
+
+// waitForCount polls until predicate returns true, or fails the test
+// after a generous deadline. Avoids fragile time.Sleep races on the
+// fire-and-forget Emit goroutine.
+func waitForCount(t *testing.T, name string, deadline time.Duration, want int, count func() int) {
+	t.Helper()
+	timeout := time.After(deadline)
+	tick := time.NewTicker(2 * time.Millisecond)
+	defer tick.Stop()
+	for {
+		if count() == want {
+			return
+		}
+		select {
+		case <-timeout:
+			t.Fatalf("%s: timed out waiting for count=%d, got %d", name, want, count())
+		case <-tick.C:
+		}
+	}
+}
+
+func TestEmitAsync_HappyPath(t *testing.T) {
+	emitter := newFakeAuditEmitter()
+	metrics := &fakeAuditMetrics{}
+
+	entry, err := BuildEntry(
+		"user-1",
+		TargetRESTResponse,
+		"vehicle-1",
+		auth.RoleViewer,
+		AuditChannelREST,
+		[]string{"licensePlate"},
+		"/api/vehicles/{vehicleId}/snapshot",
+	)
+	if err != nil {
+		t.Fatalf("BuildEntry: %v", err)
+	}
+
+	EmitAsync(context.Background(), emitter, metrics, slog.Default(), entry)
+
+	waitForCount(t, "emitter.entries", time.Second, 1, func() int { return len(emitter.snapshot()) })
+	waitForCount(t, "metrics.writes", time.Second, 1, func() int { return int(metrics.writes.Load()) })
+	if got := metrics.failures.Load(); got != 0 {
+		t.Errorf("expected 0 failures, got %d", got)
+	}
+}
+
+func TestEmitAsync_NilEmitterIsNoop(t *testing.T) {
+	// Pass nil — must not panic, must not increment metrics.
+	metrics := &fakeAuditMetrics{}
+
+	entry, err := BuildEntry(
+		"user-1",
+		TargetWSBroadcast,
+		"vehicle-1",
+		auth.RoleViewer,
+		AuditChannelWS,
+		[]string{"licensePlate"},
+		"",
+	)
+	if err != nil {
+		t.Fatalf("BuildEntry: %v", err)
+	}
+
+	EmitAsync(context.Background(), nil, metrics, slog.Default(), entry)
+
+	// Wait a tick to confirm no goroutine fired.
+	time.Sleep(10 * time.Millisecond)
+	if got := metrics.writes.Load(); got != 0 {
+		t.Errorf("nil emitter wrote metrics: writes=%d", got)
+	}
+	if got := metrics.failures.Load(); got != 0 {
+		t.Errorf("nil emitter wrote metrics: failures=%d", got)
+	}
+}
+
+func TestEmitAsync_InsertErrorIncrementsFailureMetric(t *testing.T) {
+	emitter := newFakeAuditEmitter()
+	emitter.err = errors.New("simulated DB failure")
+	metrics := &fakeAuditMetrics{}
+
+	entry, err := BuildEntry(
+		"user-1",
+		TargetWSBroadcast,
+		"vehicle-1",
+		auth.RoleViewer,
+		AuditChannelWS,
+		[]string{"licensePlate"},
+		"",
+	)
+	if err != nil {
+		t.Fatalf("BuildEntry: %v", err)
+	}
+
+	EmitAsync(context.Background(), emitter, metrics, slog.Default(), entry)
+
+	waitForCount(t, "metrics.failures", time.Second, 1, func() int { return int(metrics.failures.Load()) })
+	if got := metrics.writes.Load(); got != 0 {
+		t.Errorf("expected 0 writes on error, got %d", got)
+	}
+}
+
+func TestEmitAsync_PanicInEmitterIncrementsFailureMetric(t *testing.T) {
+	emitter := newFakeAuditEmitter()
+	emitter.panicOn = true
+	metrics := &fakeAuditMetrics{}
+
+	entry, err := BuildEntry(
+		"user-1",
+		TargetWSBroadcast,
+		"vehicle-1",
+		auth.RoleViewer,
+		AuditChannelWS,
+		[]string{"licensePlate"},
+		"",
+	)
+	if err != nil {
+		t.Fatalf("BuildEntry: %v", err)
+	}
+
+	// Must not panic the test process.
+	EmitAsync(context.Background(), emitter, metrics, slog.Default(), entry)
+
+	waitForCount(t, "metrics.failures", time.Second, 1, func() int { return int(metrics.failures.Load()) })
+}
+
+func TestEmitAsync_DetachedFromCanceledContext(t *testing.T) {
+	emitter := newFakeAuditEmitter()
+	metrics := &fakeAuditMetrics{}
+
+	entry, err := BuildEntry(
+		"user-1",
+		TargetRESTResponse,
+		"vehicle-1",
+		auth.RoleViewer,
+		AuditChannelREST,
+		[]string{"licensePlate"},
+		"/api/vehicles/{vehicleId}/snapshot",
+	)
+	if err != nil {
+		t.Fatalf("BuildEntry: %v", err)
+	}
+
+	// Cancel the parent context BEFORE invoking EmitAsync. The detached
+	// context inside emitDetached must keep going.
+	parent, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	EmitAsync(parent, emitter, metrics, slog.Default(), entry)
+
+	waitForCount(t, "emitter.entries", time.Second, 1, func() int { return len(emitter.snapshot()) })
+}
+
+func TestEmitAsync_NewAuditID_IsCuidShaped(t *testing.T) {
+	// Sanity: a newAuditID looks like a cuid (starts with "c", is 33
+	// chars or so, hex after the prefix).
+	id := newAuditID()
+	if !strings.HasPrefix(id, "c") {
+		t.Fatalf("id = %q does not start with c", id)
+	}
+	// 1 (prefix) + 32 hex chars = 33 chars when 16 random bytes succeed.
+	if len(id) != 33 {
+		t.Errorf("id length = %d, want 33", len(id))
 	}
 }

--- a/internal/mask/audit_test.go
+++ b/internal/mask/audit_test.go
@@ -353,8 +353,18 @@ func TestEmitAsync_NilEmitterIsNoop(t *testing.T) {
 
 	EmitAsync(context.Background(), nil, metrics, slog.Default(), entry)
 
-	// Wait a tick to confirm no goroutine fired.
-	time.Sleep(10 * time.Millisecond)
+	// Nil-emitter path is synchronous (the early-return branch runs
+	// on the calling goroutine — no `go ...` is fired), so the
+	// assertion can happen immediately. No Sleep race to wait out.
+	// To prove the synchronous claim, drive a real emitter through
+	// EmitAsync afterward and waitForCount on it: once the
+	// fakeEmitter ticks, every goroutine queued so far has run, and
+	// our metrics counters above remain at zero.
+	control := newFakeAuditEmitter()
+	controlMetrics := &fakeAuditMetrics{}
+	EmitAsync(context.Background(), control, controlMetrics, slog.Default(), entry)
+	waitForCount(t, "control.entries", func() int { return len(control.snapshot()) })
+
 	if got := metrics.writes.Load(); got != 0 {
 		t.Errorf("nil emitter wrote metrics: writes=%d", got)
 	}

--- a/internal/mask/audit_test.go
+++ b/internal/mask/audit_test.go
@@ -291,18 +291,18 @@ func (f *fakeAuditMetrics) IncAuditWriteFailure(string, string) { f.failures.Add
 // waitForCount polls until predicate returns true, or fails the test
 // after a generous deadline. Avoids fragile time.Sleep races on the
 // fire-and-forget Emit goroutine.
-func waitForCount(t *testing.T, name string, deadline time.Duration, want int, count func() int) {
+func waitForCount(t *testing.T, name string, count func() int) {
 	t.Helper()
-	timeout := time.After(deadline)
+	timeout := time.After(time.Second)
 	tick := time.NewTicker(2 * time.Millisecond)
 	defer tick.Stop()
 	for {
-		if count() == want {
+		if count() == 1 {
 			return
 		}
 		select {
 		case <-timeout:
-			t.Fatalf("%s: timed out waiting for count=%d, got %d", name, want, count())
+			t.Fatalf("%s: timed out waiting for count=1, got %d", name, count())
 		case <-tick.C:
 		}
 	}
@@ -327,8 +327,8 @@ func TestEmitAsync_HappyPath(t *testing.T) {
 
 	EmitAsync(context.Background(), emitter, metrics, slog.Default(), entry)
 
-	waitForCount(t, "emitter.entries", time.Second, 1, func() int { return len(emitter.snapshot()) })
-	waitForCount(t, "metrics.writes", time.Second, 1, func() int { return int(metrics.writes.Load()) })
+	waitForCount(t, "emitter.entries", func() int { return len(emitter.snapshot()) })
+	waitForCount(t, "metrics.writes", func() int { return int(metrics.writes.Load()) })
 	if got := metrics.failures.Load(); got != 0 {
 		t.Errorf("expected 0 failures, got %d", got)
 	}
@@ -383,7 +383,7 @@ func TestEmitAsync_InsertErrorIncrementsFailureMetric(t *testing.T) {
 
 	EmitAsync(context.Background(), emitter, metrics, slog.Default(), entry)
 
-	waitForCount(t, "metrics.failures", time.Second, 1, func() int { return int(metrics.failures.Load()) })
+	waitForCount(t, "metrics.failures", func() int { return int(metrics.failures.Load()) })
 	if got := metrics.writes.Load(); got != 0 {
 		t.Errorf("expected 0 writes on error, got %d", got)
 	}
@@ -410,7 +410,7 @@ func TestEmitAsync_PanicInEmitterIncrementsFailureMetric(t *testing.T) {
 	// Must not panic the test process.
 	EmitAsync(context.Background(), emitter, metrics, slog.Default(), entry)
 
-	waitForCount(t, "metrics.failures", time.Second, 1, func() int { return int(metrics.failures.Load()) })
+	waitForCount(t, "metrics.failures", func() int { return int(metrics.failures.Load()) })
 }
 
 func TestEmitAsync_DetachedFromCanceledContext(t *testing.T) {
@@ -437,7 +437,7 @@ func TestEmitAsync_DetachedFromCanceledContext(t *testing.T) {
 
 	EmitAsync(parent, emitter, metrics, slog.Default(), entry)
 
-	waitForCount(t, "emitter.entries", time.Second, 1, func() int { return len(emitter.snapshot()) })
+	waitForCount(t, "emitter.entries", func() int { return len(emitter.snapshot()) })
 }
 
 func TestEmitAsync_NewAuditID_IsCuidShaped(t *testing.T) {

--- a/internal/mask/metrics.go
+++ b/internal/mask/metrics.go
@@ -1,0 +1,61 @@
+package mask
+
+import (
+	"errors"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+// PrometheusAuditMetrics implements AuditMetrics using Prometheus
+// counters. The label cardinality is bounded by the closed enums
+// (action, targetType) defined in data-lifecycle.md §4.2, which keeps
+// Prometheus storage footprint tiny.
+type PrometheusAuditMetrics struct {
+	writes   *prometheus.CounterVec
+	failures *prometheus.CounterVec
+}
+
+var _ AuditMetrics = (*PrometheusAuditMetrics)(nil)
+
+// NewPrometheusAuditMetrics creates and registers the audit-log write
+// counters. Re-registration of an already-registered collector is
+// tolerated so the same metrics can survive multiple New... calls in
+// tests.
+func NewPrometheusAuditMetrics(reg prometheus.Registerer) *PrometheusAuditMetrics {
+	m := &PrometheusAuditMetrics{
+		writes: prometheus.NewCounterVec(prometheus.CounterOpts{
+			Namespace: "telemetry",
+			Subsystem: "audit",
+			Name:      "log_writes_total",
+			Help:      "Total successful AuditLog inserts, labeled by action and target.",
+		}, []string{"action", "target"}),
+
+		failures: prometheus.NewCounterVec(prometheus.CounterOpts{
+			Namespace: "telemetry",
+			Subsystem: "audit",
+			Name:      "log_write_failures_total",
+			Help:      "Total failed AuditLog inserts, labeled by action and target.",
+		}, []string{"action", "target"}),
+	}
+
+	for _, c := range []prometheus.Collector{m.writes, m.failures} {
+		if err := reg.Register(c); err != nil {
+			var are prometheus.AlreadyRegisteredError
+			if errors.As(err, &are) {
+				continue
+			}
+			panic(err) // unexpected registration error
+		}
+	}
+	return m
+}
+
+// IncAuditWrite implements AuditMetrics.
+func (m *PrometheusAuditMetrics) IncAuditWrite(action, target string) {
+	m.writes.WithLabelValues(action, target).Inc()
+}
+
+// IncAuditWriteFailure implements AuditMetrics.
+func (m *PrometheusAuditMetrics) IncAuditWriteFailure(action, target string) {
+	m.failures.WithLabelValues(action, target).Inc()
+}

--- a/internal/store/audit_emitter.go
+++ b/internal/store/audit_emitter.go
@@ -1,0 +1,66 @@
+package store
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/tnando/my-robo-taxi-telemetry/internal/mask"
+)
+
+// MaskAuditEmitter adapts AuditRepo to the mask.AuditEmitter
+// interface (MYR-71). The mask package defines its own AuditEntry
+// type so internal/mask does not depend on internal/store; this
+// adapter copies the cross-package fields one-by-one and forwards
+// to AuditRepo.InsertAuditLog.
+//
+// The mask.AuditEntry and store.AuditEntry shapes are deliberately
+// independent — drift between them is detected at compile time
+// because every field is named explicitly in convertAuditEntry.
+//
+// Usage from cmd/telemetry-server/main.go:
+//
+//	auditRepo := store.NewAuditRepo(db.Pool())
+//	emitter   := store.NewMaskAuditEmitter(auditRepo)
+//	hub := ws.NewHub(logger, metrics, ws.WithMaskAudit(emitter, ...))
+type MaskAuditEmitter struct {
+	repo *AuditRepo
+}
+
+// Compile-time check that *MaskAuditEmitter satisfies the contract.
+var _ mask.AuditEmitter = (*MaskAuditEmitter)(nil)
+
+// NewMaskAuditEmitter wraps an AuditRepo so it can be passed where
+// mask.AuditEmitter is expected.
+func NewMaskAuditEmitter(repo *AuditRepo) *MaskAuditEmitter {
+	return &MaskAuditEmitter{repo: repo}
+}
+
+// InsertAuditLog converts the cross-package mask.AuditEntry into a
+// store.AuditEntry and forwards to AuditRepo. Any field rename in
+// either struct breaks this conversion at compile time, which is
+// exactly the drift-detection we want.
+func (e *MaskAuditEmitter) InsertAuditLog(ctx context.Context, entry mask.AuditEntry) error {
+	if e.repo == nil {
+		return fmt.Errorf("store.MaskAuditEmitter.InsertAuditLog: nil repo")
+	}
+	return e.repo.InsertAuditLog(ctx, convertAuditEntry(entry))
+}
+
+// convertAuditEntry copies fields from mask.AuditEntry to
+// store.AuditEntry. The store.AuditAction conversion preserves the
+// opaque string — invalid actions land at the DB level (the column
+// is TEXT with no enum constraint at the SQL layer), but the closed
+// enums on both sides keep this safe in practice.
+func convertAuditEntry(entry mask.AuditEntry) AuditEntry {
+	return AuditEntry{
+		ID:         entry.ID,
+		UserID:     entry.UserID,
+		Timestamp:  entry.Timestamp,
+		Action:     AuditAction(entry.Action),
+		TargetType: entry.TargetType,
+		TargetID:   entry.TargetID,
+		Initiator:  entry.Initiator,
+		Metadata:   entry.Metadata,
+		CreatedAt:  entry.CreatedAt,
+	}
+}

--- a/internal/store/mask_audit_integration_test.go
+++ b/internal/store/mask_audit_integration_test.go
@@ -66,10 +66,7 @@ func TestMaskAuditEmitter_EndToEnd(t *testing.T) {
 	deadline := time.After(5 * time.Second)
 	tick := time.NewTicker(10 * time.Millisecond)
 	defer tick.Stop()
-	for {
-		if metrics.Writes()+metrics.Failures() >= int64(samples) {
-			break
-		}
+	for metrics.Writes()+metrics.Failures() < int64(samples) {
 		select {
 		case <-deadline:
 			t.Fatalf("timed out waiting for writes: writes=%d failures=%d", metrics.Writes(), metrics.Failures())

--- a/internal/store/mask_audit_integration_test.go
+++ b/internal/store/mask_audit_integration_test.go
@@ -1,0 +1,182 @@
+package store_test
+
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+	"strconv"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/tnando/my-robo-taxi-telemetry/internal/auth"
+	"github.com/tnando/my-robo-taxi-telemetry/internal/mask"
+	"github.com/tnando/my-robo-taxi-telemetry/internal/store"
+)
+
+// TestMaskAuditEmitter_EndToEnd is the MYR-71 integration test that
+// confirms the mask audit pipeline lands rows on a real Postgres.
+// Drives ~25 deterministic mask events through the
+// EmitAsync -> MaskAuditEmitter -> AuditRepo path; the 1% sampling
+// is hand-driven (we always sample in) so the assertion can be a
+// strict count match. The contract correctness of the 1% rate is
+// covered by the unit tests in internal/mask/audit_test.go.
+//
+// The integration value here is:
+//
+//   - The cross-package AuditEntry conversion in
+//     store.MaskAuditEmitter actually compiles and inserts.
+//   - Every column the contract documents (data-lifecycle.md §4.1)
+//     persists with the expected value type after a real round-trip.
+//   - The metadata JSONB column handles the canonical mask payload
+//     shape (role / channel / fieldsMasked / endpoint) and survives
+//     re-decoding.
+func TestMaskAuditEmitter_EndToEnd(t *testing.T) {
+	if !dockerAvailable {
+		t.Skip("Docker not available; skipping mask audit integration test")
+	}
+	ensureAuditSchema(t)
+	cleanAuditLog(t, testPool)
+
+	repo := store.NewAuditRepo(testPool)
+	emitter := store.NewMaskAuditEmitter(repo)
+	metrics := &countingAuditMetrics{}
+
+	const samples = 25
+	wantBy := make(map[string]struct{}, samples)
+	for i := 0; i < samples; i++ {
+		entry, err := mask.BuildEntry(
+			"user-"+strconv.Itoa(i),
+			mask.TargetWSBroadcast,
+			"vehicle-"+strconv.Itoa(i%5),
+			auth.RoleViewer,
+			mask.AuditChannelWS,
+			[]string{"licensePlate"},
+			"",
+		)
+		if err != nil {
+			t.Fatalf("BuildEntry: %v", err)
+		}
+		wantBy[entry.ID] = struct{}{}
+		mask.EmitAsync(context.Background(), emitter, metrics, slog.Default(), entry)
+	}
+
+	// Wait for every async write to settle. The metric is the
+	// safest signal — it ticks ONLY after InsertAuditLog returns.
+	deadline := time.After(5 * time.Second)
+	tick := time.NewTicker(10 * time.Millisecond)
+	defer tick.Stop()
+	for {
+		if metrics.Writes()+metrics.Failures() >= int64(samples) {
+			break
+		}
+		select {
+		case <-deadline:
+			t.Fatalf("timed out waiting for writes: writes=%d failures=%d", metrics.Writes(), metrics.Failures())
+		case <-tick.C:
+		}
+	}
+	if metrics.Failures() != 0 {
+		t.Fatalf("unexpected emit failures: %d", metrics.Failures())
+	}
+
+	// Read back exactly the rows we wrote and assert shape.
+	ctx := context.Background()
+	rows, err := testPool.Query(ctx,
+		`SELECT "id", "userId", "action", "targetType", "targetId", "initiator", "metadata"
+		 FROM "AuditLog"
+		 WHERE "action" = 'mask_applied' AND "targetType" = 'ws_broadcast'`)
+	if err != nil {
+		t.Fatalf("query AuditLog: %v", err)
+	}
+	defer rows.Close()
+
+	gotBy := map[string]struct{}{}
+	for rows.Next() {
+		var (
+			id, userID, action, targetType, targetID, initiator string
+			metaRaw                                             json.RawMessage
+		)
+		if err := rows.Scan(&id, &userID, &action, &targetType, &targetID, &initiator, &metaRaw); err != nil {
+			t.Fatalf("scan: %v", err)
+		}
+		if action != "mask_applied" {
+			t.Errorf("action = %q, want mask_applied", action)
+		}
+		if targetType != "ws_broadcast" {
+			t.Errorf("targetType = %q, want ws_broadcast", targetType)
+		}
+		if initiator != "user" {
+			t.Errorf("initiator = %q, want user", initiator)
+		}
+
+		var meta map[string]any
+		if err := json.Unmarshal(metaRaw, &meta); err != nil {
+			t.Fatalf("unmarshal metadata: %v", err)
+		}
+		// CG-DL-5 keys-only check — every key must come from the
+		// allow-list in the mask package's BuildEntry contract.
+		for k := range meta {
+			switch k {
+			case "role", "channel", "fieldsMasked", "endpoint":
+				// allowed
+			default:
+				t.Errorf("metadata key %q not in CG-DL-5 allow-list", k)
+			}
+		}
+		if meta["role"] != "viewer" {
+			t.Errorf("metadata.role = %v, want viewer", meta["role"])
+		}
+		if meta["channel"] != "ws" {
+			t.Errorf("metadata.channel = %v, want ws", meta["channel"])
+		}
+
+		gotBy[id] = struct{}{}
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatalf("rows iter: %v", err)
+	}
+
+	if len(gotBy) != samples {
+		t.Fatalf("row count = %d, want %d", len(gotBy), samples)
+	}
+	for id := range wantBy {
+		if _, ok := gotBy[id]; !ok {
+			t.Errorf("missing inserted id: %s", id)
+		}
+	}
+}
+
+// countingAuditMetrics is a thread-safe AuditMetrics that counts
+// successful writes and failures. Used as the test-side observer on
+// the EmitAsync goroutine so the loop above can wait for completion
+// deterministically (no Sleep races).
+type countingAuditMetrics struct {
+	mu       sync.Mutex
+	writes   int64
+	failures int64
+}
+
+func (c *countingAuditMetrics) IncAuditWrite(string, string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.writes++
+}
+
+func (c *countingAuditMetrics) IncAuditWriteFailure(string, string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.failures++
+}
+
+func (c *countingAuditMetrics) Writes() int64 {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.writes
+}
+
+func (c *countingAuditMetrics) Failures() int64 {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.failures
+}

--- a/internal/telemetry/vehicle_status_handler.go
+++ b/internal/telemetry/vehicle_status_handler.go
@@ -36,8 +36,15 @@ type VehicleStatusHandler struct {
 	roles        roleResolver      // optional: nil disables mask plumbing
 	idLookup     vehicleIDLookup   // optional: nil disables mask plumbing
 	maskResource mask.ResourceType // populated by WithMask alongside roles/idLookup
-	presence     VehiclePresence
-	logger       *slog.Logger
+
+	// Mask-audit fields (MYR-71, rest-api.md §5.3). All optional —
+	// nil auditEmitter disables emit. WithMaskAudit fills them.
+	auditEmitter  mask.AuditEmitter
+	auditMetrics  mask.AuditMetrics
+	auditEndpoint string // route pattern for metadata.endpoint, e.g. "/api/vehicles/{vehicleId}/snapshot"
+
+	presence VehiclePresence
+	logger   *slog.Logger
 }
 
 // NewVehicleStatusHandler creates a handler that returns real-time vehicle
@@ -134,7 +141,7 @@ func (h *VehicleStatusHandler) ServeHTTP(w http.ResponseWriter, r *http.Request)
 	}
 
 	resp := h.buildStatusResponse(vin)
-	h.writeMaskedResponse(ctx, w, vin, userID, resp)
+	h.writeMaskedResponse(ctx, r, w, vin, userID, resp)
 }
 
 // verifyOwnership checks that userID owns the vehicle identified by vin.

--- a/internal/telemetry/vehicle_status_mask.go
+++ b/internal/telemetry/vehicle_status_mask.go
@@ -2,9 +2,12 @@ package telemetry
 
 import (
 	"context"
+	"crypto/rand"
+	"encoding/hex"
 	"fmt"
 	"log/slog"
 	"net/http"
+	"time"
 
 	"github.com/tnando/my-robo-taxi-telemetry/internal/auth"
 	"github.com/tnando/my-robo-taxi-telemetry/internal/mask"
@@ -61,6 +64,29 @@ func WithMask(resource mask.ResourceType, roles roleResolver, idLookup vehicleID
 	}
 }
 
+// WithMaskAudit attaches a mask-audit emitter and metrics to the
+// handler (MYR-71, rest-api.md §5.3). When configured, every REST
+// response whose mask projection removed at least one field is
+// audit-logged at a 1% deterministic-hash sample rate. The
+// `endpoint` argument is the route pattern written to
+// metadata.endpoint — pass "/api/vehicles/{vehicleId}/snapshot"
+// rather than the substituted URL so a vehicleID does not appear
+// twice (it is already on AuditEntry.TargetID). emitter MAY be nil
+// — in which case this option is a no-op.
+func WithMaskAudit(emitter mask.AuditEmitter, metrics mask.AuditMetrics, endpoint string) VehicleStatusOption {
+	return func(h *VehicleStatusHandler) {
+		if emitter == nil {
+			return
+		}
+		h.auditEmitter = emitter
+		if metrics == nil {
+			metrics = mask.NoopAuditMetrics{}
+		}
+		h.auditMetrics = metrics
+		h.auditEndpoint = endpoint
+	}
+}
+
 // writeMaskedResponse projects the response struct through the
 // role-based field mask before encoding. When the optional
 // roleResolver / vehicleIDLookup pair is not configured, the response
@@ -74,14 +100,15 @@ func WithMask(resource mask.ResourceType, roles roleResolver, idLookup vehicleID
 // matrix-keyed design used by the WebSocket per-role projection
 // (websocket-protocol.md §4.6).
 //
-// TODO(MYR-XX audit-log): when AuditLog table exists, if
-// len(fieldsMasked) > 0 AND mask.ShouldAuditREST(userID, requestID,
-// vehicleID) == true, emit an audit entry per rest-api.md §5.3. The
-// AuditLog migration is deferred (data-lifecycle.md §4 schema doesn't
-// exist in Prisma yet — same cross-repo pattern as MYR-41's
-// chargeState/timeToFull migration).
+// Audit emit (MYR-71, rest-api.md §5.3): when at least one field is
+// stripped AND ShouldAuditREST samples in at 1%, the handler fires a
+// non-blocking AuditEntry insert via mask.EmitAsync. The 'requestID'
+// hash input is the X-Request-ID header per §4.4 (server generates
+// one if the client did not). Failures log slog.Warn and increment
+// audit_log_write_failures_total — they MUST NOT drop the response.
 func (h *VehicleStatusHandler) writeMaskedResponse(
 	ctx context.Context,
+	r *http.Request,
 	w http.ResponseWriter,
 	vin, userID string,
 	resp vehicleStatusResponse,
@@ -109,10 +136,78 @@ func (h *VehicleStatusHandler) writeMaskedResponse(
 		return
 	}
 
+	// vehicleID is the audit row's TargetID. Resolved best-effort: if
+	// the lookup fails here it would have failed in resolveCallerRole
+	// above (which 500s), so this branch is reached only on success.
+	vehicleID, _ := h.idLookup.GetVehicleIDByVIN(ctx, vin)
+
 	projected, fieldsMasked := mask.Apply(resp.ToMaskMap(), mask.For(h.maskResource, role))
-	_ = fieldsMasked // see TODO(MYR-XX audit-log) above
+
+	h.maybeEmitAuditREST(r, userID, vehicleID, role, fieldsMasked)
 
 	h.writeJSON(w, http.StatusOK, projected)
+}
+
+// maybeEmitAuditREST evaluates the REST audit-emit gate. Pulled out
+// of writeMaskedResponse so the gate logic is testable in isolation
+// and the hot path stays linear.
+func (h *VehicleStatusHandler) maybeEmitAuditREST(
+	r *http.Request,
+	userID, vehicleID string,
+	role auth.Role,
+	fieldsMasked []string,
+) {
+	if h.auditEmitter == nil {
+		return
+	}
+	if len(fieldsMasked) == 0 {
+		return
+	}
+	requestID := requestIDFromRequest(r)
+	if !mask.ShouldAuditREST(userID, requestID, vehicleID) {
+		return
+	}
+
+	entry, err := mask.BuildEntry(
+		userID,
+		mask.TargetRESTResponse,
+		vehicleID,
+		role,
+		mask.AuditChannelREST,
+		fieldsMasked,
+		h.auditEndpoint,
+	)
+	if err != nil {
+		// BuildEntry only fails on programmer errors. Log and skip;
+		// the response itself still goes out.
+		h.logger.Warn("vehicle status: BuildEntry failed",
+			slog.String("user_id", userID),
+			slog.String("error", err.Error()),
+		)
+		return
+	}
+	mask.EmitAsync(r.Context(), h.auditEmitter, h.auditMetrics, h.logger, entry)
+}
+
+// requestIDFromRequest returns the X-Request-ID header echoed by
+// rest-api.md §4.4. If the client did not send one, a random ID is
+// generated so ShouldAuditREST still has unique sampling input per
+// request. The generated ID is NOT propagated back to the response —
+// adding the response header is left to a future request-ID
+// middleware (out of scope for MYR-71).
+func requestIDFromRequest(r *http.Request) string {
+	if v := r.Header.Get("X-Request-ID"); v != "" {
+		return v
+	}
+	// Fall back to a server-generated random ID so the sampling
+	// remains uniform across clients that omit the header.
+	var b [16]byte
+	if _, err := rand.Read(b[:]); err != nil {
+		// Crypto RNG unavailable is unrecoverable; degrade to a
+		// timestamp-derived value rather than panic.
+		return fmt.Sprintf("ts-%d", time.Now().UnixNano())
+	}
+	return hex.EncodeToString(b[:])
 }
 
 // resolveCallerRole derives the caller's role for the vehicle

--- a/internal/telemetry/vehicle_status_mask_audit_test.go
+++ b/internal/telemetry/vehicle_status_mask_audit_test.go
@@ -1,0 +1,385 @@
+package telemetry
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/tnando/my-robo-taxi-telemetry/internal/auth"
+	"github.com/tnando/my-robo-taxi-telemetry/internal/mask"
+)
+
+// fakeAuditEmitter is a recording AuditEmitter for REST mask tests.
+// Each test owns its own instance (no global state).
+type fakeAuditEmitter struct {
+	mu      sync.Mutex
+	entries []mask.AuditEntry
+	err     error
+}
+
+func (f *fakeAuditEmitter) InsertAuditLog(_ context.Context, entry mask.AuditEntry) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.entries = append(f.entries, entry)
+	return f.err
+}
+
+func (f *fakeAuditEmitter) snapshot() []mask.AuditEntry {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	out := make([]mask.AuditEntry, len(f.entries))
+	copy(out, f.entries)
+	return out
+}
+
+// fakeAuditMetrics counts mask audit emits.
+type fakeAuditMetrics struct {
+	writes   atomic.Int64
+	failures atomic.Int64
+}
+
+func (f *fakeAuditMetrics) IncAuditWrite(string, string)        { f.writes.Add(1) }
+func (f *fakeAuditMetrics) IncAuditWriteFailure(string, string) { f.failures.Add(1) }
+
+// waitForEntries polls f.snapshot() until it reaches at least want
+// entries or the deadline expires. EmitAsync runs on a goroutine so
+// the test must wait — a fixed Sleep would either be too short or
+// drag tests out unnecessarily.
+func waitForEntries(t *testing.T, f *fakeAuditEmitter, want int) {
+	t.Helper()
+	deadline := time.After(2 * time.Second)
+	tick := time.NewTicker(2 * time.Millisecond)
+	defer tick.Stop()
+	for {
+		if len(f.snapshot()) >= want {
+			return
+		}
+		select {
+		case <-deadline:
+			t.Fatalf("timed out waiting for %d audit entries, got %d", want, len(f.snapshot()))
+		case <-tick.C:
+		}
+	}
+}
+
+// findSamplingRequestID discovers an X-Request-ID value that ShouldAuditREST
+// will sample IN for the given (userID, vehicleID). The test just iterates
+// integers as request IDs until it finds one — this avoids the test
+// depending on a specific FNV outcome.
+func findSamplingRequestID(t *testing.T, userID, vehicleID string) string {
+	t.Helper()
+	for i := 0; i < 5000; i++ {
+		candidate := "req-" + strconv.Itoa(i)
+		if mask.ShouldAuditREST(userID, candidate, vehicleID) {
+			return candidate
+		}
+	}
+	t.Fatalf("no sampling-in request ID found for (user=%q, veh=%q)", userID, vehicleID)
+	return ""
+}
+
+// TestVehicleStatus_MaskedResponse_EmitsAudit_OnViewerStrip drives a
+// VehicleStatusHandler with a viewer-role caller through the mask
+// pipeline. Even though the connectivity-probe shape is wider than
+// the vehicle_state allow-list, the test only verifies the audit
+// path: at least one field is stripped, and when the X-Request-ID
+// hashes into the 1% sample bucket, an AuditEntry lands.
+func TestVehicleStatus_MaskedResponse_EmitsAudit_OnViewerStrip(t *testing.T) {
+	emitter := &fakeAuditEmitter{}
+	metrics := &fakeAuditMetrics{}
+
+	const (
+		userID    = "user-1"
+		vehicleID = "veh-1"
+	)
+	requestID := findSamplingRequestID(t, userID, vehicleID)
+
+	handler := NewVehicleStatusHandler(
+		&stubTokenValidator{userID: userID},
+		&stubVehicleOwner{ownerID: userID},
+		&stubVehiclePresence{connected: true},
+		discardLogger(),
+		WithMask(
+			mask.ResourceVehicleState,
+			&stubRoleResolver{role: auth.RoleViewer},
+			&stubVehicleIDLookup{id: vehicleID},
+		),
+		WithMaskAudit(emitter, metrics, "/api/vehicles/{vehicleId}/snapshot"),
+	)
+
+	mux := http.NewServeMux()
+	mux.Handle("GET /api/vehicle-status/{vin}", handler)
+
+	req := httptest.NewRequestWithContext(
+		context.Background(),
+		http.MethodGet,
+		"/api/vehicle-status/5YJ3E1EA1PF000001",
+		nil,
+	)
+	req.Header.Set("Authorization", "Bearer t")
+	req.Header.Set("X-Request-ID", requestID)
+
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status: got %d, want 200", rec.Code)
+	}
+
+	waitForEntries(t, emitter, 1)
+	got := emitter.snapshot()
+	if len(got) != 1 {
+		t.Fatalf("expected exactly 1 entry, got %d", len(got))
+	}
+	entry := got[0]
+	if entry.Action != "mask_applied" {
+		t.Errorf("Action = %q, want mask_applied", entry.Action)
+	}
+	if entry.TargetType != string(mask.TargetRESTResponse) {
+		t.Errorf("TargetType = %q, want rest_response", entry.TargetType)
+	}
+	if entry.TargetID != vehicleID {
+		t.Errorf("TargetID = %q, want %q", entry.TargetID, vehicleID)
+	}
+	if entry.UserID != userID {
+		t.Errorf("UserID = %q, want %q (REST audit row IS per-caller)", entry.UserID, userID)
+	}
+
+	var meta map[string]any
+	if err := json.Unmarshal(entry.Metadata, &meta); err != nil {
+		t.Fatalf("unmarshal metadata: %v", err)
+	}
+	if meta["role"] != string(auth.RoleViewer) {
+		t.Errorf("metadata.role = %v, want viewer", meta["role"])
+	}
+	if meta["channel"] != string(mask.AuditChannelREST) {
+		t.Errorf("metadata.channel = %v, want rest", meta["channel"])
+	}
+	if meta["endpoint"] != "/api/vehicles/{vehicleId}/snapshot" {
+		t.Errorf("metadata.endpoint = %v, want route pattern", meta["endpoint"])
+	}
+	fields, ok := meta["fieldsMasked"].([]any)
+	if !ok || len(fields) == 0 {
+		t.Errorf("metadata.fieldsMasked = %v, want non-empty list", meta["fieldsMasked"])
+	}
+
+	if metrics.writes.Load() < 1 {
+		t.Errorf("expected at least 1 metric write, got %d", metrics.writes.Load())
+	}
+}
+
+// TestVehicleStatus_MaskedResponse_NoAudit_OnNoSample drives the
+// handler with a request whose (userID, requestID, vehicleID) does
+// NOT sample in. No audit row should land regardless of how many
+// fields the mask stripped.
+func TestVehicleStatus_MaskedResponse_NoAudit_OnNoSample(t *testing.T) {
+	emitter := &fakeAuditEmitter{}
+	metrics := &fakeAuditMetrics{}
+
+	const (
+		userID    = "user-1"
+		vehicleID = "veh-1"
+	)
+
+	// Find a request ID that does NOT sample in.
+	notSampling := ""
+	for i := 0; i < 100; i++ {
+		candidate := "noreq-" + strconv.Itoa(i)
+		if !mask.ShouldAuditREST(userID, candidate, vehicleID) {
+			notSampling = candidate
+			break
+		}
+	}
+	if notSampling == "" {
+		t.Fatal("no non-sampling request ID found")
+	}
+
+	handler := NewVehicleStatusHandler(
+		&stubTokenValidator{userID: userID},
+		&stubVehicleOwner{ownerID: userID},
+		&stubVehiclePresence{connected: true},
+		discardLogger(),
+		WithMask(
+			mask.ResourceVehicleState,
+			&stubRoleResolver{role: auth.RoleViewer},
+			&stubVehicleIDLookup{id: vehicleID},
+		),
+		WithMaskAudit(emitter, metrics, "/api/vehicles/{vehicleId}/snapshot"),
+	)
+
+	mux := http.NewServeMux()
+	mux.Handle("GET /api/vehicle-status/{vin}", handler)
+
+	req := httptest.NewRequestWithContext(
+		context.Background(),
+		http.MethodGet,
+		"/api/vehicle-status/5YJ3E1EA1PF000001",
+		nil,
+	)
+	req.Header.Set("Authorization", "Bearer t")
+	req.Header.Set("X-Request-ID", notSampling)
+
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status: got %d, want 200", rec.Code)
+	}
+
+	// Wait briefly to catch any async writes.
+	time.Sleep(50 * time.Millisecond)
+	if got := len(emitter.snapshot()); got != 0 {
+		t.Errorf("expected 0 audit entries on non-sampling request, got %d", got)
+	}
+	if got := metrics.writes.Load(); got != 0 {
+		t.Errorf("metrics.writes = %d, want 0 on non-sampling request", got)
+	}
+}
+
+// TestVehicleStatus_MaskedResponse_AuditFailure_DoesNotBreakResponse
+// confirms an InsertAuditLog error logs + increments the failure
+// metric but the 200 response still goes out.
+func TestVehicleStatus_MaskedResponse_AuditFailure_DoesNotBreakResponse(t *testing.T) {
+	emitter := &fakeAuditEmitter{err: errors.New("simulated DB failure")}
+	metrics := &fakeAuditMetrics{}
+
+	const (
+		userID    = "user-1"
+		vehicleID = "veh-1"
+	)
+	requestID := findSamplingRequestID(t, userID, vehicleID)
+
+	handler := NewVehicleStatusHandler(
+		&stubTokenValidator{userID: userID},
+		&stubVehicleOwner{ownerID: userID},
+		&stubVehiclePresence{connected: true},
+		discardLogger(),
+		WithMask(
+			mask.ResourceVehicleState,
+			&stubRoleResolver{role: auth.RoleViewer},
+			&stubVehicleIDLookup{id: vehicleID},
+		),
+		WithMaskAudit(emitter, metrics, "/api/vehicles/{vehicleId}/snapshot"),
+	)
+
+	mux := http.NewServeMux()
+	mux.Handle("GET /api/vehicle-status/{vin}", handler)
+
+	req := httptest.NewRequestWithContext(
+		context.Background(),
+		http.MethodGet,
+		"/api/vehicle-status/5YJ3E1EA1PF000001",
+		nil,
+	)
+	req.Header.Set("Authorization", "Bearer t")
+	req.Header.Set("X-Request-ID", requestID)
+
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status: got %d, want 200 even with audit failure", rec.Code)
+	}
+
+	waitForFailure(t, metrics)
+	if got := metrics.writes.Load(); got != 0 {
+		t.Errorf("metrics.writes = %d, want 0 on failure", got)
+	}
+}
+
+func waitForFailure(t *testing.T, m *fakeAuditMetrics) {
+	t.Helper()
+	deadline := time.After(2 * time.Second)
+	tick := time.NewTicker(2 * time.Millisecond)
+	defer tick.Stop()
+	for {
+		if m.failures.Load() >= 1 {
+			return
+		}
+		select {
+		case <-deadline:
+			t.Fatalf("timed out waiting for failure metric")
+		case <-tick.C:
+		}
+	}
+}
+
+// TestRequestIDFromRequest exercises the X-Request-ID header
+// fallback. When the client supplies the header, it is echoed; when
+// absent, a server-generated random ID is returned (32-char hex).
+func TestRequestIDFromRequest(t *testing.T) {
+	tests := []struct {
+		name      string
+		hdr       string
+		wantExact string // if non-empty, expect exact match
+		wantHex32 bool   // if true, expect 32-char hex
+	}{
+		{name: "client supplied header", hdr: "client-req-1", wantExact: "client-req-1"},
+		{name: "missing header generates 32-char hex", hdr: "", wantHex32: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet, "/", nil)
+			if tt.hdr != "" {
+				req.Header.Set("X-Request-ID", tt.hdr)
+			}
+			got := requestIDFromRequest(req)
+			if tt.wantExact != "" && got != tt.wantExact {
+				t.Errorf("got %q, want %q", got, tt.wantExact)
+			}
+			if tt.wantHex32 {
+				if len(got) != 32 {
+					t.Errorf("generated id length = %d, want 32", len(got))
+				}
+			}
+		})
+	}
+}
+
+// TestVehicleStatus_NoAuditEmitter_NoCrash verifies the backward-
+// compatible path: WithMaskAudit not supplied (auditEmitter is nil),
+// the handler still serves the masked response without panic.
+func TestVehicleStatus_NoAuditEmitter_NoCrash(t *testing.T) {
+	const (
+		userID    = "user-1"
+		vehicleID = "veh-1"
+	)
+
+	handler := NewVehicleStatusHandler(
+		&stubTokenValidator{userID: userID},
+		&stubVehicleOwner{ownerID: userID},
+		&stubVehiclePresence{connected: true},
+		discardLogger(),
+		WithMask(
+			mask.ResourceVehicleState,
+			&stubRoleResolver{role: auth.RoleViewer},
+			&stubVehicleIDLookup{id: vehicleID},
+		),
+		// No WithMaskAudit.
+	)
+
+	mux := http.NewServeMux()
+	mux.Handle("GET /api/vehicle-status/{vin}", handler)
+
+	req := httptest.NewRequestWithContext(
+		context.Background(),
+		http.MethodGet,
+		"/api/vehicle-status/5YJ3E1EA1PF000001",
+		nil,
+	)
+	req.Header.Set("Authorization", "Bearer t")
+
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status: got %d, want 200", rec.Code)
+	}
+}

--- a/internal/telemetry/vehicle_status_mask_audit_test.go
+++ b/internal/telemetry/vehicle_status_mask_audit_test.go
@@ -233,8 +233,12 @@ func TestVehicleStatus_MaskedResponse_NoAudit_OnNoSample(t *testing.T) {
 		t.Fatalf("status: got %d, want 200", rec.Code)
 	}
 
-	// Wait briefly to catch any async writes.
-	time.Sleep(50 * time.Millisecond)
+	// Determinism: maybeEmitAuditREST evaluates the
+	// "len(fieldsMasked) > 0 && ShouldAuditREST(...)" gate on the
+	// calling goroutine — the `go ...` in EmitAsync is only reached
+	// after both checks pass. For a non-sampling request, no
+	// goroutine is spawned, so the emitter's snapshot can be
+	// asserted synchronously after the response. No Sleep needed.
 	if got := len(emitter.snapshot()); got != 0 {
 		t.Errorf("expected 0 audit entries on non-sampling request, got %d", got)
 	}

--- a/internal/telemetry/vehicle_status_mask_audit_test.go
+++ b/internal/telemetry/vehicle_status_mask_audit_test.go
@@ -326,7 +326,7 @@ func TestRequestIDFromRequest(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			req := httptest.NewRequest(http.MethodGet, "/", nil)
+			req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/", nil)
 			if tt.hdr != "" {
 				req.Header.Set("X-Request-ID", tt.hdr)
 			}

--- a/internal/ws/hub.go
+++ b/internal/ws/hub.go
@@ -1,10 +1,12 @@
 package ws
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"log/slog"
 	"sync"
+	"sync/atomic"
 
 	"github.com/tnando/my-robo-taxi-telemetry/internal/auth"
 	"github.com/tnando/my-robo-taxi-telemetry/internal/mask"
@@ -18,15 +20,74 @@ type Hub struct {
 	logger  *slog.Logger
 	metrics HubMetrics
 	stopped bool
+
+	// Mask-audit fields (rest-api.md §5.3). All optional — a nil
+	// auditEmitter disables emit and EmitAsync becomes a no-op. Test
+	// wiring leaves them nil; production wiring fills them via
+	// HubOption.
+	auditEmitter mask.AuditEmitter
+	auditMetrics mask.AuditMetrics
+
+	// Per-vehicle monotonic frame counter feeding ShouldAuditWS as
+	// frameSeq input. Per rest-api.md §5.3, until DV-02 lands the hub
+	// uses an in-process counter — distinct vehicles get distinct
+	// streams, distinct frames within a stream get distinct counter
+	// values, and the deterministic hash distributes the 1% sample
+	// across them. sync.Map keyed by vehicleID -> *atomic.Uint64 so
+	// the per-vehicle increment is lock-free on the hot path.
+	frameCounters sync.Map
+}
+
+// HubOption configures optional Hub behavior. Following the v1 SDK
+// pattern (cmd/telemetry-server/main.go's WithMask), options are
+// composable, idempotent, and default to a quiet no-op when omitted.
+type HubOption func(*Hub)
+
+// WithMaskAudit attaches a mask-audit emitter and metrics to the hub.
+// When configured, the hub emits an AuditEntry per (vehicleID, role,
+// frame) where the role's mask removed at least one field, sampled at
+// the 1% rate computed by mask.ShouldAuditWS. emitter MAY be nil — in
+// which case this option is a no-op (defensive: a misconfigured wiring
+// path should not crash the hot path).
+func WithMaskAudit(emitter mask.AuditEmitter, metrics mask.AuditMetrics) HubOption {
+	return func(h *Hub) {
+		if emitter == nil {
+			return
+		}
+		h.auditEmitter = emitter
+		if metrics == nil {
+			metrics = mask.NoopAuditMetrics{}
+		}
+		h.auditMetrics = metrics
+	}
 }
 
 // NewHub creates a Hub ready to accept client registrations.
-func NewHub(logger *slog.Logger, metrics HubMetrics) *Hub {
-	return &Hub{
+func NewHub(logger *slog.Logger, metrics HubMetrics, opts ...HubOption) *Hub {
+	h := &Hub{
 		clients: make(map[*Client]struct{}),
 		logger:  logger,
 		metrics: metrics,
 	}
+	for _, opt := range opts {
+		opt(h)
+	}
+	return h
+}
+
+// nextFrameSeq increments and returns the per-vehicle monotonic frame
+// counter used as ShouldAuditWS input. The first call for a given
+// vehicleID returns 1; subsequent calls return 2, 3, ... A sync.Map
+// LoadOrStore on the first call avoids the race between two goroutines
+// observing zero and both creating a counter — the second goroutine
+// loses the LoadOrStore race, throws away its counter, and uses the
+// winner's.
+func (h *Hub) nextFrameSeq(vehicleID string) uint64 {
+	v, ok := h.frameCounters.Load(vehicleID)
+	if !ok {
+		v, _ = h.frameCounters.LoadOrStore(vehicleID, new(atomic.Uint64))
+	}
+	return v.(*atomic.Uint64).Add(1)
 }
 
 // Register adds an authenticated client to the hub.
@@ -146,8 +207,15 @@ func (h *Hub) BroadcastMasked(
 		return
 	}
 
+	// Per rest-api.md §5.3: the audit emit's frameSeq is per-vehicle.
+	// Bump once per BroadcastMasked call so every role that processes
+	// this frame sees the same seq value — the role itself goes into
+	// the hash too, so distinct roles still get distinct sampling
+	// decisions for the same frame.
+	frameSeq := h.nextFrameSeq(vehicleID)
+
 	// Pass 2: marshal only the frames we will actually use.
-	framesByRole := buildRoleFrames(vehicleID, resource, timestamp, payload, activeRoles)
+	framesByRole := h.buildRoleFrames(vehicleID, resource, timestamp, payload, activeRoles, frameSeq)
 	if len(framesByRole) == 0 {
 		return
 	}
@@ -189,25 +257,31 @@ var v1Roles = []auth.Role{auth.RoleOwner, auth.RoleViewer}
 // for that role" rather than an error return — a single role's marshal
 // failure must not poison the broadcast for other roles.
 //
-// TODO(MYR-XX audit-log): when AuditLog table exists, for each role
-// where len(fieldsMasked) > 0 AND mask.ShouldAuditWS(vehicleID, role,
-// frameSeq) == true, emit an audit entry per rest-api.md §5.3. The
-// AuditLog migration is deferred (data-lifecycle.md §4 schema doesn't
-// exist in Prisma yet — same cross-repo pattern as MYR-41's
-// chargeState/timeToFull migration). fieldsMasked carries the list of
-// removed field names (P0 — names only, never values).
-func buildRoleFrames(
+// Audit emit (MYR-71, rest-api.md §5.3): for each role where the
+// mask removed at least one field AND mask.ShouldAuditWS samples in,
+// the hub fires a non-blocking AuditEntry insert via mask.EmitAsync.
+// The emit is per (vehicleID, role, frame) at the hub layer rather
+// than per client — this keeps audit volume proportional to vehicle
+// activity, not viewer count. Failures log slog.Warn and increment
+// audit_log_write_failures_total; they MUST NOT drop the frame.
+func (h *Hub) buildRoleFrames(
 	vehicleID string,
 	resource mask.ResourceType,
 	timestamp string,
 	payload map[string]any,
 	activeRoles map[auth.Role]struct{},
+	frameSeq uint64,
 ) map[auth.Role][]byte {
 	frames := make(map[auth.Role][]byte, len(activeRoles))
 	for role := range activeRoles {
 		m := mask.For(resource, role)
 		projected, fieldsMasked := mask.Apply(payload, m)
-		_ = fieldsMasked // see TODO above
+
+		// Audit-log emit per rest-api.md §5.3. Sampled at 1% by
+		// deterministic hash. Skipped if the role didn't actually
+		// strip any fields (the contract gates emit on
+		// "removed at least one field").
+		h.maybeEmitAuditWS(vehicleID, role, frameSeq, fieldsMasked)
 
 		if len(projected) == 0 {
 			// Empty-payload suppression per websocket-protocol.md §4.6.
@@ -222,6 +296,54 @@ func buildRoleFrames(
 		frames[role] = frame
 	}
 	return frames
+}
+
+// maybeEmitAuditWS evaluates the audit-emit gate for one (vehicleID,
+// role, frame) and fires a non-blocking insert if both the
+// "fieldsMasked is non-empty" precondition and the 1% sampler agree.
+// Pulled out of buildRoleFrames so the hot path stays linear and the
+// gate logic is independently testable.
+func (h *Hub) maybeEmitAuditWS(
+	vehicleID string,
+	role auth.Role,
+	frameSeq uint64,
+	fieldsMasked []string,
+) {
+	if h.auditEmitter == nil {
+		return
+	}
+	if len(fieldsMasked) == 0 {
+		return
+	}
+	if !mask.ShouldAuditWS(vehicleID, role, frameSeq) {
+		return
+	}
+	// userID is empty for WS — the audit emit is per (vehicleID, role,
+	// frame) at the hub, not per client. The targetID column carries
+	// the vehicleID; the role is in metadata; that's the canonical
+	// shape from rest-api.md §5.3 ("The audit emit happens once per
+	// (vehicleId, role, frame) at the hub layer, not per client").
+	entry, err := mask.BuildEntry(
+		"",
+		mask.TargetWSBroadcast,
+		vehicleID,
+		role,
+		mask.AuditChannelWS,
+		fieldsMasked,
+		"",
+	)
+	if err != nil {
+		// BuildEntry only fails on programmer errors (empty
+		// fieldsMasked, marshal panic). Log and skip — the frame
+		// itself still flies.
+		h.logger.Warn("hub.maybeEmitAuditWS: BuildEntry failed",
+			slog.String("vehicle_id", vehicleID),
+			slog.String("role", role.String()),
+			slog.String("error", err.Error()),
+		)
+		return
+	}
+	mask.EmitAsync(context.Background(), h.auditEmitter, h.auditMetrics, h.logger, entry)
 }
 
 // marshalVehicleUpdate wraps a projected payload in the wsMessage

--- a/internal/ws/hub.go
+++ b/internal/ws/hub.go
@@ -1,14 +1,9 @@
 package ws
 
 import (
-	"context"
-	"encoding/json"
-	"fmt"
 	"log/slog"
 	"sync"
-	"sync/atomic"
 
-	"github.com/tnando/my-robo-taxi-telemetry/internal/auth"
 	"github.com/tnando/my-robo-taxi-telemetry/internal/mask"
 )
 
@@ -21,20 +16,18 @@ type Hub struct {
 	metrics HubMetrics
 	stopped bool
 
-	// Mask-audit fields (rest-api.md §5.3). All optional — a nil
-	// auditEmitter disables emit and EmitAsync becomes a no-op. Test
-	// wiring leaves them nil; production wiring fills them via
-	// HubOption.
+	// Mask-audit fields (rest-api.md §5.3, MYR-71). All optional —
+	// a nil auditEmitter disables emit and EmitAsync becomes a
+	// no-op. Test wiring leaves them nil; production wiring fills
+	// them via WithMaskAudit. The masked-broadcast surface (this
+	// option, BroadcastMasked, buildRoleFrames, maybeEmitAuditWS,
+	// nextFrameSeq, and frameCounters) lives in hub_masked.go.
 	auditEmitter mask.AuditEmitter
 	auditMetrics mask.AuditMetrics
 
 	// Per-vehicle monotonic frame counter feeding ShouldAuditWS as
-	// frameSeq input. Per rest-api.md §5.3, until DV-02 lands the hub
-	// uses an in-process counter — distinct vehicles get distinct
-	// streams, distinct frames within a stream get distinct counter
-	// values, and the deterministic hash distributes the 1% sample
-	// across them. sync.Map keyed by vehicleID -> *atomic.Uint64 so
-	// the per-vehicle increment is lock-free on the hot path.
+	// frameSeq input. sync.Map keyed by vehicleID -> *atomic.Uint64
+	// so the per-vehicle increment is lock-free on the hot path.
 	frameCounters sync.Map
 }
 
@@ -42,25 +35,6 @@ type Hub struct {
 // pattern (cmd/telemetry-server/main.go's WithMask), options are
 // composable, idempotent, and default to a quiet no-op when omitted.
 type HubOption func(*Hub)
-
-// WithMaskAudit attaches a mask-audit emitter and metrics to the hub.
-// When configured, the hub emits an AuditEntry per (vehicleID, role,
-// frame) where the role's mask removed at least one field, sampled at
-// the 1% rate computed by mask.ShouldAuditWS. emitter MAY be nil — in
-// which case this option is a no-op (defensive: a misconfigured wiring
-// path should not crash the hot path).
-func WithMaskAudit(emitter mask.AuditEmitter, metrics mask.AuditMetrics) HubOption {
-	return func(h *Hub) {
-		if emitter == nil {
-			return
-		}
-		h.auditEmitter = emitter
-		if metrics == nil {
-			metrics = mask.NoopAuditMetrics{}
-		}
-		h.auditMetrics = metrics
-	}
-}
 
 // NewHub creates a Hub ready to accept client registrations.
 func NewHub(logger *slog.Logger, metrics HubMetrics, opts ...HubOption) *Hub {
@@ -73,21 +47,6 @@ func NewHub(logger *slog.Logger, metrics HubMetrics, opts ...HubOption) *Hub {
 		opt(h)
 	}
 	return h
-}
-
-// nextFrameSeq increments and returns the per-vehicle monotonic frame
-// counter used as ShouldAuditWS input. The first call for a given
-// vehicleID returns 1; subsequent calls return 2, 3, ... A sync.Map
-// LoadOrStore on the first call avoids the race between two goroutines
-// observing zero and both creating a counter — the second goroutine
-// loses the LoadOrStore race, throws away its counter, and uses the
-// winner's.
-func (h *Hub) nextFrameSeq(vehicleID string) uint64 {
-	v, ok := h.frameCounters.Load(vehicleID)
-	if !ok {
-		v, _ = h.frameCounters.LoadOrStore(vehicleID, new(atomic.Uint64))
-	}
-	return v.(*atomic.Uint64).Add(1)
 }
 
 // Register adds an authenticated client to the hub.
@@ -155,213 +114,6 @@ func (h *Hub) Broadcast(vehicleID string, msg []byte) {
 			)
 		}
 	}
-}
-
-// BroadcastMasked is the per-role projection broadcast path required
-// by websocket-protocol.md §4.6. It pre-marshals one frame per
-// active role for this vehicle (the set of distinct roles held by
-// currently-subscribed clients), then fans out the role-appropriate
-// bytes to each authorized client based on that client's per-vehicle
-// role (populated at handshake time).
-//
-// Marshal cost is O(|active roles for this vehicle|), bounded above by
-// O(|v1 roles|). Fan-out is O(|clients|). Per §4.6 "empty-payload
-// suppression": if a role's mask projects the payload down to zero
-// fields, no frame is emitted for clients holding that role — a viewer
-// who shouldn't even know an event happened on the vehicle MUST NOT
-// see an empty vehicle_update.
-//
-// Clients whose roleFor(vehicleID) returns the empty Role("") sentinel
-// (e.g., handshake-time ResolveRole failed) receive nothing — the
-// fail-closed behavior described in rest-api.md §5.
-//
-// Active-role pre-pass: we walk h.clients ONCE under RLock to collect
-// the distinct roles actually subscribed for this vehicleID, then only
-// marshal frames for those roles. Skipping unused roles matters in
-// practice today (every connection in v1 is owner — viewers via the
-// Invite flow haven't shipped yet) and the savings grow with FR-5.5's
-// third role. PR #195 review suggestion #1.
-func (h *Hub) BroadcastMasked(
-	vehicleID string,
-	resource mask.ResourceType,
-	timestamp string,
-	payload map[string]any,
-) {
-	if len(payload) == 0 {
-		return
-	}
-
-	h.mu.RLock()
-	defer h.mu.RUnlock()
-
-	// Pass 1: collect the distinct set of roles held by clients
-	// subscribed to this vehicle. O(|clients|).
-	activeRoles := make(map[auth.Role]struct{}, len(v1Roles))
-	for client := range h.clients {
-		if !client.hasVehicle(vehicleID) {
-			continue
-		}
-		activeRoles[client.roleFor(vehicleID)] = struct{}{}
-	}
-	if len(activeRoles) == 0 {
-		return
-	}
-
-	// Per rest-api.md §5.3: the audit emit's frameSeq is per-vehicle.
-	// Bump once per BroadcastMasked call so every role that processes
-	// this frame sees the same seq value — the role itself goes into
-	// the hash too, so distinct roles still get distinct sampling
-	// decisions for the same frame.
-	frameSeq := h.nextFrameSeq(vehicleID)
-
-	// Pass 2: marshal only the frames we will actually use.
-	framesByRole := h.buildRoleFrames(vehicleID, resource, timestamp, payload, activeRoles, frameSeq)
-	if len(framesByRole) == 0 {
-		return
-	}
-
-	// Pass 3: fan out under the same RLock so the client set we marshaled
-	// for is the same client set we deliver to (no torn snapshot).
-	for client := range h.clients {
-		if !client.hasVehicle(vehicleID) {
-			continue
-		}
-		role := client.roleFor(vehicleID)
-		frame, ok := framesByRole[role]
-		if !ok || frame == nil {
-			// Empty-payload suppression OR unknown role -> deny-all.
-			continue
-		}
-		if dropped := client.enqueue(frame); dropped {
-			h.metrics.IncMessagesDropped()
-			h.logger.Debug("dropped masked message for slow client",
-				slog.String("user_id", client.userID),
-				slog.String("vehicle_id", vehicleID),
-				slog.String("role", role.String()),
-			)
-		}
-	}
-}
-
-// v1Roles enumerates the roles for which the hub pre-marshals a frame
-// per call to BroadcastMasked. Two roles in v1 (FR-5.4); FR-5.5 adds
-// limited_viewer in a later release.
-var v1Roles = []auth.Role{auth.RoleOwner, auth.RoleViewer}
-
-// buildRoleFrames produces the per-role pre-marshaled vehicle_update
-// frames for a single broadcast. Iterates ONLY the activeRoles set
-// (distinct roles held by clients subscribed to this vehicle) to avoid
-// wasting marshal cost on roles no one is listening with. Returns a
-// map[role]frame; an entry with a nil value indicates empty-payload
-// suppression for that role. Marshal failures fall back to "no frame
-// for that role" rather than an error return — a single role's marshal
-// failure must not poison the broadcast for other roles.
-//
-// Audit emit (MYR-71, rest-api.md §5.3): for each role where the
-// mask removed at least one field AND mask.ShouldAuditWS samples in,
-// the hub fires a non-blocking AuditEntry insert via mask.EmitAsync.
-// The emit is per (vehicleID, role, frame) at the hub layer rather
-// than per client — this keeps audit volume proportional to vehicle
-// activity, not viewer count. Failures log slog.Warn and increment
-// audit_log_write_failures_total; they MUST NOT drop the frame.
-func (h *Hub) buildRoleFrames(
-	vehicleID string,
-	resource mask.ResourceType,
-	timestamp string,
-	payload map[string]any,
-	activeRoles map[auth.Role]struct{},
-	frameSeq uint64,
-) map[auth.Role][]byte {
-	frames := make(map[auth.Role][]byte, len(activeRoles))
-	for role := range activeRoles {
-		m := mask.For(resource, role)
-		projected, fieldsMasked := mask.Apply(payload, m)
-
-		// Audit-log emit per rest-api.md §5.3. Sampled at 1% by
-		// deterministic hash. Skipped if the role didn't actually
-		// strip any fields (the contract gates emit on
-		// "removed at least one field").
-		h.maybeEmitAuditWS(vehicleID, role, frameSeq, fieldsMasked)
-
-		if len(projected) == 0 {
-			// Empty-payload suppression per websocket-protocol.md §4.6.
-			frames[role] = nil
-			continue
-		}
-		frame, err := marshalVehicleUpdate(vehicleID, projected, timestamp)
-		if err != nil {
-			// Drop this role only; do not poison the broadcast.
-			continue
-		}
-		frames[role] = frame
-	}
-	return frames
-}
-
-// maybeEmitAuditWS evaluates the audit-emit gate for one (vehicleID,
-// role, frame) and fires a non-blocking insert if both the
-// "fieldsMasked is non-empty" precondition and the 1% sampler agree.
-// Pulled out of buildRoleFrames so the hot path stays linear and the
-// gate logic is independently testable.
-func (h *Hub) maybeEmitAuditWS(
-	vehicleID string,
-	role auth.Role,
-	frameSeq uint64,
-	fieldsMasked []string,
-) {
-	if h.auditEmitter == nil {
-		return
-	}
-	if len(fieldsMasked) == 0 {
-		return
-	}
-	if !mask.ShouldAuditWS(vehicleID, role, frameSeq) {
-		return
-	}
-	// userID is empty for WS — the audit emit is per (vehicleID, role,
-	// frame) at the hub, not per client. The targetID column carries
-	// the vehicleID; the role is in metadata; that's the canonical
-	// shape from rest-api.md §5.3 ("The audit emit happens once per
-	// (vehicleId, role, frame) at the hub layer, not per client").
-	entry, err := mask.BuildEntry(
-		"",
-		mask.TargetWSBroadcast,
-		vehicleID,
-		role,
-		mask.AuditChannelWS,
-		fieldsMasked,
-		"",
-	)
-	if err != nil {
-		// BuildEntry only fails on programmer errors (empty
-		// fieldsMasked, marshal panic). Log and skip — the frame
-		// itself still flies.
-		h.logger.Warn("hub.maybeEmitAuditWS: BuildEntry failed",
-			slog.String("vehicle_id", vehicleID),
-			slog.String("role", role.String()),
-			slog.String("error", err.Error()),
-		)
-		return
-	}
-	mask.EmitAsync(context.Background(), h.auditEmitter, h.auditMetrics, h.logger, entry)
-}
-
-// marshalVehicleUpdate wraps a projected payload in the wsMessage
-// envelope and returns the JSON bytes ready to enqueue.
-func marshalVehicleUpdate(vehicleID string, fields map[string]any, timestamp string) ([]byte, error) {
-	payloadBytes, err := json.Marshal(vehicleUpdatePayload{
-		VehicleID: vehicleID,
-		Fields:    fields,
-		Timestamp: timestamp,
-	})
-	if err != nil {
-		return nil, fmt.Errorf("marshalVehicleUpdate(vehicle=%s): payload: %w", vehicleID, err)
-	}
-	msg, err := json.Marshal(wsMessage{Type: msgTypeVehicleUpdate, Payload: payloadBytes})
-	if err != nil {
-		return nil, fmt.Errorf("marshalVehicleUpdate(vehicle=%s): envelope: %w", vehicleID, err)
-	}
-	return msg, nil
 }
 
 // BroadcastAll sends a message to all connected clients regardless of

--- a/internal/ws/hub_audit_test.go
+++ b/internal/ws/hub_audit_test.go
@@ -1,0 +1,296 @@
+package ws
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"log/slog"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/tnando/my-robo-taxi-telemetry/internal/auth"
+	"github.com/tnando/my-robo-taxi-telemetry/internal/mask"
+)
+
+// fakeAuditEmitter is a hub-level test AuditEmitter that records every
+// call and exposes a snapshot for assertions. The struct mirrors the
+// fakeAuditEmitter in internal/mask/audit_test.go but cannot be reused
+// across packages — keeping a copy here avoids a cyclic test-only
+// import.
+type fakeAuditEmitter struct {
+	mu      sync.Mutex
+	entries []mask.AuditEntry
+	err     error
+}
+
+func (f *fakeAuditEmitter) InsertAuditLog(_ context.Context, entry mask.AuditEntry) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.entries = append(f.entries, entry)
+	return f.err
+}
+
+func (f *fakeAuditEmitter) snapshot() []mask.AuditEntry {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	out := make([]mask.AuditEntry, len(f.entries))
+	copy(out, f.entries)
+	return out
+}
+
+// fakeAuditMetrics counts successful and failed audit writes.
+type fakeAuditMetrics struct {
+	writes   atomic.Int64
+	failures atomic.Int64
+}
+
+func (f *fakeAuditMetrics) IncAuditWrite(string, string)        { f.writes.Add(1) }
+func (f *fakeAuditMetrics) IncAuditWriteFailure(string, string) { f.failures.Add(1) }
+
+// waitForEmitter polls until f.snapshot() reaches the desired length
+// or the deadline expires. EmitAsync runs on a goroutine, so the test
+// must wait for it to settle before asserting.
+func waitForEmitter(t *testing.T, f *fakeAuditEmitter, want int) {
+	t.Helper()
+	deadline := time.After(2 * time.Second)
+	tick := time.NewTicker(2 * time.Millisecond)
+	defer tick.Stop()
+	for {
+		if len(f.snapshot()) >= want {
+			return
+		}
+		select {
+		case <-deadline:
+			t.Fatalf("timed out waiting for %d emitter entries, got %d", want, len(f.snapshot()))
+		case <-tick.C:
+		}
+	}
+}
+
+// TestHub_BroadcastMasked_EmitsAudit_OnViewerStrip exercises the WS
+// audit-emit gate end-to-end through BroadcastMasked. A viewer-role
+// client subscribes to a vehicle whose mask strips licensePlate. The
+// hub uses a per-vehicle frame counter starting at 1 and incrementing
+// per BroadcastMasked call; the test loops until ShouldAuditWS samples
+// in (1% rate, modulus 100), then asserts an audit row landed with the
+// canonical metadata shape from rest-api.md §5.3.
+func TestHub_BroadcastMasked_EmitsAudit_OnViewerStrip(t *testing.T) {
+	emitter := &fakeAuditEmitter{}
+	metrics := &fakeAuditMetrics{}
+
+	hub := NewHub(slog.Default(), NoopHubMetrics{}, WithMaskAudit(emitter, metrics))
+	t.Cleanup(hub.Stop)
+
+	a := &testAuth{
+		userID:        "user-1",
+		vehicleIDs:    []string{"v-1"},
+		roleByVehicle: map[string]auth.Role{"v-1": auth.RoleViewer},
+	}
+	srv := newTestServer(t, hub, a)
+	t.Cleanup(srv.Close)
+
+	conn := dialAndAuth(t, srv.URL, "valid-token")
+	t.Cleanup(func() { _ = conn.CloseNow() })
+
+	waitForClients(t, hub, 1)
+
+	// Compute up front which frameSeq value will sample in for our
+	// (vehicleID="v-1", role=viewer) pair. ShouldAuditWS uses
+	// 1-indexed counters per nextFrameSeq, so loop from 1 upward.
+	const vehicleID = "v-1"
+	role := auth.RoleViewer
+	var firstHit uint64 = 0
+	for seq := uint64(1); seq <= 5000; seq++ {
+		if mask.ShouldAuditWS(vehicleID, role, seq) {
+			firstHit = seq
+			break
+		}
+	}
+	if firstHit == 0 {
+		t.Fatal("no ShouldAuditWS hit found in 5000 frames; sampler is broken")
+	}
+
+	// Drive BroadcastMasked exactly firstHit times with a payload
+	// that the viewer mask strips at least one field from
+	// (licensePlate is owner-only).
+	payload := map[string]any{
+		"speed":        65,
+		"licensePlate": "ABC-123",
+	}
+	for i := uint64(0); i < firstHit; i++ {
+		hub.BroadcastMasked(
+			vehicleID,
+			mask.ResourceVehicleState,
+			time.Now().UTC().Format(time.RFC3339),
+			payload,
+		)
+	}
+
+	waitForEmitter(t, emitter, 1)
+
+	got := emitter.snapshot()
+	if len(got) != 1 {
+		t.Fatalf("expected exactly 1 audit entry, got %d", len(got))
+	}
+	entry := got[0]
+	if entry.Action != "mask_applied" {
+		t.Errorf("Action = %q, want mask_applied", entry.Action)
+	}
+	if entry.TargetType != string(mask.TargetWSBroadcast) {
+		t.Errorf("TargetType = %q, want ws_broadcast", entry.TargetType)
+	}
+	if entry.TargetID != vehicleID {
+		t.Errorf("TargetID = %q, want %q", entry.TargetID, vehicleID)
+	}
+	if entry.UserID != "" {
+		t.Errorf("UserID = %q; WS audit row must use empty userID (per-vehicle/role/frame, not per-client)", entry.UserID)
+	}
+
+	var meta map[string]any
+	if err := json.Unmarshal(entry.Metadata, &meta); err != nil {
+		t.Fatalf("unmarshal metadata: %v", err)
+	}
+	if meta["role"] != string(auth.RoleViewer) {
+		t.Errorf("metadata.role = %v, want viewer", meta["role"])
+	}
+	if meta["channel"] != string(mask.AuditChannelWS) {
+		t.Errorf("metadata.channel = %v, want ws", meta["channel"])
+	}
+	fields, ok := meta["fieldsMasked"].([]any)
+	if !ok || len(fields) == 0 {
+		t.Fatalf("metadata.fieldsMasked = %v, want non-empty list", meta["fieldsMasked"])
+	}
+
+	// Metric sanity: at least one successful write logged.
+	if got := metrics.writes.Load(); got < 1 {
+		t.Errorf("expected >=1 audit_log_writes_total, got %d", got)
+	}
+}
+
+// TestHub_BroadcastMasked_NoAudit_OnOwnerNoStrip verifies the gate's
+// "len(fieldsMasked) > 0" precondition: an owner-role broadcast where
+// the mask passes every field through MUST NOT trigger an audit emit
+// even if ShouldAuditWS would otherwise sample in. The contract emits
+// only when at least one field was actually removed.
+func TestHub_BroadcastMasked_NoAudit_OnOwnerNoStrip(t *testing.T) {
+	emitter := &fakeAuditEmitter{}
+	metrics := &fakeAuditMetrics{}
+
+	hub := NewHub(slog.Default(), NoopHubMetrics{}, WithMaskAudit(emitter, metrics))
+	t.Cleanup(hub.Stop)
+
+	a := &testAuth{
+		userID:        "user-1",
+		vehicleIDs:    []string{"v-1"},
+		roleByVehicle: map[string]auth.Role{"v-1": auth.RoleOwner},
+	}
+	srv := newTestServer(t, hub, a)
+	t.Cleanup(srv.Close)
+
+	conn := dialAndAuth(t, srv.URL, "valid-token")
+	t.Cleanup(func() { _ = conn.CloseNow() })
+
+	waitForClients(t, hub, 1)
+
+	// Drive 1000 broadcasts; without any fields removed, audit emit
+	// must stay at zero.
+	payload := map[string]any{"speed": 65, "licensePlate": "ABC-123"}
+	for range 1000 {
+		hub.BroadcastMasked(
+			"v-1",
+			mask.ResourceVehicleState,
+			time.Now().UTC().Format(time.RFC3339),
+			payload,
+		)
+	}
+
+	// Drain the connection so dropped messages don't backfill the
+	// emitter via some unintended path. Read deadlines are short
+	// because the goal is just to consume any pending frames.
+	go func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+		defer cancel()
+		for {
+			if _, _, err := conn.Read(ctx); err != nil {
+				return
+			}
+		}
+	}()
+
+	// Wait briefly for any goroutines to settle.
+	time.Sleep(50 * time.Millisecond)
+
+	if got := len(emitter.snapshot()); got != 0 {
+		t.Errorf("audit emitted %d times for owner with no fields stripped; want 0", got)
+	}
+	if got := metrics.writes.Load(); got != 0 {
+		t.Errorf("metrics.writes = %d, want 0 when nothing was masked", got)
+	}
+}
+
+// TestHub_BroadcastMasked_AuditEmitFailure_DoesNotDropFrame guards the
+// contract's non-blocking invariant: an InsertAuditLog error MUST log
+// + increment the failure metric but MUST NOT prevent the masked frame
+// from reaching the client.
+func TestHub_BroadcastMasked_AuditEmitFailure_DoesNotDropFrame(t *testing.T) {
+	emitter := &fakeAuditEmitter{err: errors.New("simulated DB failure")}
+	metrics := &fakeAuditMetrics{}
+
+	hub := NewHub(slog.Default(), NoopHubMetrics{}, WithMaskAudit(emitter, metrics))
+	t.Cleanup(hub.Stop)
+
+	a := &testAuth{
+		userID:        "user-1",
+		vehicleIDs:    []string{"v-1"},
+		roleByVehicle: map[string]auth.Role{"v-1": auth.RoleViewer},
+	}
+	srv := newTestServer(t, hub, a)
+	t.Cleanup(srv.Close)
+
+	conn := dialAndAuth(t, srv.URL, "valid-token")
+	t.Cleanup(func() { _ = conn.CloseNow() })
+
+	waitForClients(t, hub, 1)
+
+	// One broadcast that strips licensePlate; even if audit fails,
+	// the viewer must receive the projected frame.
+	hub.BroadcastMasked(
+		"v-1",
+		mask.ResourceVehicleState,
+		time.Now().UTC().Format(time.RFC3339),
+		map[string]any{
+			"speed":        65,
+			"licensePlate": "ABC-123",
+		},
+	)
+
+	got := readMessage(t, conn)
+	if got.Type != msgTypeVehicleUpdate {
+		t.Fatalf("expected vehicle_update despite audit failure, got %q", got.Type)
+	}
+}
+
+// TestHub_NextFrameSeq_PerVehicleMonotonic verifies the per-vehicle
+// counter is independent across vehicles and monotonic within one
+// vehicle. The audit sampler depends on this counter being unique per
+// (vehicleID, frame) so the 1% sample distributes uniformly.
+func TestHub_NextFrameSeq_PerVehicleMonotonic(t *testing.T) {
+	hub := NewHub(slog.Default(), NoopHubMetrics{})
+	t.Cleanup(hub.Stop)
+
+	if got := hub.nextFrameSeq("v-1"); got != 1 {
+		t.Errorf("first nextFrameSeq for v-1 = %d, want 1", got)
+	}
+	if got := hub.nextFrameSeq("v-1"); got != 2 {
+		t.Errorf("second nextFrameSeq for v-1 = %d, want 2", got)
+	}
+	// Distinct vehicles must keep distinct counters.
+	if got := hub.nextFrameSeq("v-2"); got != 1 {
+		t.Errorf("first nextFrameSeq for v-2 = %d, want 1 (independent counter)", got)
+	}
+	if got := hub.nextFrameSeq("v-1"); got != 3 {
+		t.Errorf("third nextFrameSeq for v-1 = %d, want 3", got)
+	}
+}

--- a/internal/ws/hub_audit_test.go
+++ b/internal/ws/hub_audit_test.go
@@ -174,6 +174,13 @@ func TestHub_BroadcastMasked_EmitsAudit_OnViewerStrip(t *testing.T) {
 // the mask passes every field through MUST NOT trigger an audit emit
 // even if ShouldAuditWS would otherwise sample in. The contract emits
 // only when at least one field was actually removed.
+//
+// Determinism note: maybeEmitAuditWS evaluates the
+// "len(fieldsMasked) > 0" gate on the CALLING goroutine — the `go ...`
+// in EmitAsync is only reached after the gate passes. For owner-no-
+// strip, no goroutine is spawned, so the emitter's snapshot can be
+// asserted synchronously after BroadcastMasked returns. No
+// time.Sleep is needed.
 func TestHub_BroadcastMasked_NoAudit_OnOwnerNoStrip(t *testing.T) {
 	emitter := &fakeAuditEmitter{}
 	metrics := &fakeAuditMetrics{}
@@ -194,8 +201,10 @@ func TestHub_BroadcastMasked_NoAudit_OnOwnerNoStrip(t *testing.T) {
 
 	waitForClients(t, hub, 1)
 
-	// Drive 1000 broadcasts; without any fields removed, audit emit
-	// must stay at zero.
+	// Drive 1000 owner-only broadcasts. The owner mask passes every
+	// field through, so maybeEmitAuditWS hits the
+	// `len(fieldsMasked) == 0` early return on every iteration — no
+	// goroutines spawn, no asynchrony to wait for.
 	payload := map[string]any{"speed": 65, "licensePlate": "ABC-123"}
 	for range 1000 {
 		hub.BroadcastMasked(
@@ -206,22 +215,21 @@ func TestHub_BroadcastMasked_NoAudit_OnOwnerNoStrip(t *testing.T) {
 		)
 	}
 
-	// Drain the connection so dropped messages don't backfill the
-	// emitter via some unintended path. Read deadlines are short
-	// because the goal is just to consume any pending frames.
+	// Drain the connection so dropped messages don't accumulate.
+	// Read deadlines are short because the goal is just to consume
+	// any pending frames so the buffer doesn't backpressure.
+	drainCtx, drainCancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+	defer drainCancel()
 	go func() {
-		ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
-		defer cancel()
 		for {
-			if _, _, err := conn.Read(ctx); err != nil {
+			if _, _, err := conn.Read(drainCtx); err != nil {
 				return
 			}
 		}
 	}()
 
-	// Wait briefly for any goroutines to settle.
-	time.Sleep(50 * time.Millisecond)
-
+	// Synchronous assertion — no goroutine ever fired for owner-no-
+	// strip, so the emitter must be empty immediately.
 	if got := len(emitter.snapshot()); got != 0 {
 		t.Errorf("audit emitted %d times for owner with no fields stripped; want 0", got)
 	}

--- a/internal/ws/hub_masked.go
+++ b/internal/ws/hub_masked.go
@@ -1,0 +1,259 @@
+package ws
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"sync/atomic"
+
+	"github.com/tnando/my-robo-taxi-telemetry/internal/auth"
+	"github.com/tnando/my-robo-taxi-telemetry/internal/mask"
+)
+
+// WithMaskAudit attaches a mask-audit emitter and metrics to the hub.
+// When configured, the hub emits an AuditEntry per (vehicleID, role,
+// frame) where the role's mask removed at least one field, sampled at
+// the 1% rate computed by mask.ShouldAuditWS. emitter MAY be nil — in
+// which case this option is a no-op (defensive: a misconfigured wiring
+// path should not crash the hot path).
+func WithMaskAudit(emitter mask.AuditEmitter, metrics mask.AuditMetrics) HubOption {
+	return func(h *Hub) {
+		if emitter == nil {
+			return
+		}
+		h.auditEmitter = emitter
+		if metrics == nil {
+			metrics = mask.NoopAuditMetrics{}
+		}
+		h.auditMetrics = metrics
+	}
+}
+
+// nextFrameSeq increments and returns the per-vehicle monotonic frame
+// counter used as ShouldAuditWS input. The first call for a given
+// vehicleID returns 1; subsequent calls return 2, 3, ... A sync.Map
+// LoadOrStore on the first call avoids the race between two goroutines
+// observing zero and both creating a counter — the second goroutine
+// loses the LoadOrStore race, throws away its counter, and uses the
+// winner's.
+//
+// Note on lifetime: frameCounters keys live for the lifetime of the
+// process. At fleet scale this would leak ~24 bytes per VIN forever;
+// in v1 the vehicle set is small. DV-02 (envelope sequence numbers)
+// will obsolete this counter entirely, so a cleanup hook is not
+// added here — the eviction problem disappears with the migration.
+func (h *Hub) nextFrameSeq(vehicleID string) uint64 {
+	v, ok := h.frameCounters.Load(vehicleID)
+	if !ok {
+		v, _ = h.frameCounters.LoadOrStore(vehicleID, new(atomic.Uint64))
+	}
+	return v.(*atomic.Uint64).Add(1)
+}
+
+// BroadcastMasked is the per-role projection broadcast path required
+// by websocket-protocol.md §4.6. It pre-marshals one frame per
+// active role for this vehicle (the set of distinct roles held by
+// currently-subscribed clients), then fans out the role-appropriate
+// bytes to each authorized client based on that client's per-vehicle
+// role (populated at handshake time).
+//
+// Marshal cost is O(|active roles for this vehicle|), bounded above by
+// O(|v1 roles|). Fan-out is O(|clients|). Per §4.6 "empty-payload
+// suppression": if a role's mask projects the payload down to zero
+// fields, no frame is emitted for clients holding that role — a viewer
+// who shouldn't even know an event happened on the vehicle MUST NOT
+// see an empty vehicle_update.
+//
+// Clients whose roleFor(vehicleID) returns the empty Role("") sentinel
+// (e.g., handshake-time ResolveRole failed) receive nothing — the
+// fail-closed behavior described in rest-api.md §5.
+//
+// Active-role pre-pass: we walk h.clients ONCE under RLock to collect
+// the distinct roles actually subscribed for this vehicleID, then only
+// marshal frames for those roles. Skipping unused roles matters in
+// practice today (every connection in v1 is owner — viewers via the
+// Invite flow haven't shipped yet) and the savings grow with FR-5.5's
+// third role. PR #195 review suggestion #1.
+func (h *Hub) BroadcastMasked(
+	vehicleID string,
+	resource mask.ResourceType,
+	timestamp string,
+	payload map[string]any,
+) {
+	if len(payload) == 0 {
+		return
+	}
+
+	h.mu.RLock()
+	defer h.mu.RUnlock()
+
+	// Pass 1: collect the distinct set of roles held by clients
+	// subscribed to this vehicle. O(|clients|).
+	activeRoles := make(map[auth.Role]struct{}, len(v1Roles))
+	for client := range h.clients {
+		if !client.hasVehicle(vehicleID) {
+			continue
+		}
+		activeRoles[client.roleFor(vehicleID)] = struct{}{}
+	}
+	if len(activeRoles) == 0 {
+		return
+	}
+
+	// Per rest-api.md §5.3: the audit emit's frameSeq is per-vehicle.
+	// Bump once per BroadcastMasked call so every role that processes
+	// this frame sees the same seq value — the role itself goes into
+	// the hash too, so distinct roles still get distinct sampling
+	// decisions for the same frame.
+	frameSeq := h.nextFrameSeq(vehicleID)
+
+	// Pass 2: marshal only the frames we will actually use.
+	framesByRole := h.buildRoleFrames(vehicleID, resource, timestamp, payload, activeRoles, frameSeq)
+	if len(framesByRole) == 0 {
+		return
+	}
+
+	// Pass 3: fan out under the same RLock so the client set we marshaled
+	// for is the same client set we deliver to (no torn snapshot).
+	for client := range h.clients {
+		if !client.hasVehicle(vehicleID) {
+			continue
+		}
+		role := client.roleFor(vehicleID)
+		frame, ok := framesByRole[role]
+		if !ok || frame == nil {
+			// Empty-payload suppression OR unknown role -> deny-all.
+			continue
+		}
+		if dropped := client.enqueue(frame); dropped {
+			h.metrics.IncMessagesDropped()
+			h.logger.Debug("dropped masked message for slow client",
+				slog.String("user_id", client.userID),
+				slog.String("vehicle_id", vehicleID),
+				slog.String("role", role.String()),
+			)
+		}
+	}
+}
+
+// v1Roles enumerates the roles for which the hub pre-marshals a frame
+// per call to BroadcastMasked. Two roles in v1 (FR-5.4); FR-5.5 adds
+// limited_viewer in a later release.
+var v1Roles = []auth.Role{auth.RoleOwner, auth.RoleViewer}
+
+// buildRoleFrames produces the per-role pre-marshaled vehicle_update
+// frames for a single broadcast. Iterates ONLY the activeRoles set
+// (distinct roles held by clients subscribed to this vehicle) to avoid
+// wasting marshal cost on roles no one is listening with. Returns a
+// map[role]frame; an entry with a nil value indicates empty-payload
+// suppression for that role. Marshal failures fall back to "no frame
+// for that role" rather than an error return — a single role's marshal
+// failure must not poison the broadcast for other roles.
+//
+// Audit emit (MYR-71, rest-api.md §5.3): for each role where the
+// mask removed at least one field AND mask.ShouldAuditWS samples in,
+// the hub fires a non-blocking AuditEntry insert via mask.EmitAsync.
+// The emit is per (vehicleID, role, frame) at the hub layer rather
+// than per client — this keeps audit volume proportional to vehicle
+// activity, not viewer count. Failures log slog.Warn and increment
+// audit_log_write_failures_total; they MUST NOT drop the frame.
+func (h *Hub) buildRoleFrames(
+	vehicleID string,
+	resource mask.ResourceType,
+	timestamp string,
+	payload map[string]any,
+	activeRoles map[auth.Role]struct{},
+	frameSeq uint64,
+) map[auth.Role][]byte {
+	frames := make(map[auth.Role][]byte, len(activeRoles))
+	for role := range activeRoles {
+		m := mask.For(resource, role)
+		projected, fieldsMasked := mask.Apply(payload, m)
+
+		// Audit-log emit per rest-api.md §5.3. Sampled at 1% by
+		// deterministic hash. Skipped if the role didn't actually
+		// strip any fields (the contract gates emit on
+		// "removed at least one field").
+		h.maybeEmitAuditWS(vehicleID, role, frameSeq, fieldsMasked)
+
+		if len(projected) == 0 {
+			// Empty-payload suppression per websocket-protocol.md §4.6.
+			frames[role] = nil
+			continue
+		}
+		frame, err := marshalVehicleUpdate(vehicleID, projected, timestamp)
+		if err != nil {
+			// Drop this role only; do not poison the broadcast.
+			continue
+		}
+		frames[role] = frame
+	}
+	return frames
+}
+
+// maybeEmitAuditWS evaluates the audit-emit gate for one (vehicleID,
+// role, frame) and fires a non-blocking insert if both the
+// "fieldsMasked is non-empty" precondition and the 1% sampler agree.
+// Pulled out of buildRoleFrames so the hot path stays linear and the
+// gate logic is independently testable.
+func (h *Hub) maybeEmitAuditWS(
+	vehicleID string,
+	role auth.Role,
+	frameSeq uint64,
+	fieldsMasked []string,
+) {
+	if h.auditEmitter == nil {
+		return
+	}
+	if len(fieldsMasked) == 0 {
+		return
+	}
+	if !mask.ShouldAuditWS(vehicleID, role, frameSeq) {
+		return
+	}
+	// userID is empty for WS — the audit emit is per (vehicleID, role,
+	// frame) at the hub, not per client. The targetID column carries
+	// the vehicleID; the role is in metadata; that's the canonical
+	// shape from rest-api.md §5.3 ("The audit emit happens once per
+	// (vehicleId, role, frame) at the hub layer, not per client").
+	entry, err := mask.BuildEntry(
+		"",
+		mask.TargetWSBroadcast,
+		vehicleID,
+		role,
+		mask.AuditChannelWS,
+		fieldsMasked,
+		"",
+	)
+	if err != nil {
+		// BuildEntry only fails on programmer errors (empty
+		// fieldsMasked, marshal panic). Log and skip — the frame
+		// itself still flies.
+		h.logger.Warn("hub.maybeEmitAuditWS: BuildEntry failed",
+			slog.String("vehicle_id", vehicleID),
+			slog.String("role", role.String()),
+			slog.String("error", err.Error()),
+		)
+		return
+	}
+	mask.EmitAsync(context.Background(), h.auditEmitter, h.auditMetrics, h.logger, entry)
+}
+
+// marshalVehicleUpdate wraps a projected payload in the wsMessage
+// envelope and returns the JSON bytes ready to enqueue.
+func marshalVehicleUpdate(vehicleID string, fields map[string]any, timestamp string) ([]byte, error) {
+	payloadBytes, err := json.Marshal(vehicleUpdatePayload{
+		VehicleID: vehicleID,
+		Fields:    fields,
+		Timestamp: timestamp,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("marshalVehicleUpdate(vehicle=%s): payload: %w", vehicleID, err)
+	}
+	msg, err := json.Marshal(wsMessage{Type: msgTypeVehicleUpdate, Payload: payloadBytes})
+	if err != nil {
+		return nil, fmt.Errorf("marshalVehicleUpdate(vehicle=%s): envelope: %w", vehicleID, err)
+	}
+	return msg, nil
+}


### PR DESCRIPTION
## Summary

Wires the three existing `mask_applied` AuditLog-insert TODOs against the `AuditLog` table from MYR-70. This is the lowest-risk way to validate the audit infrastructure end-to-end before user-facing deletion endpoints ship — the inserted rows describe routine RBAC mask events with strictly P0 metadata.

- **WS hub** (`internal/ws/hub.go`): per-(vehicleID, role, frame) audit emit at the hub layer per rest-api.md §5.3. Per-vehicle `sync.Map` of `*atomic.Uint64` supplies the in-process `frameSeq` until DV-02 ships envelope sequence numbers.
- **REST** (`internal/telemetry/vehicle_status_mask.go`): per-request audit emit gated on `ShouldAuditREST(userID, X-Request-ID, vehicleID)` at 1%. The handler reads the `X-Request-ID` header per §4.4 and falls back to a 32-char hex random when missing.
- **Helpers** (`internal/mask/audit.go`): `BuildEntry`, `EmitAsync`, `AuditEmitter`, `AuditMetrics`. Strict `auditMetadata` struct (role / channel / fieldsMasked / endpoint) makes CG-DL-5 P1 leakage uncompilable. `EmitAsync` detaches from the caller's context (`context.WithoutCancel` + 2s timeout), recovers from emitter panics, and increments Prometheus counters — never drops a frame on failure.
- **Adapter** (`internal/store/audit_emitter.go`): `MaskAuditEmitter` bridges `mask.AuditEntry` -> `store.AuditEntry` so internal/mask never imports internal/store. Field-by-field copy in `convertAuditEntry` makes any cross-package field rename a compile error.
- **Composition root** (`cmd/telemetry-server/main.go`): `store.NewAuditRepo`, `store.NewMaskAuditEmitter`, `mask.NewPrometheusAuditMetrics`, and `ws.WithMaskAudit(...)` wired together.

## Sampling design

Per `rest-api.md` §5.3, deterministic 1% sampling computed by hash modulo 100:

```
REST: shouldAudit := hash(userId || requestId || resourceId) mod 100 == 0
WS:   shouldAudit := hash(vehicleId || role || frameSeq)     mod 100 == 0
```

FNV-1a length-prefixed inputs avoid collisions like `("ab", "cdef")` vs `("abc", "def")`. Distribution test over 10000 samples confirms 50–200 hits (target ~100).

## Non-blocking design

- `EmitAsync` spawns a goroutine — the hot path never blocks on the DB.
- Detached context (`context.WithoutCancel`) so a canceled request still completes the audit insert.
- 2 s timeout caps stuck-pool failure modes.
- `recover()` around the insert so a buggy emitter cannot crash the broadcast goroutine.
- Failures log `slog.Warn` and increment `audit_log_write_failures_total{action,target}`; successes increment `audit_log_writes_total{action,target}`.

## Prometheus metrics added

- `telemetry_audit_log_writes_total{action,target}` — successful inserts.
- `telemetry_audit_log_write_failures_total{action,target}` — insert errors.

Cardinality is bounded by the closed `action` × `targetType` enum set in data-lifecycle.md §4.2.

## CG-DL-5 compliance

Metadata is constructed via the strict `auditMetadata` struct with closed fields `role` / `channel` / `fieldsMasked` / `endpoint`. No free-form `map[string]any` reaches the JSONB column — adding a new key requires a contract update first. The integration test asserts every persisted metadata key is in the allow-list after a real DB round-trip.

## Test plan

- [x] `go vet ./...` passes
- [x] `golangci-lint run ./...` passes (0 issues)
- [x] `go build ./cmd/...` passes
- [x] `go test ./...` passes (all packages green)
- [x] Unit: sampling distribution (~1% over 10K samples), `BuildEntry` shape, P1 metadata rejection
- [x] Hub test: `BroadcastMasked` calls audit emitter when fields stripped + sampler agrees; not called on owner allow-all
- [x] Hub test: emit failure does not drop the masked frame to clients
- [x] REST test: sampling-in / not-sampling-in paths, X-Request-ID header fallback, audit-failure-does-not-break-response invariant
- [x] Integration test (testcontainers Postgres): drives 25 deterministic events through `EmitAsync -> MaskAuditEmitter -> AuditRepo`, asserts every column persists with the canonical metadata shape after a real DB round-trip

## Anchored FRs/NFRs

- FR-10.2 / NFR-3.29 — audit infrastructure (mask_applied is the first system-initiated emit)
- NFR-3.20 — audit log sampling for masked responses
- `data-lifecycle.md` §4.2 — mask_applied action / targetType / initiator enums
- `data-lifecycle.md` §4.4 / CG-DL-5 — P0-only metadata
- `rest-api.md` §5.3 — 1% deterministic-hash sampling normative spec
- `websocket-protocol.md` §4.6 — hub-layer per-role projection (where the WS audit emit lives)

🤖 Generated with [Claude Code](https://claude.com/claude-code)