### PR TITLE
MYR-138 obs(store): wire PrometheusMetrics, replacing NoopMetrics

### DIFF
--- a/cmd/telemetry-server/main.go
+++ b/cmd/telemetry-server/main.go
@@ -49,6 +49,15 @@ const vehicleGPSGaugeInterval = 1 * time.Hour
 // Nano. 1h gives them headroom and matches the other two gauges.
 const routeBlobGaugeInterval = 1 * time.Hour
 
+// storePoolStatsInterval is how often the running server samples the
+// pgxpool stats (acquired/idle/total) and pushes them into the
+// telemetry_store_pool_*_conns gauges. 15s is short enough to catch
+// short-lived contention spikes between scrapes (Prometheus default
+// 60s) but long enough that the .Stat() call is invisible at the
+// process level. MYR-138 wired this in after MYR-132 found the
+// testbench had no pool visibility.
+const storePoolStatsInterval = 15 * time.Second
+
 // Build-time variables set via ldflags (see .goreleaser.yml).
 var (
 	version = "dev"
@@ -129,12 +138,26 @@ func run() error { //nolint:funlen // composition root — sequential dependency
 		return err
 	}
 
+	// --- Store metrics (MYR-138) ---
+	// Single PrometheusMetrics instance shared by NewDB, VehicleRepo,
+	// and DriveRepo so all telemetry_store_* series come from one
+	// coherent surface. Replaces the three NoopMetrics{} sites that
+	// MYR-132's testbench audit found were hiding DB latency / errors
+	// / pool stats from prod observability.
+	storeMetrics := store.NewPrometheusMetrics(reg)
+
 	// --- Database connection ---
-	db, err := store.NewDB(ctx, cfg.Database(), logger.With(slog.String("component", "store")), store.NoopMetrics{})
+	db, err := store.NewDB(ctx, cfg.Database(), logger.With(slog.String("component", "store")), storeMetrics)
 	if err != nil {
 		return fmt.Errorf("connecting to database: %w", err)
 	}
 	defer db.Close()
+
+	// --- Pool-stats collector (MYR-138) ---
+	// Periodically samples the pgxpool stats and publishes them via
+	// storeMetrics.SetPoolStats so the gauges reflect live state
+	// between Prometheus scrapes. Goroutine exits when ctx cancels.
+	startPoolStatsCollector(ctx, db, storePoolStatsInterval, logger.With(slog.String("component", "store-pool-stats")))
 
 	// --- Database migrations (Go-owned tables) ---
 	// Applies all embedded SQL migrations in internal/store/migrations/ to the
@@ -181,8 +204,8 @@ func run() error { //nolint:funlen // composition root — sequential dependency
 	// ciphertext preference. Half-pair *Enc rows fall back to
 	// plaintext per the atomic-pair invariant in
 	// vehicle-state-schema.md §3.3.
-	vehicleRepo := store.NewVehicleRepoWithEncryption(db.Pool(), store.NoopMetrics{}, encryptor, logger.With(slog.String("component", "vehicle-repo")))
-	driveRepo := store.NewDriveRepoWithEncryption(db.Pool(), store.NoopMetrics{}, encryptor, logger.With(slog.String("component", "drive-repo")))
+	vehicleRepo := store.NewVehicleRepoWithEncryption(db.Pool(), storeMetrics, encryptor, logger.With(slog.String("component", "vehicle-repo")))
+	driveRepo := store.NewDriveRepoWithEncryption(db.Pool(), storeMetrics, encryptor, logger.With(slog.String("component", "drive-repo")))
 	accountRepo := store.NewAccountRepo(db.Pool(), encryptor)
 
 	// MYR-62 + MYR-63 plaintext-zero gauges. Both register against the

--- a/cmd/telemetry-server/wiring.go
+++ b/cmd/telemetry-server/wiring.go
@@ -104,6 +104,32 @@ func startPlaintextGauges(
 	go routeBlobGauge.Run(ctx)
 }
 
+// startPoolStatsCollector spawns a background goroutine that polls
+// db.CollectPoolStats every interval and exits when ctx cancels.
+// CollectPoolStats reads pgxpool.Stat() and pushes the values into the
+// store.Metrics implementation wired into the DB — under MYR-138 that
+// is store.PrometheusMetrics, so the gauges land on /metrics. The
+// .Stat() call is a cheap accessor over atomic counters, so the 15s
+// cadence is well below any measurable cost.
+func startPoolStatsCollector(ctx context.Context, db *store.DB, interval time.Duration, logger *slog.Logger) {
+	logger.Info("store pool-stats collector started", slog.Duration("interval", interval))
+	go func() {
+		ticker := time.NewTicker(interval)
+		defer ticker.Stop()
+		// Sample once immediately so the gauges aren't NaN/zero for
+		// the first interval after startup.
+		db.CollectPoolStats()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				db.CollectPoolStats()
+			}
+		}
+	}()
+}
+
 // setupAuthenticator returns a NoopAuthenticator in dev mode (accepts any
 // token) or a JWTAuthenticator wired against the auth secret + DB pool in
 // production mode.

