### PR TITLE
config(fly): allow testbench.myrobotaxi.app WS origin

### DIFF
--- a/configs/fly.json
+++ b/configs/fly.json
@@ -34,7 +34,8 @@
     "read_limit": 4096,
     "allowed_origins": [
       "https://myrobotaxi.app",
-      "https://www.myrobotaxi.app"
+      "https://www.myrobotaxi.app",
+      "https://testbench.myrobotaxi.app"
     ]
   },
   "auth": {


### PR DESCRIPTION
One-line WS allowlist addition so the SDK test bench (deployed to `https://testbench.myrobotaxi.app`) can open its browser WebSocket to the deployed `/api/ws` — otherwise the handler origin-rejects it server-side (NFR-3.22).

**Scope:** WS `allowed_origins` only. REST is unchanged: the platform calls telemetry REST server-side (react-frontend's `TELEMETRY_API_URL` is server-only), and the bench mirrors that by proxying REST through its own Next server — so no CORS surface is added to prod.

Deploy: redeploy telemetry with `configs/fly.json` for this to take effect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)