### PR TITLE
MYR-131 follow-up perf(gauges): bump *PlaintextGauge intervals 5m → 1h

### DIFF
--- a/cmd/telemetry-server/main.go
+++ b/cmd/telemetry-server/main.go
@@ -29,22 +29,25 @@ import (
 )
 
 // accountTokenGaugeInterval is how often the running server polls the
-// Account table for plaintext-without-ciphertext tokens. Slow enough to
-// avoid load (the rollout window is hours/days, not seconds), fast
-// enough that an alerting pipeline catches a regression promptly.
-const accountTokenGaugeInterval = 5 * time.Minute
+// Account table for plaintext-without-ciphertext tokens. The rollout
+// window is hours/days, not seconds — 1h cadence is plenty for an
+// alerting pipeline and a 12× reduction in COUNT(*) scans vs. the
+// prior 5m. MYR-131 flagged the 5m cadence as the bigger disk-IO
+// offender on Nano compute.
+const accountTokenGaugeInterval = 1 * time.Hour
 
 // vehicleGPSGaugeInterval is the MYR-63 sibling of
-// accountTokenGaugeInterval — same 5-minute cadence over the six
-// Vehicle GPS *Enc columns. The two loops are independent so a stall
-// in one (e.g., a long-running migration) doesn't starve the other.
-const vehicleGPSGaugeInterval = 5 * time.Minute
+// accountTokenGaugeInterval — same 1h cadence over the six Vehicle
+// GPS *Enc columns. The two loops are independent so a stall in one
+// (e.g., a long-running migration) doesn't starve the other.
+const vehicleGPSGaugeInterval = 1 * time.Hour
 
-// routeBlobGaugeInterval is the MYR-64 sibling — same 5-minute cadence
-// over Vehicle.navRouteCoordinatesEnc and Drive.routePointsEnc. The
-// route-blob queries can be heavier (jsonb columns) so the cadence
-// stays loose to keep the SELECT off the hot path.
-const routeBlobGaugeInterval = 5 * time.Minute
+// routeBlobGaugeInterval is the MYR-64 sibling — same 1h cadence over
+// Vehicle.navRouteCoordinatesEnc and Drive.routePointsEnc. The
+// route-blob queries can be heavier (jsonb columns), which is exactly
+// why their old 5m cadence kept timing out under statement_timeout on
+// Nano. 1h gives them headroom and matches the other two gauges.
+const routeBlobGaugeInterval = 1 * time.Hour
 
 // Build-time variables set via ldflags (see .goreleaser.yml).
 var (


### PR DESCRIPTION
## Summary

Bumps the three `*PlaintextGauge` polling intervals from `5 * time.Minute` → `1 * time.Hour` in `cmd/telemetry-server/main.go` (account-token, vehicle-GPS, route-blob).

## Why

Live evidence from the Fly log monitor right now:

```
WARN vehicle-gps plaintext-remaining query failed ... count latitude: canceling statement due to statement timeout (57014)
WARN route-blob plaintext-remaining query failed ... count Vehicle.navRouteCoordinates: canceling statement due to statement timeout (57014)
```

Every 5 minutes, each gauge runs a wide `COUNT(*)` over a Prisma-owned table to populate `*_plaintext_remaining_total` Prometheus metrics for the encryption rollout. On Nano compute the route-blob (jsonb) and GPS (encrypted shadow column) counts now time out at the 120s `statement_timeout` — meaning every 5 minutes, the DB burns ~2 minutes of CPU/IO on a query that returns a single integer.

MYR-131 explicitly listed this in its out-of-scope:
> "Bumping the three *PlaintextGauge intervals from 5min → 1hr (11 sequential COUNT(*) scans every 5 min is the bigger disk-IO offender)."

12× reduction in COUNT(*) scans, matching the 12× write reduction MYR-131 already shipped on the writer side. The rollout window these track is hours/days, so 1h cadence is plenty for an alerting pipeline.

## Test plan

- [x] `go vet ./...` clean
- [x] `go test ./cmd/telemetry-server/...` green
- [ ] After CI deploys: monitor's `vehicle-gps plaintext-remaining query failed` / `route-blob plaintext-remaining query failed` lines should stop firing (or fire only once per hour instead of every 5 min)
- [ ] Bench `/api/vehicles` request should complete substantially faster as the DB stops burning CPU/IO on the COUNT(*) loop

## Out of scope

- Removing the gauges entirely (they're useful for the encryption rollout — just lower-cadence now)
- The deeper NFR-3.28 architectural change (in-RAM live state, drive-end-only persistence)

🤖 Generated with [Claude Code](https://claude.com/claude-code)