### PR TITLE
MYR-129 perf(db): right-size pgxpool for Nano (max_conns 20→8, min_conns 2→1)

### DIFF
--- a/configs/fly.json
+++ b/configs/fly.json
@@ -11,8 +11,8 @@
     "ca_file": "/tmp/certs/tesla-ca.pem"
   },
   "database": {
-    "max_conns": 20,
-    "min_conns": 2,
+    "max_conns": 8,
+    "min_conns": 1,
     "disable_prepared_statements": false
   },
   "telemetry": {


### PR DESCRIPTION
## Summary

Drops `max_conns: 20 → 8` and `min_conns: 2 → 1` in `configs/fly.json`.

## Why

My earlier MYR-129 change (#240) bumped `max_conns 10 → 20` — wrong direction for the actual deployed compute, which is Supabase **Nano** Postgres (small connection budget). The other agent's MYR-131 (#241) explicitly flagged this in follow-ups: *"Tuning the pgxpool: MaxConns=20→8, MinConns=5→1 for the Nano tier."*

## Evidence

After MYR-131 deployed (v139), bench `GET /api/vehicles` went from 24s → **122s + 500 (`statement_timeout`)** — worse, not better. MYR-131's 12× write reduction is doing its job on the writer side, but the read path is hitting `ERROR: canceling statement due to statement timeout (SQLSTATE 57014)` because the DB is still saturated. Connection pressure from `max_conns=20` likely contributed.

Keeping the direct-connection + prepared-statements parts of MYR-129 (those are still net-positive once connection count is right-sized for Nano).

## Test plan

- [x] Two-line config change, no code logic touched
- [ ] After CI auto-deploys: check Fly logs for `database connection established max_conns=8 min_conns=1`
- [ ] Refresh bench `/api/vehicles` should complete (DB headroom restored). If still slow, the DB itself is still recovering from prior write-amp backlog and the proper next step is upgrading Nano → Small or further reducing telemetry footprint (NFR-3.28 alignment)

## Out of scope

- The deeper NFR-3.28 alignment (stop persisting per-frame telemetry) — separate ticket.
- Reverting MYR-129's direct-connection + prepared-statements is intentionally **not** done — those are still the right shape for direct-5432, just with the correct connection count.

🤖 Generated with [Claude Code](https://claude.com/claude-code)