### PR TITLE
MYR-139 R3 fix(drives): watchdog ends drive on silent telemetry + DB cleanup binary

### DIFF
--- a/cmd/cleanup-stuck-drives/main.go
+++ b/cmd/cleanup-stuck-drives/main.go
@@ -1,0 +1,215 @@
+// Binary cleanup-stuck-drives deletes orphaned Drive rows that the
+// telemetry server's drive state machine never completed -- rows where
+// "endTime" IS NULL and "startTime" is older than the configured age
+// threshold (default 24h).
+//
+// Background (MYR-139 R3b): before the MYR-139 R3a watchdog fix, Tesla
+// going silent at vehicle park left drives open in memory and the
+// Drive row in Postgres with endTime/distanceMiles/durationMinutes
+// unwritten. The R3a fix prevents new orphans; this one-shot script
+// cleans up the pre-existing orphans.
+//
+// Why a Go script and not a SQL migration:
+//
+//	"Drive" is Prisma-owned. Contract-guard rule CG-DL-9 (see
+//	docs/contracts/data-lifecycle.md §7) forbids any SQL file under
+//	internal/store/migrations/ from referencing Prisma-owned tables.
+//	Runtime application queries against Prisma-owned tables are
+//	permitted -- this script is one such query.
+//
+// Configuration is env-driven:
+//
+//	DATABASE_URL                          Postgres connection string (required)
+//	CLEANUP_STUCK_DRIVES_MIN_AGE          Optional. Go duration string for
+//	                                      the age threshold. Default: 24h.
+//	                                      Only drives with startTime older
+//	                                      than NOW() - MIN_AGE are touched.
+//	CLEANUP_STUCK_DRIVES_DRY_RUN          Optional. "true" to count matching
+//	                                      rows without deleting. Default: false.
+//	DATABASE_DISABLE_PREPARED_STATEMENTS  "true" for PgBouncer (Supabase 6543);
+//	                                      auto-detected when URL contains :6543.
+//
+// Exit codes:
+//
+//	0  success (any number of rows, including zero)
+//	1  delete operation returned an error after open
+//	2  fatal startup error (env, DB open, ping)
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log/slog"
+	"os"
+	"os/signal"
+	"strings"
+	"syscall"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+const (
+	exitOK         = 0
+	exitRunError   = 1
+	exitFatalSetup = 2
+
+	defaultMinAge = 24 * time.Hour
+
+	// deleteStmt removes orphan Drive rows older than the cutoff. The
+	// "endTime IS NULL" predicate is the precise definition of "stuck"
+	// produced by the pre-MYR-139-R3a state machine: the start INSERT
+	// ran, but the completion UPDATE never did. The startTime cutoff
+	// avoids racing with drives that are currently active in the
+	// running telemetry-server (which has its own in-memory state and
+	// will fire drive.ended via the watchdog within EndDebounce).
+	deleteStmt = `DELETE FROM "Drive"
+		WHERE "endTime" IS NULL
+		  AND "startTime" < NOW() - $1::interval`
+
+	// countStmt mirrors the WHERE clause of deleteStmt for dry-runs.
+	countStmt = `SELECT COUNT(*) FROM "Drive"
+		WHERE "endTime" IS NULL
+		  AND "startTime" < NOW() - $1::interval`
+)
+
+func main() {
+	os.Exit(run())
+}
+
+// run is the testable seam: separates os.Exit from the work loop so a
+// future test can drive it without process-level side effects.
+func run() int {
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelInfo}))
+
+	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	defer stop()
+
+	minAge, err := loadMinAge()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "cleanup-stuck-drives: %s\n", err)
+		return exitFatalSetup
+	}
+	dryRun := os.Getenv("CLEANUP_STUCK_DRIVES_DRY_RUN") == "true"
+
+	pool, err := openPool(ctx)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "cleanup-stuck-drives: %s\n", err)
+		return exitFatalSetup
+	}
+	defer pool.Close()
+
+	logger.Info("cleanup-stuck-drives starting",
+		slog.Duration("min_age", minAge),
+		slog.Bool("dry_run", dryRun),
+	)
+
+	deleted, runErr := cleanupOrphans(ctx, pool, minAge, dryRun)
+
+	report := struct {
+		MinAge     string `json:"minAge"`
+		DryRun     bool   `json:"dryRun"`
+		RowsHit    int64  `json:"rowsHit"`
+		Error      string `json:"error,omitempty"`
+	}{
+		MinAge:  minAge.String(),
+		DryRun:  dryRun,
+		RowsHit: deleted,
+	}
+	if runErr != nil {
+		report.Error = runErr.Error()
+	}
+
+	// JSON to stdout so an operator pipeline can parse the result.
+	if err := json.NewEncoder(os.Stdout).Encode(report); err != nil {
+		fmt.Fprintf(os.Stderr, "cleanup-stuck-drives: write report: %s\n", err)
+		// Don't override a run-error exit with a stdout encoding failure.
+	}
+
+	switch {
+	case runErr != nil && !errors.Is(runErr, context.Canceled):
+		return exitRunError
+	default:
+		return exitOK
+	}
+}
+
+// loadMinAge parses CLEANUP_STUCK_DRIVES_MIN_AGE or returns the default.
+// A negative or zero duration is rejected to prevent the operator from
+// accidentally widening the deletion window to "every open drive".
+func loadMinAge() (time.Duration, error) {
+	raw := strings.TrimSpace(os.Getenv("CLEANUP_STUCK_DRIVES_MIN_AGE"))
+	if raw == "" {
+		return defaultMinAge, nil
+	}
+	d, err := time.ParseDuration(raw)
+	if err != nil {
+		return 0, fmt.Errorf("CLEANUP_STUCK_DRIVES_MIN_AGE: %w", err)
+	}
+	if d <= 0 {
+		return 0, fmt.Errorf("CLEANUP_STUCK_DRIVES_MIN_AGE must be > 0, got %s", d)
+	}
+	return d, nil
+}
+
+// openPool builds a pgxpool from DATABASE_URL using the same
+// PgBouncer-aware logic as the server's openDB helper. The pool is
+// sized at 2 because this binary executes a single statement and is
+// not expected to be invoked concurrently with itself.
+func openPool(ctx context.Context) (*pgxpool.Pool, error) {
+	url := os.Getenv("DATABASE_URL")
+	if url == "" {
+		return nil, fmt.Errorf("DATABASE_URL is required")
+	}
+	cfg, err := pgxpool.ParseConfig(url)
+	if err != nil {
+		return nil, fmt.Errorf("parse DATABASE_URL: %w", err)
+	}
+	disablePrep := strings.Contains(url, ":6543") ||
+		os.Getenv("DATABASE_DISABLE_PREPARED_STATEMENTS") == "true"
+	if disablePrep {
+		cfg.ConnConfig.DefaultQueryExecMode = pgx.QueryExecModeSimpleProtocol
+	}
+	pool, err := pgxpool.NewWithConfig(ctx, cfg)
+	if err != nil {
+		return nil, fmt.Errorf("open pool: %w", err)
+	}
+	if err := pool.Ping(ctx); err != nil {
+		pool.Close()
+		return nil, fmt.Errorf("ping: %w", err)
+	}
+	return pool, nil
+}
+
+// cleanupOrphans runs the count (dry-run) or the delete (default) and
+// returns the number of rows touched. The interval is passed to Postgres
+// as a string so the same parameter type works under both prepared and
+// simple-protocol query modes.
+func cleanupOrphans(ctx context.Context, pool *pgxpool.Pool, minAge time.Duration, dryRun bool) (int64, error) {
+	interval := intervalString(minAge)
+
+	if dryRun {
+		var n int64
+		if err := pool.QueryRow(ctx, countStmt, interval).Scan(&n); err != nil {
+			return 0, fmt.Errorf("count orphans: %w", err)
+		}
+		return n, nil
+	}
+
+	tag, err := pool.Exec(ctx, deleteStmt, interval)
+	if err != nil {
+		return 0, fmt.Errorf("delete orphans: %w", err)
+	}
+	return tag.RowsAffected(), nil
+}
+
+// intervalString formats a Go duration for Postgres's INTERVAL parser
+// using seconds. We avoid PG's "1 day" notation because fractional days
+// don't survive round-trip, and the seconds form is unambiguous for any
+// minAge value an operator might supply.
+func intervalString(d time.Duration) string {
+	return fmt.Sprintf("%d seconds", int64(d.Seconds()))
+}

