### PR TITLE
MYR-129 perf(db): enable prepared statements; max_conns 10 → 20 (pairs with direct-connection DATABASE_URL)

### DIFF
--- a/configs/fly.json
+++ b/configs/fly.json
@@ -11,9 +11,9 @@
     "ca_file": "/tmp/certs/tesla-ca.pem"
   },
   "database": {
-    "max_conns": 10,
+    "max_conns": 20,
     "min_conns": 2,
-    "disable_prepared_statements": true
+    "disable_prepared_statements": false
   },
   "telemetry": {
     "max_vehicles": 100,


### PR DESCRIPTION
## Summary

Two-line config change in `configs/fly.json`:
- `disable_prepared_statements: true` → `false`
- `max_conns: 10` → `20`

## Why

The current Fly `DATABASE_URL` points at Supabase's **PgBouncer transaction-mode pooler** (`pooler.supabase.com:6543`). That's the wrong tier for a long-lived Fly machine — it forces pgx into `QueryExecModeSimpleProtocol` (no prepared statements, per-query parse/plan overhead), and adds PgBouncer connection-routing latency on every call.

Hard evidence from the MYR-122 duration logs after the lean projection deployed:
- `vehicle.list_summaries_by_user` returned **2 rows in 31.19 s**
- WS handshake `auth.GetUserVehicles` timed out at **4.7 s** with `context deadline exceeded` — and this is the root cause of [MYR-126](https://linear.app/myrobotaxi/issue/MYR-126) (Live Stream not populating; the 6 s pre-auth gate trips before `auth_ok`)

Neither number is query-plan work. It's pooler + parse overhead.

## Ordering (load-bearing)

1. **First**: user updates `DATABASE_URL` Fly secret to Supabase's **direct connection** URI (`postgresql://...:5432/postgres`). That auto-deploys.
2. **Then**: merge this PR. That triggers a second deploy with the new config consuming the new URL.

If this PR merges before the secret flips, pgx will try prepared statements on PgBouncer transaction-mode connections and queries will fail with `prepared statement does not exist`. The `disable_prepared_statements: true` was guarding against exactly that. Once the secret is direct-5432, the guard becomes a tax.

## Acceptance

- [x] User has updated Fly `DATABASE_URL` to Supabase direct connection (port 5432)
- [ ] Merge → Fly deploys → check `vehicle.list_summaries_by_user` duration log: < 100 ms warm, < 500 ms cold
- [ ] Check WS handshake `ws.handshake: GetUserVehicles` duration log: < 200 ms (was timing out at 4.7 s)
- [ ] Bench refresh: vehicles list snappy; Live Stream starts populating frames ([MYR-126](https://linear.app/myrobotaxi/issue/MYR-126) closes as a side effect)

## Out of scope

- Drives 404 ([MYR-130](https://linear.app/myrobotaxi/issue/MYR-130)) — different fix (implement the endpoint).
- Prisma `Vehicle(userId)` index ([MYR-127](https://linear.app/myrobotaxi/issue/MYR-127)) — still worth shipping for steady-state but the dominant gain comes from this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)