--- a/internal/store/prometheus_metrics.go
+++ b/internal/store/prometheus_metrics.go
@@ -1,0 +1,100 @@
+package store
+
+import "github.com/prometheus/client_golang/prometheus"
+
+// queryDurationBuckets extends prometheus.DefBuckets with low-end
+// resolution so sub-100ms queries (the common case for pgx point
+// lookups) land in distinct buckets instead of collapsing into the
+// first DefBuckets bucket (5ms). MYR-132 found the testbench was
+// flying blind on the [1ms, 50ms] band where DB query histograms are
+// most informative.
+var queryDurationBuckets = []float64{
+	0.001, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10,
+}
+
+// PrometheusMetrics implements Metrics against a Prometheus registry.
+// Register it once at startup via NewPrometheusMetrics and share the
+// returned pointer across all store constructors (NewDB,
+// NewVehicleRepoWithEncryption, NewDriveRepoWithEncryption) so query
+// timings and the connection pool gauges land on a single coherent
+// observability surface under the telemetry_store_* prefix.
+type PrometheusMetrics struct {
+	queryDuration *prometheus.HistogramVec
+	queryErrors   *prometheus.CounterVec
+	poolAcquired  prometheus.Gauge
+	poolIdle      prometheus.Gauge
+	poolTotal     prometheus.Gauge
+}
+
+var _ Metrics = (*PrometheusMetrics)(nil)
+
+// NewPrometheusMetrics registers the five store metric series on reg
+// and returns a Metrics implementation ready to pass into the store
+// constructors. Mirrors the auditsidecar.NewPrometheusMetrics pattern:
+// one constructor, MustRegister at startup so a duplicate registration
+// is a fail-fast configuration error rather than a silent miss.
+//
+// Operation labels follow the "entity.method" convention from
+// store/metrics.go (e.g., "vehicle.get_by_id", "drive.create"). These
+// strings are P2 (operational metadata) — they must never carry P1
+// fields like VINs or userIds.
+func NewPrometheusMetrics(reg prometheus.Registerer) *PrometheusMetrics {
+	queryDuration := prometheus.NewHistogramVec(prometheus.HistogramOpts{
+		Name:    "telemetry_store_query_duration_seconds",
+		Help:    "Latency of database operations in seconds, labelled by entity.method. Buckets are tuned for the pgx sub-100ms point-lookup regime that DefBuckets collapses into a single 5ms bucket.",
+		Buckets: queryDurationBuckets,
+	}, []string{"operation"})
+	reg.MustRegister(queryDuration)
+
+	queryErrors := prometheus.NewCounterVec(prometheus.CounterOpts{
+		Name: "telemetry_store_query_errors_total",
+		Help: "Count of database operations that returned an error, labelled by entity.method. Alert on rate > 0 for sustained windows; spikes commonly indicate pool exhaustion or a Supabase connection rotation.",
+	}, []string{"operation"})
+	reg.MustRegister(queryErrors)
+
+	poolAcquired := prometheus.NewGauge(prometheus.GaugeOpts{
+		Name: "telemetry_store_pool_acquired_conns",
+		Help: "Connections currently checked out of the pgxpool by in-flight queries. Sustained values at MaxConns indicate the pool is the bottleneck and queries are queuing.",
+	})
+	reg.MustRegister(poolAcquired)
+
+	poolIdle := prometheus.NewGauge(prometheus.GaugeOpts{
+		Name: "telemetry_store_pool_idle_conns",
+		Help: "Connections currently idle in the pgxpool, available for immediate acquisition. A persistent idle=0 with acquired=MaxConns means contention.",
+	})
+	reg.MustRegister(poolIdle)
+
+	poolTotal := prometheus.NewGauge(prometheus.GaugeOpts{
+		Name: "telemetry_store_pool_total_conns",
+		Help: "Total connections (acquired + idle) the pgxpool currently holds open, bounded by MaxConns. Useful for confirming the pool grew under load and for sizing MaxConns against Supabase's connection limit.",
+	})
+	reg.MustRegister(poolTotal)
+
+	return &PrometheusMetrics{
+		queryDuration: queryDuration,
+		queryErrors:   queryErrors,
+		poolAcquired:  poolAcquired,
+		poolIdle:      poolIdle,
+		poolTotal:     poolTotal,
+	}
+}
+
+// ObserveQueryDuration records a query latency sample under the given
+// operation label.
+func (m *PrometheusMetrics) ObserveQueryDuration(operation string, seconds float64) {
+	m.queryDuration.WithLabelValues(operation).Observe(seconds)
+}
+
+// IncQueryError increments the error counter for the given operation.
+func (m *PrometheusMetrics) IncQueryError(operation string) {
+	m.queryErrors.WithLabelValues(operation).Inc()
+}
+
+// SetPoolStats updates the three connection-pool gauges. Called from
+// the periodic collector goroutine in cmd/telemetry-server that polls
+// DB.CollectPoolStats every 15s.
+func (m *PrometheusMetrics) SetPoolStats(acquired, idle, total int32) {
+	m.poolAcquired.Set(float64(acquired))
+	m.poolIdle.Set(float64(idle))
+	m.poolTotal.Set(float64(total))
+}

