### PR TITLE
MYR-131 perf(db): bump telemetry batch_write_interval 5s → 60s

### DIFF
--- a/configs/default.json
+++ b/configs/default.json
@@ -16,7 +16,7 @@
   "telemetry": {
     "max_vehicles": 100,
     "event_buffer_size": 1000,
-    "batch_write_interval": "5s",
+    "batch_write_interval": "60s",
     "batch_write_size": 100
   },
   "drives": {

--- a/configs/dev-notls.json
+++ b/configs/dev-notls.json
@@ -16,7 +16,7 @@
   "telemetry": {
     "max_vehicles": 100,
     "event_buffer_size": 1000,
-    "batch_write_interval": "5s",
+    "batch_write_interval": "60s",
     "batch_write_size": 100
   },
   "drives": {

--- a/configs/fly.json
+++ b/configs/fly.json
@@ -18,7 +18,7 @@
   "telemetry": {
     "max_vehicles": 100,
     "event_buffer_size": 1000,
-    "batch_write_interval": "5s",
+    "batch_write_interval": "60s",
     "batch_write_size": 100
   },
   "drives": {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -169,7 +169,7 @@ func TestLoad_DefaultsApplied(t *testing.T) {
 		{"database.min_conns", cfg.Database().MinConns, 5},
 		{"telemetry.max_vehicles", cfg.Telemetry().MaxVehicles, 100},
 		{"telemetry.event_buffer_size", cfg.Telemetry().EventBufferSize, 1000},
-		{"telemetry.batch_write_interval", cfg.Telemetry().BatchWriteInterval, 5 * time.Second},
+		{"telemetry.batch_write_interval", cfg.Telemetry().BatchWriteInterval, 60 * time.Second},
 		{"telemetry.batch_write_size", cfg.Telemetry().BatchWriteSize, 100},
 		{"drives.min_duration", cfg.Drives().MinDuration, 2 * time.Minute},
 		{"drives.min_distance_miles", cfg.Drives().MinDistanceMiles, 0.1},

--- a/internal/config/defaults.go
+++ b/internal/config/defaults.go
@@ -35,7 +35,11 @@ func applyTelemetryDefaults(t *fileTelemetryConfig) {
 		t.EventBufferSize = 1000
 	}
 	if t.BatchWriteInterval.Dur() == 0 {
-		t.BatchWriteInterval = Duration{d: 5 * time.Second}
+		// 60s default chosen to relieve Postgres write pressure (MYR-131).
+		// NFR-3.11 cold-load freshness tolerates ≤60s staleness because
+		// browsers open the live WS immediately after /snapshot and the
+		// next telemetry frame snaps the UI to current.
+		t.BatchWriteInterval = Duration{d: 60 * time.Second}
 	}
 	if t.BatchWriteSize == 0 {
 		t.BatchWriteSize = 100


### PR DESCRIPTION
## Summary

- Bumps `telemetry.batch_write_interval` from **5s → 60s** in `internal/config/defaults.go` and all three `configs/*.json` (including `configs/fly.json` which prod loads).
- Reduces per-vehicle `Vehicle` row UPDATEs by **12×** (17,280/day → 1,440/day).
- One-line config change. No writer logic, schema, or contract changes.

## Why now

Supabase Nano Postgres has been pinned at **100% max CPU + 100% daily disk-IO budget** for the past week (75% baseline memory). The dominant write-path cost is the 5s wide UPDATE on the `Vehicle` row per active VIN, which under simple-protocol mode re-parses + re-plans every statement. MYR-129 already addressed the simple-protocol side by enabling prepared statements; this PR addresses the write *frequency*.

## Why it's contract-safe

- **NFR-3.11** (`docs/contracts/rest-api.md` §7.1): "Reconnect re-fetches DB snapshot before resuming live stream." The contract doesn't require the snapshot to be sub-second fresh — the browser opens the live WS immediately after `/snapshot` and the next telemetry frame snaps the UI to current. A ≤60s-stale snapshot row still satisfies NFR-3.11.
- **NFR-3.28** (`docs/contracts/data-lifecycle.md` §1.5): "Per-second speed/heading/GPS during active drive — None as individual events — Aggregated into Drive.routePoints at drive completion only." The long-term aim is to stop persisting live telemetry per-frame entirely. This change moves us toward NFR-3.28 alignment without yet touching the writer architecture.
- **WebSocket message shapes** (`internal/ws/messages.go`, `nav_broadcast.go`, `route_broadcast.go`): unchanged. The live UI is driven by the event-bus broadcast path (`route_accumulator`, `nav_broadcast`), not the DB write path.
- **Atomic groups** (`docs/contracts/data-lifecycle.md` §6.1): about consistency *within* a write, not write frequency. Identical guarantees at 60s.

See [MYR-131](https://linear.app/myrobotaxi/issue/MYR-131) for full design rationale and follow-ups.

## Test plan

- [x] `go vet ./...` clean
- [x] `go test ./...` passes (config + store + telemetry + cmd)
- [x] `golangci-lint run ./...` reports 0 issues
- [ ] CI green (lint, test, build, contract-guard)
- [ ] Post-merge: Fly logs show `store writer started ... flush_interval=1m0s`
- [ ] Post-merge: Supabase CPU/disk-IO drop measurably within 24h

## Rollback

Revert this PR. Fly redeploys in ~1 minute. No schema or data migration.

## Out of scope (filed as follow-ups, not in this PR)

- Collapse `DriveRepo.AppendRoutePoints` to a single drive-end write (eliminates the per-10s JSONB-concat hot loop).
- Bump the three `*PlaintextGauge` intervals from 5min → 1hr (11 sequential `COUNT(*)` scans every 5 min is the next-biggest disk-IO offender).
- pgxpool tuning for the Nano tier (`MaxConns=20→8, MinConns=5→1`).
- Move to in-RAM live-state cache (full NFR-3.28 alignment).

🤖 Generated with [Claude Code](https://claude.com/claude-code)