### PR TITLE
infra: migrate Claude Review workflow to myrobotaxi-pr-review GitHub App

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -30,15 +30,27 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
+      # Generate a short-lived (~1h) installation token from the
+      # `myrobotaxi-pr-review` GitHub App, owned by the org. App-issued
+      # tokens are accepted by branch protection's "required approving
+      # reviews" rule and the App identity does not consume a billable
+      # seat (replaces the previous tnando-gh-bot collaborator).
+      - name: Generate App installation token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ vars.REVIEWER_APP_ID }}
+          private-key: ${{ secrets.REVIEWER_APP_PRIVATE_KEY }}
+
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
-          token: ${{ secrets.GH_PAT }}
+          token: ${{ steps.app-token.outputs.token }}
 
       - name: Collect PR context
         id: context
         env:
-          GH_TOKEN: ${{ secrets.GH_PAT }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           PR_NUM="${{ github.event.pull_request.number }}"
 
@@ -68,7 +80,7 @@ jobs:
         uses: anthropics/claude-code-action@b4d67413279fc18c6e5de930ae307c4f108714eb # v1.0.104
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          github_token: ${{ secrets.GH_PAT }}
+          github_token: ${{ steps.app-token.outputs.token }}
           use_sticky_comment: true
           track_progress: true
           claude_args: >-
@@ -96,7 +108,7 @@ jobs:
       - name: Extract review verdict
         id: verdict
         env:
-          GH_TOKEN: ${{ secrets.GH_PAT }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           PR_NUM="${{ github.event.pull_request.number }}"
 
@@ -117,7 +129,7 @@ jobs:
 
       - name: Submit review verdict
         env:
-          GH_TOKEN: ${{ secrets.BOT_PAT }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           PR_NUM="${{ github.event.pull_request.number }}"
           VERDICT="${{ steps.verdict.outputs.verdict }}"
@@ -146,10 +158,17 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
+      - name: Generate App installation token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ vars.REVIEWER_APP_ID }}
+          private-key: ${{ secrets.REVIEWER_APP_PRIVATE_KEY }}
+
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
-          token: ${{ secrets.GH_PAT }}
+          token: ${{ steps.app-token.outputs.token }}
 
       # Pinned to v1.0.104. v1.0.105 (Apr 23 23:24) bumped the underlying
       # Agent SDK to 0.2.119 and broke the action with an internal
@@ -160,6 +179,6 @@ jobs:
       - uses: anthropics/claude-code-action@b4d67413279fc18c6e5de930ae307c4f108714eb # v1.0.104
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          github_token: ${{ secrets.GH_PAT }}
+          github_token: ${{ steps.app-token.outputs.token }}
           claude_args: >-
             --max-turns 10


### PR DESCRIPTION
## Summary

Replaces personal-access-token authentication in the Claude Review workflow (`GH_PAT` for checkout + action, `BOT_PAT` for review submission) with short-lived installation tokens from the new `myrobotaxi-pr-review` GitHub App owned by the org.

## Why

- **App-issued reviews satisfy branch protection's "required approving reviews" rule** — same gate strength as a human approval, no `tnando-gh-bot` collaborator needed.
- **No billable org seat consumed** — the previous `tnando-gh-bot` pattern was costing $4/month per repo. One App, one set of credentials, every repo in the org inherits.
- **Org-level secret + variable** — `REVIEWER_APP_PRIVATE_KEY` + `REVIEWER_APP_ID` are configured at the org level (visibility: all). Rotating the App's private key is a single `gh secret set --org` command for the entire org.

## Required org-level credentials (already configured)

| Type | Name | Value |
|---|---|---|
| Variable | `REVIEWER_APP_ID` | `3671549` |
| Secret | `REVIEWER_APP_PRIVATE_KEY` | App private key `.pem` |
| Secret | `CLAUDE_CODE_OAUTH_TOKEN` | Anthropic Claude Code OAuth token |

## Changes

Both jobs in `.github/workflows/claude-review.yml` (`review` and `interactive`) now generate an App installation token via `actions/create-github-app-token@v1` and use it everywhere the prior `GH_PAT` / `BOT_PAT` were used:

- `actions/checkout`'s `token`
- `claude-code-action`'s `github_token`
- `GH_TOKEN` env on the verdict-extraction step
- `GH_TOKEN` env on the `gh pr review --approve` / `--request-changes` / `--comment` step

## Cleanup follow-ups (deferred)

- `GH_PAT` and `BOT_PAT` secrets on this repo can be retired after the next Claude Review fires successfully under the new App identity.
- `tnando-gh-bot` collaborator can be removed from this repo (and the GitHub account closed if no longer used elsewhere).
- 666 `tnando/` URL references in `docs/contracts/` etc. remain in place — GitHub's owner-rename auto-redirect handles them. A bulk rename PR can be filed separately when convenient.

## Test plan

- [ ] CI's `Lint` / `Test` / `Build` / `Security` / `Contract Guard` jobs all pass (these don't touch the App token).
- [ ] `Claude Review` job uses the App token and posts a sticky comment under the `myrobotaxi-pr-review[bot]` identity.
- [ ] The verdict-submission step uses the App token and the PR shows an APPROVED/COMMENT/REQUEST_CHANGES review under the bot identity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)