--- a/internal/drives/debounce.go
+++ b/internal/drives/debounce.go
@@ -9,6 +9,89 @@ import (
 	"github.com/myrobotaxi/telemetry/internal/events"
 )
 
+// runWatchdog periodically scans all per-vehicle states and ends any
+// drive whose last telemetry frame is older than EndDebounce. Tesla
+// stops streaming when the vehicle parks, so the gear=P -> AfterFunc
+// path is not guaranteed to fire; this watchdog is the safety net that
+// guarantees DriveEndedEvent emission even when streaming goes silent.
+//
+// MYR-139 R3a: without this, stuck Drive rows accumulate in the DB with
+// endTime IS NULL because the writer subscribes to drive.ended and the
+// detector never publishes it.
+func (d *Detector) runWatchdog() {
+	defer d.watchdogWG.Done()
+
+	ticker := time.NewTicker(d.watchdogInterval())
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-d.ctx.Done():
+			return
+		case <-ticker.C:
+			d.watchdogTick()
+		}
+	}
+}
+
+// watchdogTick walks every active per-vehicle state and ends drives
+// whose last telemetry arrival is older than EndDebounce.
+//
+// Locking: each vehicle lock is acquired in its own iteration so a slow
+// endDrive (which publishes to the bus) does not block other vehicles.
+// We tolerate sync.Map's "no snapshot" semantics because Range visits
+// each key at most once even under concurrent insertion.
+func (d *Detector) watchdogTick() {
+	now := d.now()
+	cutoff := d.cfg.EndDebounce
+
+	d.states.Range(func(key, value any) bool {
+		vin, _ := key.(string)
+		state, _ := value.(*vehicleState)
+		if state == nil {
+			return true
+		}
+
+		state.mu.Lock()
+		// Guard 1: only active drives are candidates.
+		if state.status != StatusDriving {
+			state.mu.Unlock()
+			return true
+		}
+		// Guard 2: never preempt an in-flight gear=P debounce timer.
+		// Letting the AfterFunc fire keeps debounce semantics intact
+		// (cancellable up to EndDebounce after gear=P) and avoids a
+		// double-end race.
+		if state.debounceTimer != nil {
+			state.mu.Unlock()
+			return true
+		}
+		// Guard 3: a drive in flight must have had at least one
+		// telemetry frame already (the start frame). If not, leave
+		// it alone -- the watchdog only acts on observed silence.
+		if state.lastTelemetryAt.IsZero() {
+			state.mu.Unlock()
+			return true
+		}
+		// The actual condition: telemetry has been silent for at
+		// least EndDebounce.
+		if now.Sub(state.lastTelemetryAt) < cutoff {
+			state.mu.Unlock()
+			return true
+		}
+
+		d.logger.Info("ending drive via watchdog (telemetry silent)",
+			slog.String("vin", redactVIN(vin)),
+			slog.Duration("silent_for", now.Sub(state.lastTelemetryAt)),
+			slog.Duration("end_debounce", cutoff),
+		)
+		d.metrics.IncWatchdogEnded()
+		d.endDrive(state, vin)
+		state.mu.Unlock()
+		return true
+	})
+}
+
 // debounceCallback is invoked by time.AfterFunc when the debounce period
 // elapses. It runs on a timer goroutine and must acquire state.mu.
 func (d *Detector) debounceCallback(vin string) {

--- a/internal/drives/detector.go
+++ b/internal/drives/detector.go
@@ -10,11 +10,18 @@ import (
 	"log/slog"
 	"sync"
 	"sync/atomic"
+	"time"
 
 	"github.com/myrobotaxi/telemetry/internal/config"
 	"github.com/myrobotaxi/telemetry/internal/events"
 	"github.com/myrobotaxi/telemetry/internal/telemetry"
 )
+
+// minWatchdogInterval is the floor for the periodic watchdog tick. Even
+// for very small EndDebounce values used in tests, we won't churn faster
+// than this. In production EndDebounce is 30s, so the watchdog runs at
+// 15s. See Detector.watchdogInterval.
+const minWatchdogInterval = 100 * time.Millisecond
 
 // Detector subscribes to vehicle telemetry events and maintains a per-vehicle
 // state machine that detects drive start/end transitions. It publishes drive
@@ -43,6 +50,15 @@ type Detector struct {
 	// ctx is the parent context for debounce timer goroutines.
 	ctx    context.Context
 	cancel context.CancelFunc
+
+	// now returns the current wall-clock time. Indirected so the watchdog
+	// can be tested deterministically without sleeping for EndDebounce.
+	// Defaults to time.Now in NewDetector.
+	now func() time.Time
+
+	// watchdogWG tracks the background watchdog goroutine so Stop can
+	// wait for it to exit before returning.
+	watchdogWG sync.WaitGroup
 }
 
 // NewDetector creates a Detector. The bus is used both for subscribing to
@@ -59,7 +75,26 @@ func NewDetector(
 		cfg:     cfg,
 		logger:  logger,
 		metrics: metrics,
+		now:     time.Now,
 	}
+}
+
+// setNow overrides the time source used by the watchdog. Test-only seam;
+// not exported because no production caller should swap the clock.
+func (d *Detector) setNow(fn func() time.Time) {
+	d.now = fn
+}
+
+// watchdogInterval returns how often the end-condition watchdog runs.
+// Half of EndDebounce keeps worst-case end-detection latency at
+// 1.5 × EndDebounce, while ensuring we never churn faster than
+// minWatchdogInterval even when tests set EndDebounce to a few ms.
+func (d *Detector) watchdogInterval() time.Duration {
+	iv := d.cfg.EndDebounce / 2
+	if iv < minWatchdogInterval {
+		iv = minWatchdogInterval
+	}
+	return iv
 }
 
 // Start subscribes to TopicVehicleTelemetry and TopicConnectivity and begins