--- a/internal/store/prometheus_metrics_test.go
+++ b/internal/store/prometheus_metrics_test.go
@@ -15,7 +15,16 @@ import (
 // registration would fail-fast inside MustRegister.
 func TestPrometheusMetrics_RegistersAllSeries(t *testing.T) {
 	reg := prometheus.NewRegistry()
-	_ = NewPrometheusMetrics(reg)
+	m := NewPrometheusMetrics(reg)
+
+	// HistogramVec and CounterVec children are materialized lazily —
+	// Gather() returns no metric family for them until at least one
+	// WithLabelValues observation. Force one for each so the
+	// registration assertion below covers all 5 series, not just the 3
+	// label-free Gauges. Observe(0) and Add(0) record without skewing
+	// any subsequent test that uses its own registry.
+	m.ObserveQueryDuration("_startup", 0)
+	m.queryErrors.WithLabelValues("_startup").Add(0)
 
 	mfs, err := reg.Gather()
 	if err != nil {

--- a/internal/store/prometheus_metrics_test.go
+++ b/internal/store/prometheus_metrics_test.go
@@ -1,0 +1,165 @@
+package store
+
+import (
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
+)
+
+// TestPrometheusMetrics_RegistersAllSeries asserts the constructor
+// publishes every store metric family on the registry so a /metrics
+// scrape immediately after startup surfaces the full surface (even
+// before the first query). Mirrors the cryptox pattern: zero series is
+// a regression, missing names are a regression, and a duplicate
+// registration would fail-fast inside MustRegister.
+func TestPrometheusMetrics_RegistersAllSeries(t *testing.T) {
+	reg := prometheus.NewRegistry()
+	_ = NewPrometheusMetrics(reg)
+
+	mfs, err := reg.Gather()
+	if err != nil {
+		t.Fatalf("Gather: %v", err)
+	}
+
+	want := []string{
+		"telemetry_store_query_duration_seconds",
+		"telemetry_store_query_errors_total",
+		"telemetry_store_pool_acquired_conns",
+		"telemetry_store_pool_idle_conns",
+		"telemetry_store_pool_total_conns",
+	}
+	for _, name := range want {
+		if findMetricFamily(mfs, name) == nil {
+			t.Errorf("metric family %q not registered", name)
+		}
+	}
+}
+
+// TestPrometheusMetrics_ObserveQueryDurationRecordsSample asserts a
+// single Observe call lands in the histogram under the matching
+// operation label.
+func TestPrometheusMetrics_ObserveQueryDurationRecordsSample(t *testing.T) {
+	reg := prometheus.NewRegistry()
+	m := NewPrometheusMetrics(reg)
+
+	m.ObserveQueryDuration("vehicle.get_by_id", 0.123)
+
+	mfs, err := reg.Gather()
+	if err != nil {
+		t.Fatalf("Gather: %v", err)
+	}
+	mf := findMetricFamily(mfs, "telemetry_store_query_duration_seconds")
+	if mf == nil {
+		t.Fatal("telemetry_store_query_duration_seconds not registered")
+	}
+
+	var sample *dto.Histogram
+	for _, mt := range mf.Metric {
+		if labelValue(mt, "operation") == "vehicle.get_by_id" {
+			sample = mt.GetHistogram()
+			break
+		}
+	}
+	if sample == nil {
+		t.Fatal("no histogram sample for operation=vehicle.get_by_id")
+	}
+	if got, want := sample.GetSampleCount(), uint64(1); got != want {
+		t.Errorf("sample count = %d, want %d", got, want)
+	}
+	if got, want := sample.GetSampleSum(), 0.123; got != want {
+		t.Errorf("sample sum = %v, want %v", got, want)
+	}
+}
+
+// TestPrometheusMetrics_IncQueryErrorIncrementsCounter asserts the
+// labelled error counter increments and the unrelated operation label
+// stays at zero (no cross-label leakage).
+func TestPrometheusMetrics_IncQueryErrorIncrementsCounter(t *testing.T) {
+	reg := prometheus.NewRegistry()
+	m := NewPrometheusMetrics(reg)
+
+	m.IncQueryError("drive.create")
+	m.IncQueryError("drive.create")
+
+	mfs, err := reg.Gather()
+	if err != nil {
+		t.Fatalf("Gather: %v", err)
+	}
+	mf := findMetricFamily(mfs, "telemetry_store_query_errors_total")
+	if mf == nil {
+		t.Fatal("telemetry_store_query_errors_total not registered")
+	}
+
+	got := map[string]float64{}
+	for _, mt := range mf.Metric {
+		got[labelValue(mt, "operation")] = mt.GetCounter().GetValue()
+	}
+	if got["drive.create"] != 2 {
+		t.Errorf("drive.create counter = %v, want 2", got["drive.create"])
+	}
+	if v, ok := got["vehicle.get_by_id"]; ok && v != 0 {
+		t.Errorf("vehicle.get_by_id counter = %v, want 0 (no cross-label leakage)", v)
+	}
+}
+
+// TestPrometheusMetrics_SetPoolStatsReflectsValues asserts the three
+// pool gauges reflect the most recent SetPoolStats call. This is the
+// end-to-end check that the periodic collector goroutine in
+// cmd/telemetry-server flows DB.CollectPoolStats() into /metrics.
+func TestPrometheusMetrics_SetPoolStatsReflectsValues(t *testing.T) {
+	reg := prometheus.NewRegistry()
+	m := NewPrometheusMetrics(reg)
+
+	m.SetPoolStats(5, 2, 7)
+
+	mfs, err := reg.Gather()
+	if err != nil {
+		t.Fatalf("Gather: %v", err)
+	}
+
+	tests := []struct {
+		name string
+		want float64
+	}{
+		{"telemetry_store_pool_acquired_conns", 5},
+		{"telemetry_store_pool_idle_conns", 2},
+		{"telemetry_store_pool_total_conns", 7},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mf := findMetricFamily(mfs, tt.name)
+			if mf == nil {
+				t.Fatalf("%s not registered", tt.name)
+			}
+			if got := len(mf.Metric); got != 1 {
+				t.Fatalf("metric count = %d, want 1", got)
+			}
+			if got := mf.Metric[0].GetGauge().GetValue(); got != tt.want {
+				t.Errorf("%s = %v, want %v", tt.name, got, tt.want)
+			}
+		})
+	}
+}
+
+// findMetricFamily returns the *dto.MetricFamily with the given name,
+// or nil if absent.
+func findMetricFamily(mfs []*dto.MetricFamily, name string) *dto.MetricFamily {
+	for _, mf := range mfs {
+		if mf.GetName() == name {
+			return mf
+		}
+	}
+	return nil
+}
+
+// labelValue returns the value for a given label name on a Metric, or
+// "" if the label is absent.
+func labelValue(m *dto.Metric, name string) string {
+	for _, l := range m.Label {
+		if l.GetName() == name {
+			return l.GetValue()
+		}
+	}
+	return ""
+}


### PR DESCRIPTION
## Summary

- Implements `store.Metrics` (interface defined in `internal/store/metrics.go`) with real Prometheus collectors.
- Replaces 3 `NoopMetrics{}` usages in `cmd/telemetry-server/main.go` with one shared `*PrometheusMetrics`.
- Adds a 15s pool-stats collector goroutine (re-uses existing `db.CollectPoolStats()`).

## Why

[MYR-132](https://linear.app/myrobotaxi/issue/MYR-132) audit found we have **zero DB observability in prod** — `Metrics` was wired with no-ops everywhere, so query latency, error counts, and pool stats all dropped on the floor. [MYR-138](https://linear.app/myrobotaxi/issue/MYR-138) flagged >1s REST latency in the audit; we can't fix what we can't measure.

This PR doesn't change a query plan or tune a pool — it just gives the operator the visibility needed to diagnose MYR-138 (and many future "why is the DB slow" questions) from `/metrics` in production.

## New metric series

| Name | Type | Labels | Purpose |
|---|---|---|---|
| `telemetry_store_query_duration_seconds` | HistogramVec | `operation` | Per-query latency (e.g. `vehicle.get_by_id`, `drive.create`) |
| `telemetry_store_query_errors_total` | CounterVec | `operation` | Per-operation error count |
| `telemetry_store_pool_acquired_conns` | Gauge | – | pgxpool acquired connections |
| `telemetry_store_pool_idle_conns` | Gauge | – | pgxpool idle connections |
| `telemetry_store_pool_total_conns` | Gauge | – | pgxpool total connections |

Histogram buckets are tuned for pgx point lookups (1ms → 10s) instead of `prometheus.DefBuckets`, which is HTTP-shaped and useless for DB queries.

## What's NOT in scope

- Adding the `Vehicle(userId)` index — that's a Prisma migration in the partner repo (tracked as MYR-127).
- Changing pool size / pooling mode — that's MYR-129 territory.
- A Grafana dashboard or alerting rules — separate observability work.

This PR just unblocks measurement.

## Test plan

- [x] `go vet ./...` clean
- [x] `go test ./...` passes (4 new sub-tests covering registration, histogram observe, counter inc with no cross-label leak, gauge set)
- [x] `golangci-lint run ./...` reports 0 issues (cache cleared)
- [x] `go build ./cmd/...` succeeds
- [ ] CI green (lint, test, build, contract-guard)
- [ ] Post-merge: `curl https://localhost:9090/metrics | grep telemetry_store_` shows non-zero values after Fly deploy

## Rollback

Revert the PR. Returns to NoopMetrics — no behavioral change beyond observability.

🤖 Generated with [Claude Code](https://claude.com/claude-code)