@@ -83,7 +118,17 @@ func (d *Detector) Start(ctx context.Context) error {
 
 	d.subs = []events.Subscription{telSub, connSub}
 
-	d.logger.Info("drive detector started")
+	// Start the end-condition watchdog. Tesla stops streaming when the
+	// vehicle parks, so a gear=P frame is not guaranteed -- without this
+	// watchdog the time.AfterFunc-based debounce path is never primed and
+	// the drive stays open forever (the MYR-139 R3a regression).
+	d.watchdogWG.Add(1)
+	go d.runWatchdog()
+
+	d.logger.Info("drive detector started",
+		slog.Duration("end_debounce", d.cfg.EndDebounce),
+		slog.Duration("watchdog_interval", d.watchdogInterval()),
+	)
 	return nil
 }
 
@@ -91,6 +136,11 @@ func (d *Detector) Start(ctx context.Context) error {
 // Active drives are NOT forcibly ended -- they remain in memory.
 func (d *Detector) Stop() error {
 	d.cancel()
+
+	// Wait for the watchdog goroutine to exit before tearing down the
+	// per-vehicle timers below. Otherwise a watchdog tick could race
+	// with this loop and observe nil-but-not-yet-stopped timers.
+	d.watchdogWG.Wait()
 
 	// Stop all debounce timers.
 	d.states.Range(func(_, value any) bool {
@@ -194,6 +244,12 @@ func (d *Detector) handleTelemetry(te events.VehicleTelemetryEvent) {
 
 	state.mu.Lock()
 	defer state.mu.Unlock()
+
+	// Stamp the wall-clock arrival time so the watchdog can detect
+	// vehicles that stopped streaming (Tesla goes silent when the car
+	// parks and the state machine would otherwise never see a gear=P
+	// frame to start the debounce).
+	state.lastTelemetryAt = d.now()
 
 	// Extract gear from the telemetry fields (may be absent).
 	gear := extractStringField(te.Fields, telemetry.FieldGear)

--- a/internal/drives/detector_test.go
+++ b/internal/drives/detector_test.go
@@ -117,6 +117,41 @@ func expectNoEvent(t *testing.T, ch <-chan events.Event, timeout time.Duration, 
 	}
 }
 
+// keepTelemetryAlive starts a goroutine that publishes gear=D telemetry
+// for vin every 20ms until the returned stop function is called. Used
+// by tests that need to assert NO drive.ended event under conditions
+// other than telemetry silence -- without it, the MYR-139 R3a watchdog
+// would end the drive after EndDebounce.
+//
+// The goroutine swallows bus.Publish errors so a teardown race (bus
+// closed while the goroutine is in flight) does not fail the test.
+func keepTelemetryAlive(bus events.Bus, vin string, start time.Time) func() {
+	stop := make(chan struct{})
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		ticker := time.NewTicker(20 * time.Millisecond)
+		defer ticker.Stop()
+		i := 0
+		for {
+			select {
+			case <-stop:
+				return
+			case <-ticker.C:
+				i++
+				ts := start.Add(time.Duration(i) * time.Second)
+				lat := 33.09 + 0.001*float64(i)
+				evt := events.NewEvent(telemetryEvent(vin, ts, driveFields("D", 30.0, lat, -96.82)))
+				_ = bus.Publish(context.Background(), evt)
+			}
+		}
+	}()
+	return func() {
+		close(stop)
+		<-done
+	}
+}
+
 // subscribeTopic subscribes to a topic and returns a channel that receives events.
 func subscribeTopic(t *testing.T, bus events.Bus, topic events.Topic) <-chan events.Event {
 	t.Helper()
@@ -254,6 +289,12 @@ func TestDetector_DebounceCancellation(t *testing.T) {
 
 	// Shift back to D immediately -- cancels debounce before it fires.
 	publishTelemetry(t, bus, telemetryEvent("VIN003", now.Add(2*time.Second), driveFields("D", 25.0, 33.10, -96.83)))
+
+	// Keep telemetry flowing so the silent-telemetry watchdog (MYR-139
+	// R3a) does not end the drive as a side effect. This test asserts
+	// gear=P -> gear=D debounce cancellation specifically.
+	stopTel := keepTelemetryAlive(bus, "VIN003", now)
+	defer stopTel()
 
 	// The debounce period passes -- drive should NOT have ended.
 	expectNoEvent(t, endedCh, 300*time.Millisecond, "drive should continue after debounce cancellation")
@@ -642,6 +683,135 @@ func TestDetector_DisconnectEndsDrive(t *testing.T) {
 	}
 }
 
+// TestDetector_WatchdogEndsDriveWhenTelemetrySilent reproduces MYR-139 R3a:
+// a vehicle drives for a minute, then Tesla stops streaming entirely
+// without ever sending a gear=P frame. The state machine's gear=P-triggered
+// AfterFunc debounce never primes, so without the watchdog the drive would
+// stay open forever, leaving the DB row with endTime IS NULL.
+//
+// The test uses an injectable clock so it doesn't have to sleep for the
+// real EndDebounce. We feed driving telemetry, then advance the clock
+// past EndDebounce and wait for the watchdog tick to fire.
+func TestDetector_WatchdogEndsDriveWhenTelemetrySilent(t *testing.T) {
+	bus := testBus()
+	defer bus.Close(context.Background())
+
+	cfg := testConfig()
+	// EndDebounce drives the watchdog interval (half of). 200ms keeps
+	// the test under 1s while still exercising the production path.
+	cfg.EndDebounce = 200 * time.Millisecond
+	cfg.MinDuration = 0
+	cfg.MinDistanceMiles = 0
+
+	d := NewDetector(bus, cfg, testLogger(), NoopDetectorMetrics{})
+
+	// Inject a clock we can fast-forward. The watchdog reads now() to
+	// decide whether telemetry has been silent for EndDebounce.
+	var clockMu sync.Mutex
+	wallNow := time.Now()
+	d.setNow(func() time.Time {
+		clockMu.Lock()
+		defer clockMu.Unlock()
+		return wallNow
+	})
+	advanceClock := func(by time.Duration) {
+		clockMu.Lock()
+		wallNow = wallNow.Add(by)
+		clockMu.Unlock()
+	}
+
+	if err := d.Start(context.Background()); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	defer func() { _ = d.Stop() }()
+
+	startedCh := subscribeTopic(t, bus, events.TopicDriveStarted)
+	endedCh := subscribeTopic(t, bus, events.TopicDriveEnded)
+
+	eventTime := time.Now()
+
+	// Drive for a minute (in event-time): start frame plus several
+	// route points. Telemetry is fully gear=D the whole time; we never
+	// send gear=P -- this is the bug scenario.
+	publishTelemetry(t, bus, telemetryEvent("VIN_SILENT", eventTime, driveFields("D", 30.0, 33.09, -96.82)))
+	if _, ok := waitForEvent(startedCh); !ok {
+		t.Fatal("timed out waiting for DriveStartedEvent")
+	}
+
+	for i := 1; i <= 6; i++ {
+		ts := eventTime.Add(time.Duration(i*10) * time.Second)
+		lat := 33.09 + 0.001*float64(i)
+		publishTelemetry(t, bus, telemetryEvent("VIN_SILENT", ts, driveFields("D", 40.0, lat, -96.82)))
+	}
+
+	// Give the bus handler a moment to process all the telemetry events
+	// so lastTelemetryAt is set in the vehicle state.
+	time.Sleep(50 * time.Millisecond)
+
+	// Confirm no end yet: the gear=P path was never taken and the
+	// clock has not advanced, so the watchdog should not act.
+	expectNoEvent(t, endedCh, 100*time.Millisecond, "watchdog should not fire before silence cutoff")
+
+	// Now simulate Tesla going silent: advance the wall clock past
+	// EndDebounce. The next watchdog tick should observe the silence
+	// and end the drive.
+	advanceClock(2 * cfg.EndDebounce)
+
+	evt, ok := waitForEvent(endedCh)
+	if !ok {
+		t.Fatal("timed out waiting for DriveEndedEvent from watchdog")
+	}
+
+	payload, ok := evt.Payload.(events.DriveEndedEvent)
+	if !ok {
+		t.Fatalf("expected DriveEndedEvent, got %T", evt.Payload)
+	}
+	if payload.VIN != "VIN_SILENT" {
+		t.Errorf("VIN: got %q, want %q", payload.VIN, "VIN_SILENT")
+	}
+	if payload.DriveID == "" {
+		t.Error("DriveID should not be empty")
+	}
+}
+
+// TestDetector_WatchdogIgnoresActiveDrives ensures the watchdog does NOT
+// fire while telemetry is still arriving regularly. Regression guard for
+// the watchdog reading lastTelemetryAt correctly.
+func TestDetector_WatchdogIgnoresActiveDrives(t *testing.T) {
+	bus := testBus()
+	defer bus.Close(context.Background())
+
+	cfg := testConfig()
+	cfg.EndDebounce = 200 * time.Millisecond
+	cfg.MinDuration = 0
+	cfg.MinDistanceMiles = 0
+
+	d := NewDetector(bus, cfg, testLogger(), NoopDetectorMetrics{})
+	if err := d.Start(context.Background()); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	defer func() { _ = d.Stop() }()
+
+	startedCh := subscribeTopic(t, bus, events.TopicDriveStarted)
+	endedCh := subscribeTopic(t, bus, events.TopicDriveEnded)
+
+	now := time.Now()
+
+	// Start a drive.
+	publishTelemetry(t, bus, telemetryEvent("VIN_ACTIVE", now, driveFields("D", 30.0, 33.09, -96.82)))
+	if _, ok := waitForEvent(startedCh); !ok {
+		t.Fatal("timed out waiting for DriveStartedEvent")
+	}
+
+	// Feed telemetry continuously at an interval well below EndDebounce.
+	// The watchdog must NOT fire because lastTelemetryAt is fresh.
+	stopTel := keepTelemetryAlive(bus, "VIN_ACTIVE", now)
+	defer stopTel()
+
+	// Wait longer than EndDebounce -- still no end event.
+	expectNoEvent(t, endedCh, 3*cfg.EndDebounce, "watchdog should not end an active drive")
+}
+
 func TestDetector_DisconnectWhileIdle_NoEffect(t *testing.T) {
 	bus := testBus()
 	defer bus.Close(context.Background())
@@ -688,6 +858,12 @@ func TestDetector_ConnectedEvent_NoEffect(t *testing.T) {
 
 	// Connected event should NOT end the drive.
 	publishConnectivity(t, bus, "VIN_CONN", events.StatusConnected)
+
+	// Keep telemetry flowing so the silent-telemetry watchdog (MYR-139
+	// R3a) does not end the drive as a side effect. This test asserts
+	// connected-event behaviour specifically.
+	stopTel := keepTelemetryAlive(bus, "VIN_CONN", now)
+	defer stopTel()
 
 	expectNoEvent(t, endedCh, 200*time.Millisecond, "connected event should not end drive")
 }

--- a/internal/drives/metrics.go
+++ b/internal/drives/metrics.go
@@ -17,6 +17,12 @@ type DetectorMetrics interface {
 	// (vehicle resumed driving before debounce elapsed).
 	IncDebounceCancelled()
 
+	// IncWatchdogEnded increments the count of drives ended by the
+	// silent-telemetry watchdog (Tesla stopped streaming without a
+	// gear=P frame, so the AfterFunc-based debounce never primed).
+	// MYR-139 R3a.
+	IncWatchdogEnded()
+
 	// ObserveDriveDuration records the duration of a completed drive.
 	ObserveDriveDuration(seconds float64)
 

--- a/internal/drives/noop_metrics.go
+++ b/internal/drives/noop_metrics.go
@@ -10,6 +10,7 @@ func (NoopDetectorMetrics) IncDriveStarted()              {}
 func (NoopDetectorMetrics) IncDriveEnded()                {}
 func (NoopDetectorMetrics) IncMicroDriveDiscarded()        {}
 func (NoopDetectorMetrics) IncDebounceCancelled()          {}
+func (NoopDetectorMetrics) IncWatchdogEnded()              {}
 func (NoopDetectorMetrics) ObserveDriveDuration(float64)   {}
 func (NoopDetectorMetrics) ObserveDriveDistance(float64)   {}
 func (NoopDetectorMetrics) SetActiveVehicles(int)          {}

--- a/internal/drives/state.go
+++ b/internal/drives/state.go
@@ -52,6 +52,13 @@ type vehicleState struct {
 	// lastLocation caches the most recent valid location for drives that
 	// start without a location in the triggering event.
 	lastLocation *events.Location
+
+	// lastTelemetryAt records the wall-clock time of the most recently
+	// received telemetry event for this vehicle (any field, gear-bearing
+	// or not). The end-condition watchdog uses this to detect drives
+	// that have gone silent because Tesla stopped streaming when the car
+	// parked. See watchdogTick in debounce.go.
+	lastTelemetryAt time.Time
 }
 
 // activeDrive accumulates data during an in-progress drive.


### PR DESCRIPTION
Fixes MYR-139 findings R3a (drive_ended never fires) + R3b (stuck active drives in DB).

## R3a — Root cause

\`internal/drives/transitions.go:81-88\` — the gear=P → \`time.AfterFunc\` debounce only primes when \`handleDriving\` observes a frame with \`gearPosition=P\`. **Tesla stops streaming the moment a vehicle parks**, so a gear=P frame is not guaranteed to arrive at all. When telemetry simply goes silent, the AfterFunc is never scheduled, and the drive stays in \`StatusDriving\` forever. The writer subscribes to \`drive.ended\`, so no completion UPDATE ever runs — leaving \`Drive\` rows with \`endTime IS NULL\`. Matches the prod symptom exactly.

## R3a — Fix

- New \`lastTelemetryAt\` field on \`vehicleState\`, stamped in \`handleTelemetry\`.
- New \`runWatchdog\`/\`watchdogTick\` in \`debounce.go\`, launched from \`Detector.Start\`, stopped via \`watchdogWG.Wait()\` in \`Detector.Stop\`. Interval = \`max(EndDebounce/2, 100ms)\`. Tick scans \`sync.Map\`, ends any drive whose \`lastTelemetryAt\` is older than \`EndDebounce\`. Guards: status must be \`StatusDriving\`, no in-flight gear=P timer, \`lastTelemetryAt\` non-zero.
- Existing gear=P path untouched. \`DriveEndedEvent\` shape untouched.
- New \`IncWatchdogEnded\` metric distinguishes silent-telemetry ends from gear=P ends.

## R3b — Approach

**Standalone Go binary \`cmd/cleanup-stuck-drives/main.go\`**, not a SQL migration. Safety: \`docs/architecture/migrations.md\` §4.2 + CG-DL-9 forbid SQL migrations from referencing \`"Drive"\` (Prisma-owned). Runtime queries are allowed.

\`DELETE FROM "Drive" WHERE "endTime" IS NULL AND "startTime" < NOW() - $1::interval\`. Defaults to 24h, env-overridable. \`CLEANUP_STUCK_DRIVES_DRY_RUN=true\` for preview. Mirrors \`cmd/backfill-account-tokens\` patterns.

## Tests

- \`TestDetector_WatchdogEndsDriveWhenTelemetrySilent\` — exact prod repro
- \`TestDetector_WatchdogIgnoresActiveDrives\` — regression guard
- 2 existing tests updated (their pre-fix passing depended on the buggy "open forever" behavior)
- \`-race\` clean, full repo \`go test ./...\` green, \`golangci-lint\` 0 issues

## Test plan

- [x] go vet clean
- [x] go test ./... passes
- [x] golangci-lint 0 issues
- [ ] CI green
- [ ] Post-merge: run \`cleanup-stuck-drives\` on prod to clear the 5 known stuck rows

## Out of scope (filed follow-up)

Micro-drive filter at \`debounce.go:53-66\` is a secondary orphan source: when a drive starts but is discarded as a micro-drive, the \`Drive\` row stays open. Separate fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)