### PR TITLE
MYR-141 Phase 1: contract tests for /vehicles, /snapshot, /drives + CI gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,6 +110,31 @@ jobs:
           if-no-files-found: ignore
           retention-days: 7
 
+  contract:
+    name: Contract conformance
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    # MYR-141: contract-level conformance tests for the Go REST surface.
+    # These mount the real handlers from `internal/telemetry/*` against a
+    # real Postgres (via testcontainers-go) and assert wire-shape adherence
+    # for every endpoint in `docs/contracts/schemas/`. The tests are
+    # tagged `contract` so the default `go test ./...` (which runs without
+    # Docker on dev laptops) does not pull them in.
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-go@v6
+        with:
+          go-version-file: 'go.mod'
+          cache-dependency-path: 'go.sum'
+
+      - name: Run contract conformance tests
+        # GitHub-hosted runners have Docker available; the suite's
+        # TestMain skips out cleanly if it ever isn't. -count=1 disables
+        # the test cache so the suite runs against the canonical
+        # schemas on every push.
+        run: go test -tags=contract -count=1 -timeout=180s ./tests/contract/...
+
   security:
     name: Security
     runs-on: ubuntu-latest
@@ -145,7 +170,7 @@ jobs:
     name: Build
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    needs: [lint, test, security]
+    needs: [lint, test, contract, security]
     steps:
       - uses: actions/checkout@v6
 

--- a/docs/contracts/schemas/vehicle-summary.schema.json
+++ b/docs/contracts/schemas/vehicle-summary.schema.json
@@ -1,0 +1,89 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://myrobotaxi.com/schemas/vehicle-summary.schema.json",
+  "title": "VehicleSummary",
+  "description": "Thin per-row catalog shape returned by GET /api/vehicles (rest-api.md §7.0). The list is deliberately a catalog -- live telemetry (GPS, navigation, climate, full charge group) lives in VehicleState (vehicle-state.schema.json) and is fetched per-vehicle via GET /api/vehicles/{vehicleId}/snapshot. Owner sees every field; viewer sees every field except `name` per the §5.2.0 mask.",
+  "type": "object",
+  "required": [
+    "vehicleId",
+    "model",
+    "year",
+    "color",
+    "vinLast4",
+    "status",
+    "chargeLevel",
+    "estimatedRange",
+    "lastUpdated",
+    "role"
+  ],
+  "properties": {
+    "vehicleId": {
+      "type": "string",
+      "description": "Opaque database identifier (cuid). NOT the VIN. The SDK uses this in every other endpoint's path parameter (`/api/vehicles/{vehicleId}/snapshot`, etc.).",
+      "x-classification": "P0",
+      "examples": ["clxyz1234567890abcdef"]
+    },
+    "name": {
+      "type": "string",
+      "description": "User-assigned vehicle name. Owner-only field per §5.2.0 — viewer responses MUST NOT include this property at all (mask-strip removes the key, not nulls it).",
+      "x-classification": "P1",
+      "examples": ["Stumpy"]
+    },
+    "model": {
+      "type": "string",
+      "description": "Tesla model: 'Model 3', 'Model S', 'Model X', 'Model Y', 'Cybertruck', etc.",
+      "x-classification": "P0",
+      "examples": ["Model 3"]
+    },
+    "year": {
+      "type": "integer",
+      "description": "Model year.",
+      "x-classification": "P0",
+      "examples": [2024]
+    },
+    "color": {
+      "type": "string",
+      "description": "Display color.",
+      "x-classification": "P0",
+      "examples": ["Midnight Silver Metallic"]
+    },
+    "vinLast4": {
+      "type": "string",
+      "description": "Last 4 characters of the VIN. The full VIN is never emitted per data-classification.md §1.5 + redactVIN(). Empty string allowed for vehicles whose VIN is unknown.",
+      "x-classification": "P0",
+      "maxLength": 4,
+      "examples": ["0001"]
+    },
+    "status": {
+      "type": "string",
+      "enum": ["driving", "parked", "charging", "offline", "in_service"],
+      "description": "Derived vehicle status. Mirrors the VehicleStatus Prisma enum.",
+      "x-classification": "P0"
+    },
+    "chargeLevel": {
+      "type": "integer",
+      "description": "Battery state of charge, 0-100. Lightweight indicator for the catalog view; full charge group lives in /snapshot.",
+      "x-classification": "P0",
+      "minimum": 0,
+      "maximum": 100
+    },
+    "estimatedRange": {
+      "type": "integer",
+      "description": "Estimated remaining range in miles.",
+      "x-classification": "P0",
+      "minimum": 0
+    },
+    "lastUpdated": {
+      "type": "string",
+      "format": "date-time",
+      "description": "ISO 8601 timestamp of the most recent telemetry write to this vehicle. The catalog uses it to render 'last seen N minutes ago.'",
+      "x-classification": "P0"
+    },
+    "role": {
+      "type": "string",
+      "enum": ["owner", "viewer"],
+      "description": "The caller's relationship to the vehicle. v1 only emits 'owner' (the only reachable path on the Go server); the 'viewer' value is reserved for the planned viewer-merged pathway. See §7.0 RBAC v1 implementation note.",
+      "x-classification": "P0"
+    }
+  }
+}

--- a/tests/contract/contract_test.go
+++ b/tests/contract/contract_test.go
@@ -1,0 +1,752 @@
+//go:build contract
+
+// Package contract_test contract conformance harness for the Go REST
+// surface (MYR-141 Quality 1 Phase 1).
+//
+// What this file is: shared helpers for endpoint-level contract tests
+// that spin up the real handlers from `internal/telemetry/*`, wired
+// against a real Postgres (via testcontainers-go) using the same lean
+// repos the production binary mounts. The point is to catch contract
+// drift — missing routes (MYR-132's 404 on /drives), data-shape
+// mismatches (MYR-139), and schema-breaking changes — on every PR
+// against the actual handler code rather than against fixtures alone.
+//
+// Build tag: `contract`. The default `go test ./...` does NOT execute
+// these tests, mirroring the pattern in `internal/store/db_test.go` —
+// local dev without Docker still passes. CI runs them in a dedicated
+// `Contract conformance` job per `.github/workflows/ci.yml`.
+//
+// Docker gating: when Docker is unreachable, TestMain logs a skip
+// notice and exits 0 without running any tests. This matches the
+// behavior in `internal/store/db_test.go` so a workstation without
+// Docker is never a hard failure.
+//
+// Schema validation: bodies are validated against the canonical
+// `docs/contracts/schemas/*.schema.json` shapes using
+// `github.com/santhosh-tekuri/jsonschema/v6` (already a dependency for
+// `fixtures_test.go` — Phase 1 adds no new modules). The task spec
+// proposed v5; v6 is the version already vendored, so we reuse it
+// rather than introduce a parallel version.
+package contract_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/golang-jwt/jwt/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/santhosh-tekuri/jsonschema/v6"
+	"github.com/testcontainers/testcontainers-go"
+	"github.com/testcontainers/testcontainers-go/modules/postgres"
+	"github.com/testcontainers/testcontainers-go/wait"
+
+	"github.com/myrobotaxi/telemetry/internal/auth"
+	"github.com/myrobotaxi/telemetry/internal/store"
+	"github.com/myrobotaxi/telemetry/internal/telemetry"
+)
+
+// ---------------------------------------------------------------------------
+// Shared container state (TestMain)
+// ---------------------------------------------------------------------------
+
+// contractTestSecret is the HS256 signing secret the JWT minter and the
+// JWTAuthenticator share for all contract tests. Hardcoded because the
+// secret is irrelevant outside the test process — what matters is the
+// minter and the validator agree.
+const contractTestSecret = "contract-test-secret-key" // #nosec G101 -- test-only
+
+// testPool is the shared pgx pool for every contract test. Initialized
+// in TestMain and reused across t.Run subtests; each subtest owns its
+// data by calling cleanTables before seeding.
+var testPool *pgxpool.Pool
+
+// dockerAvailable mirrors internal/store/db_test.go: when false, the
+// suite exits 0 instead of running tests against a missing daemon.
+var dockerAvailable bool
+
+func TestMain(m *testing.M) {
+	if !isDockerRunning() {
+		fmt.Fprintln(os.Stderr, "Docker is not available, skipping contract tests")
+		os.Exit(0)
+	}
+
+	ctx := context.Background()
+
+	pgContainer, err := postgres.Run(ctx,
+		"postgres:16-alpine",
+		postgres.WithDatabase("contractdb"),
+		postgres.WithUsername("testuser"),
+		postgres.WithPassword("testpass"),
+		testcontainers.WithWaitStrategy(
+			wait.ForLog("database system is ready to accept connections").
+				WithOccurrence(2).
+				WithStartupTimeout(60*time.Second),
+		),
+	)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "failed to start postgres container: %v\n", err)
+		os.Exit(1)
+	}
+
+	connStr, err := pgContainer.ConnectionString(ctx, "sslmode=disable")
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "failed to get connection string: %v\n", err)
+		os.Exit(1)
+	}
+
+	pool, err := pgxpool.New(ctx, connStr)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "failed to create pool: %v\n", err)
+		os.Exit(1)
+	}
+
+	if err := createContractSchema(ctx, pool); err != nil {
+		fmt.Fprintf(os.Stderr, "failed to create schema: %v\n", err)
+		os.Exit(1)
+	}
+
+	testPool = pool
+	dockerAvailable = true
+
+	code := m.Run()
+
+	pool.Close()
+	if err := pgContainer.Terminate(ctx); err != nil {
+		fmt.Fprintf(os.Stderr, "failed to terminate container: %v\n", err)
+	}
+
+	os.Exit(code)
+}
+
+// isDockerRunning probes the Docker daemon. A 5s ceiling keeps a stalled
+// daemon from blocking CI indefinitely.
+func isDockerRunning() bool {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, "docker", "info") // #nosec G204 -- hardcoded command, not user input
+	return cmd.Run() == nil
+}
+
+// createContractSchema provisions the Prisma-owned tables the handlers
+// read from. Mirrors the shape in internal/store/db_test.go for
+// Vehicle + Drive, plus a minimal User table for the JWTAuthenticator's
+// fail-closed existence check (data-lifecycle.md §3.5).
+func createContractSchema(ctx context.Context, pool *pgxpool.Pool) error {
+	schema := `
+	CREATE TYPE "VehicleStatus" AS ENUM (
+		'driving', 'parked', 'charging', 'offline', 'in_service'
+	);
+
+	CREATE TABLE "User" (
+		"id" TEXT PRIMARY KEY
+	);
+
+	CREATE TABLE "Vehicle" (
+		"id"               TEXT PRIMARY KEY,
+		"userId"           TEXT NOT NULL,
+		"teslaVehicleId"   TEXT UNIQUE,
+		"vin"              TEXT UNIQUE,
+		"name"             TEXT NOT NULL DEFAULT '',
+		"model"            TEXT NOT NULL DEFAULT '',
+		"year"             INT NOT NULL DEFAULT 0,
+		"color"            TEXT NOT NULL DEFAULT '',
+		"licensePlate"     TEXT NOT NULL DEFAULT '',
+		"chargeLevel"      INT NOT NULL DEFAULT 0,
+		"estimatedRange"   INT NOT NULL DEFAULT 0,
+		"chargeState"      TEXT,
+		"timeToFull"       DOUBLE PRECISION,
+		"status"           "VehicleStatus" NOT NULL DEFAULT 'offline',
+		"speed"            INT NOT NULL DEFAULT 0,
+		"gearPosition"     TEXT,
+		"heading"          INT NOT NULL DEFAULT 0,
+		"locationName"     TEXT NOT NULL DEFAULT '',
+		"locationAddress"  TEXT NOT NULL DEFAULT '',
+		"latitude"         DOUBLE PRECISION NOT NULL DEFAULT 0,
+		"longitude"        DOUBLE PRECISION NOT NULL DEFAULT 0,
+		"latitudeEnc"          TEXT,
+		"longitudeEnc"         TEXT,
+		"interiorTemp"     INT NOT NULL DEFAULT 0,
+		"exteriorTemp"     INT NOT NULL DEFAULT 0,
+		"odometerMiles"    INT NOT NULL DEFAULT 0,
+		"fsdMilesSinceReset"    DOUBLE PRECISION NOT NULL DEFAULT 0,
+		"virtualKeyPaired" BOOLEAN NOT NULL DEFAULT FALSE,
+		"destinationName"  TEXT,
+		"destinationLatitude"  DOUBLE PRECISION,
+		"destinationLongitude" DOUBLE PRECISION,
+		"destinationLatitudeEnc"  TEXT,
+		"destinationLongitudeEnc" TEXT,
+		"originLatitude"       DOUBLE PRECISION,
+		"originLongitude"      DOUBLE PRECISION,
+		"originLatitudeEnc"    TEXT,
+		"originLongitudeEnc"   TEXT,
+		"destinationAddress" TEXT,
+		"etaMinutes"       INT,
+		"tripDistanceMiles" DOUBLE PRECISION,
+		"tripDistanceRemaining" DOUBLE PRECISION,
+		"navRouteCoordinates" JSONB,
+		"navRouteCoordinatesEnc" TEXT,
+		"lastUpdated"      TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+		"createdAt"        TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+		"updatedAt"        TIMESTAMPTZ NOT NULL DEFAULT NOW()
+	);
+
+	CREATE TABLE "Drive" (
+		"id"               TEXT PRIMARY KEY,
+		"vehicleId"        TEXT NOT NULL REFERENCES "Vehicle"("id"),
+		"date"             TEXT NOT NULL,
+		"startTime"        TEXT NOT NULL,
+		"endTime"          TEXT NOT NULL DEFAULT '',
+		"startLocation"    TEXT NOT NULL DEFAULT '',
+		"startAddress"     TEXT NOT NULL DEFAULT '',
+		"endLocation"      TEXT NOT NULL DEFAULT '',
+		"endAddress"       TEXT NOT NULL DEFAULT '',
+		"distanceMiles"    DOUBLE PRECISION NOT NULL DEFAULT 0,
+		"durationMinutes"  INT NOT NULL DEFAULT 0,
+		"avgSpeedMph"      DOUBLE PRECISION NOT NULL DEFAULT 0,
+		"maxSpeedMph"      DOUBLE PRECISION NOT NULL DEFAULT 0,
+		"energyUsedKwh"    DOUBLE PRECISION NOT NULL DEFAULT 0,
+		"startChargeLevel" INT NOT NULL DEFAULT 0,
+		"endChargeLevel"   INT NOT NULL DEFAULT 0,
+		"fsdMiles"         DOUBLE PRECISION NOT NULL DEFAULT 0,
+		"fsdPercentage"    DOUBLE PRECISION NOT NULL DEFAULT 0,
+		"interventions"    INT NOT NULL DEFAULT 0,
+		"routePoints"      JSONB NOT NULL DEFAULT '[]',
+		"routePointsEnc"   TEXT,
+		"createdAt"        TIMESTAMPTZ NOT NULL DEFAULT NOW()
+	);`
+	if _, err := pool.Exec(ctx, schema); err != nil {
+		return fmt.Errorf("create schema: %w", err)
+	}
+	return nil
+}
+
+// ---------------------------------------------------------------------------
+// Test server: real handlers, real repos, slim mux
+// ---------------------------------------------------------------------------
+
+// seedHelpers exposes the seed primitives every test needs to plant
+// rows into the test DB. Returned by setupTestServer so a test holds a
+// pointer to both the server and the seed surface in one value.
+type seedHelpers struct {
+	pool *pgxpool.Pool
+}
+
+// setupTestServer wires the three REST handlers under test against a
+// real Postgres and a real JWTAuthenticator. The mux is intentionally
+// lean — only the three routes Phase 1 covers are mounted; cmd/
+// composition concerns (TLS, metrics, fleet config, debug stream) are
+// out of scope. The signature mirrors the structure proposed in the
+// task: `(*httptest.Server, *seedHelpers)`.
+//
+// The httptest.Server and the test pool are torn down via t.Cleanup
+// so callers don't need defer.
+func setupTestServer(t *testing.T) (*httptest.Server, *seedHelpers) {
+	t.Helper()
+	if !dockerAvailable {
+		t.Skip("Docker not available; skipping contract test")
+	}
+
+	cleanTables(t, testPool)
+
+	logger := slog.New(slog.NewTextHandler(io.Discard, &slog.HandlerOptions{Level: slog.LevelError}))
+
+	vehicleRepo := store.NewVehicleRepo(testPool, store.NoopMetrics{})
+	driveRepo := store.NewDriveRepo(testPool, store.NoopMetrics{})
+
+	// Issuer / audience left empty: the test minter omits them too, so
+	// the JWT validator skips those checks. This mirrors the dev-mode
+	// shape — sufficient for contract conformance (we care about
+	// route + body shape, not claim-policy enforcement).
+	authenticator := auth.NewJWTAuthenticator(contractTestSecret, "", "", testPool)
+
+	listAdapter := &contractVehicleLister{repo: vehicleRepo}
+	snapshotAdapter := &contractVehicleSnapshotReader{repo: vehicleRepo}
+	driveAdapter := &contractDriveLister{repo: driveRepo}
+
+	listHandler := telemetry.NewVehiclesListHandler(authenticator, listAdapter, logger)
+	snapshotHandler := telemetry.NewVehicleSnapshotHandler(
+		authenticator, snapshotAdapter, logger,
+		telemetry.WithSnapshotRoleResolver(authenticator),
+	)
+	drivesHandler := telemetry.NewVehicleDrivesHandler(
+		authenticator, snapshotAdapter, driveAdapter, logger,
+		telemetry.WithDrivesRoleResolver(authenticator),
+	)
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /api/vehicles", listHandler.ServeHTTP)
+	mux.HandleFunc("GET /api/vehicles/{vehicleId}/snapshot", snapshotHandler.ServeHTTP)
+	mux.HandleFunc("GET /api/vehicles/{vehicleId}/drives", drivesHandler.ServeHTTP)
+
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+
+	return srv, &seedHelpers{pool: testPool}
+}
+
+// ---------------------------------------------------------------------------
+// Real-repo adapters (mirror cmd/telemetry-server/adapters.go but live
+// in the test package so we don't introduce a cyclic dep through cmd/)
+// ---------------------------------------------------------------------------
+
+type contractVehicleLister struct{ repo *store.VehicleRepo }
+
+func (a *contractVehicleLister) ListByUser(ctx context.Context, userID string) ([]telemetry.VehicleCatalogRow, error) {
+	rows, err := a.repo.ListSummariesByUser(ctx, userID)
+	if err != nil {
+		return nil, fmt.Errorf("contractVehicleLister.ListByUser: %w", err)
+	}
+	out := make([]telemetry.VehicleCatalogRow, 0, len(rows))
+	for i := range rows {
+		v := &rows[i]
+		out = append(out, telemetry.VehicleCatalogRow{
+			ID:             v.ID,
+			VIN:            v.VIN,
+			Name:           v.Name,
+			Model:          v.Model,
+			Year:           v.Year,
+			Color:          v.Color,
+			Status:         string(v.Status),
+			ChargeLevel:    v.ChargeLevel,
+			EstimatedRange: v.EstimatedRange,
+			LastUpdated:    v.LastUpdated,
+		})
+	}
+	return out, nil
+}
+
+type contractVehicleSnapshotReader struct{ repo *store.VehicleRepo }
+
+func (a *contractVehicleSnapshotReader) GetByID(ctx context.Context, vehicleID string) (telemetry.VehicleSnapshotRow, error) {
+	v, err := a.repo.GetByID(ctx, vehicleID)
+	if err != nil {
+		return telemetry.VehicleSnapshotRow{}, fmt.Errorf("contractVehicleSnapshotReader.GetByID: %w", err)
+	}
+	return telemetry.VehicleSnapshotRow{
+		ID:                   v.ID,
+		UserID:               v.UserID,
+		VIN:                  v.VIN,
+		Name:                 v.Name,
+		Model:                v.Model,
+		Year:                 v.Year,
+		Color:                v.Color,
+		Status:               string(v.Status),
+		ChargeLevel:          v.ChargeLevel,
+		EstimatedRange:       v.EstimatedRange,
+		ChargeState:          v.ChargeState,
+		TimeToFull:           v.TimeToFull,
+		Speed:                v.Speed,
+		GearPosition:         v.GearPosition,
+		Heading:              v.Heading,
+		Latitude:             v.Latitude,
+		Longitude:            v.Longitude,
+		LocationName:         v.LocationName,
+		LocationAddress:      v.LocationAddress,
+		InteriorTemp:         v.InteriorTemp,
+		ExteriorTemp:         v.ExteriorTemp,
+		OdometerMiles:        v.OdometerMiles,
+		FsdMilesSinceReset:   v.FsdMilesSinceReset,
+		DestinationName:      v.DestinationName,
+		DestinationAddress:   v.DestinationAddress,
+		DestinationLatitude:  v.DestinationLatitude,
+		DestinationLongitude: v.DestinationLongitude,
+		OriginLatitude:       v.OriginLatitude,
+		OriginLongitude:      v.OriginLongitude,
+		EtaMinutes:           v.EtaMinutes,
+		TripDistRemaining:    v.TripDistRemaining,
+		NavRouteCoordinates:  v.NavRouteCoordinates,
+		LastUpdated:          v.LastUpdated,
+	}, nil
+}
+
+type contractDriveLister struct{ repo *store.DriveRepo }
+
+func (a *contractDriveLister) ListByVehicleID(ctx context.Context, vehicleID string, cursor telemetry.DriveListCursor, limit int) (telemetry.DriveListPage, error) {
+	page, err := a.repo.ListByVehicleID(ctx, vehicleID, store.DriveListCursor{
+		StartTime: cursor.StartTime,
+		ID:        cursor.ID,
+	}, limit)
+	if err != nil {
+		return telemetry.DriveListPage{}, fmt.Errorf("contractDriveLister.ListByVehicleID: %w", err)
+	}
+	items := make([]telemetry.DriveListItem, 0, len(page.Items))
+	for i := range page.Items {
+		d := &page.Items[i]
+		items = append(items, telemetry.DriveListItem{
+			ID:               d.ID,
+			VehicleID:        d.VehicleID,
+			StartTime:        d.StartTime,
+			EndTime:          d.EndTime,
+			Date:             d.Date,
+			DistanceMiles:    d.DistanceMiles,
+			DurationMinutes:  d.DurationMinutes,
+			AvgSpeedMph:      d.AvgSpeedMph,
+			MaxSpeedMph:      d.MaxSpeedMph,
+			StartChargeLevel: d.StartChargeLevel,
+			EndChargeLevel:   d.EndChargeLevel,
+			CreatedAt:        d.CreatedAt,
+		})
+	}
+	return telemetry.DriveListPage{Items: items, HasMore: page.HasMore}, nil
+}
+
+// ---------------------------------------------------------------------------
+// Token minting
+// ---------------------------------------------------------------------------
+
+// mintToken signs an HS256 JWT using the shared contract-test secret.
+// The `scopes` argument is reserved for future per-scope checks
+// (rest-api.md §3.x); v1 carries it as a claim but the validator
+// ignores it. Kept in the signature so that callers under §7.0 / §7.1
+// / §7.2 don't need refactoring when scope-based gating lands.
+//
+//nolint:unparam // `scopes` is the contract-test harness public API per MYR-141.
+func mintToken(t *testing.T, userID string, scopes []string) string {
+	t.Helper()
+	claims := jwt.MapClaims{
+		"sub": userID,
+		"iat": time.Now().Unix(),
+		"exp": time.Now().Add(1 * time.Hour).Unix(),
+	}
+	if len(scopes) > 0 {
+		claims["scopes"] = scopes
+	}
+	tok := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
+	signed, err := tok.SignedString([]byte(contractTestSecret))
+	if err != nil {
+		t.Fatalf("mintToken: %v", err)
+	}
+	return signed
+}
+
+// mintExpiredToken returns a JWT signed with the right secret but with
+// `exp` in the past. Used by the 401 expired-token case.
+func mintExpiredToken(t *testing.T, userID string) string {
+	t.Helper()
+	claims := jwt.MapClaims{
+		"sub": userID,
+		"iat": time.Now().Add(-2 * time.Hour).Unix(),
+		"exp": time.Now().Add(-1 * time.Hour).Unix(),
+	}
+	tok := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
+	signed, err := tok.SignedString([]byte(contractTestSecret))
+	if err != nil {
+		t.Fatalf("mintExpiredToken: %v", err)
+	}
+	return signed
+}
+
+// ---------------------------------------------------------------------------
+// Seed helpers
+// ---------------------------------------------------------------------------
+
+// cleanTables truncates the contract test tables. Called by
+// setupTestServer for every test so subtests can seed freely without
+// worrying about leaks from earlier tests. Order matters: Drive has a
+// FK to Vehicle.
+func cleanTables(t *testing.T, pool *pgxpool.Pool) {
+	t.Helper()
+	ctx := context.Background()
+	if _, err := pool.Exec(ctx, `DELETE FROM "Drive"`); err != nil {
+		t.Fatalf("clean Drive: %v", err)
+	}
+	if _, err := pool.Exec(ctx, `DELETE FROM "Vehicle"`); err != nil {
+		t.Fatalf("clean Vehicle: %v", err)
+	}
+	if _, err := pool.Exec(ctx, `DELETE FROM "User"`); err != nil {
+		t.Fatalf("clean User: %v", err)
+	}
+}
+
+// seedUser inserts a minimal User row so the JWTAuthenticator's FR-10.1
+// fail-closed existence check (data-lifecycle.md §3.5) accepts the
+// caller's token. A test that mints a token for userID MUST seed that
+// user first; ValidateToken rejects unknown subjects.
+func (h *seedHelpers) seedUser(ctx context.Context, t *testing.T, userID string) {
+	t.Helper()
+	if _, err := h.pool.Exec(ctx, `INSERT INTO "User" ("id") VALUES ($1)`, userID); err != nil {
+		t.Fatalf("seedUser(%s): %v", userID, err)
+	}
+}
+
+// vehicleSeed bundles the columns most contract tests want to set on a
+// Vehicle row. Zero-valued fields fall through to their Prisma defaults
+// (status=offline, charge=0, etc.) so a minimal call site can pass just
+// the identifiers and let the schema fill the rest.
+type vehicleSeed struct {
+	ID              string
+	UserID          string
+	VIN             string
+	Name            string
+	Model           string
+	Year            int
+	Color           string
+	Status          string  // empty string falls through to schema default 'offline'
+	ChargeLevel     int
+	EstimatedRange  int
+	LocationName    string
+	LocationAddress string
+	FsdMilesReset   float64
+	LastUpdated     time.Time
+}
+
+// seedVehicle inserts a Vehicle row. The fixture covers every field the
+// snapshot handler reads back (status, charge, name, address, etc.) —
+// the wide-read path will scan all columns whether or not the test
+// cares about them.
+func (h *seedHelpers) seedVehicle(ctx context.Context, t *testing.T, v vehicleSeed) {
+	t.Helper()
+	status := v.Status
+	if status == "" {
+		status = "parked"
+	}
+	if v.LastUpdated.IsZero() {
+		v.LastUpdated = time.Now().UTC()
+	}
+	_, err := h.pool.Exec(ctx, `
+		INSERT INTO "Vehicle" (
+			"id", "userId", "vin", "name",
+			"model", "year", "color", "status",
+			"chargeLevel", "estimatedRange",
+			"locationName", "locationAddress",
+			"fsdMilesSinceReset", "lastUpdated"
+		) VALUES (
+			$1, $2, $3, $4,
+			$5, $6, $7, $8::"VehicleStatus",
+			$9, $10,
+			$11, $12,
+			$13, $14
+		)`,
+		v.ID, v.UserID, v.VIN, v.Name,
+		v.Model, v.Year, v.Color, status,
+		v.ChargeLevel, v.EstimatedRange,
+		v.LocationName, v.LocationAddress,
+		v.FsdMilesReset, v.LastUpdated,
+	)
+	if err != nil {
+		t.Fatalf("seedVehicle(%s): %v", v.ID, err)
+	}
+}
+
+// driveSeed bundles the columns that drive the drives-list ordering and
+// pagination assertions. The store-layer ListByVehicleID reads
+// startTime + id as the cursor anchor, so a test that wants
+// deterministic pagination MUST set both per row.
+type driveSeed struct {
+	ID               string
+	VehicleID        string
+	Date             string
+	StartTime        string
+	EndTime          string
+	DistanceMiles    float64
+	DurationMinutes  int
+	AvgSpeedMph      float64
+	MaxSpeedMph      float64
+	StartChargeLevel int
+	EndChargeLevel   int
+	CreatedAt        time.Time
+}
+
+// seedDrive inserts a Drive row.
+func (h *seedHelpers) seedDrive(ctx context.Context, t *testing.T, d driveSeed) {
+	t.Helper()
+	if d.CreatedAt.IsZero() {
+		d.CreatedAt = time.Now().UTC()
+	}
+	_, err := h.pool.Exec(ctx, `
+		INSERT INTO "Drive" (
+			"id", "vehicleId", "date", "startTime", "endTime",
+			"distanceMiles", "durationMinutes",
+			"avgSpeedMph", "maxSpeedMph",
+			"startChargeLevel", "endChargeLevel",
+			"createdAt"
+		) VALUES (
+			$1, $2, $3, $4, $5,
+			$6, $7,
+			$8, $9,
+			$10, $11,
+			$12
+		)`,
+		d.ID, d.VehicleID, d.Date, d.StartTime, d.EndTime,
+		d.DistanceMiles, d.DurationMinutes,
+		d.AvgSpeedMph, d.MaxSpeedMph,
+		d.StartChargeLevel, d.EndChargeLevel,
+		d.CreatedAt,
+	)
+	if err != nil {
+		t.Fatalf("seedDrive(%s): %v", d.ID, err)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// HTTP convenience helpers
+// ---------------------------------------------------------------------------
+
+// doGET issues a GET against the test server. When token is non-empty
+// it sets the Authorization header — pass "" to exercise the missing-
+// token branch.
+func doGET(t *testing.T, srv *httptest.Server, path, token string) *http.Response {
+	t.Helper()
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, srv.URL+path, nil)
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+	if token != "" {
+		req.Header.Set("Authorization", "Bearer "+token)
+	}
+	resp, err := srv.Client().Do(req)
+	if err != nil {
+		t.Fatalf("do request: %v", err)
+	}
+	return resp
+}
+
+// readBody reads the response body and closes it.
+func readBody(t *testing.T, resp *http.Response) []byte {
+	t.Helper()
+	defer resp.Body.Close()
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("read body: %v", err)
+	}
+	return body
+}
+
+// decodeJSON unmarshals body into v. Fails the test on parse error —
+// every contract test SHOULD reach this point with a JSON body.
+func decodeJSON(t *testing.T, body []byte, v any) {
+	t.Helper()
+	if err := json.Unmarshal(body, v); err != nil {
+		t.Fatalf("unmarshal: %v\nbody: %s", err, string(body))
+	}
+}
+
+// jsonMarshal is a thin wrapper around json.Marshal used by tests that
+// want to re-serialize a decoded sub-object (e.g. a single list item)
+// for schema validation. Exported as a package-private helper so call
+// sites stay readable.
+func jsonMarshal(v any) ([]byte, error) { return json.Marshal(v) }
+
+// ---------------------------------------------------------------------------
+// JSON Schema validation
+// ---------------------------------------------------------------------------
+
+// validateAgainstSchema validates body against the schema at schemaPath
+// (relative to the repo root, e.g. "docs/contracts/schemas/vehicle-state.schema.json").
+// The compiler is loaded fresh per call — schemas are small and the
+// jsonschema/v6 compiler caches them internally; perf is not a concern
+// at test scale.
+func validateAgainstSchema(t *testing.T, schemaPath string, body []byte) {
+	t.Helper()
+
+	root := repoRoot(t)
+	schemasAbs := filepath.Join(root, "docs/contracts/schemas")
+	mainSchema := filepath.Join(root, schemaPath)
+
+	compiler := jsonschema.NewCompiler()
+	loadSchemaResources(t, compiler, schemasAbs)
+
+	mainID := schemaIDFromFile(t, mainSchema)
+	schema, err := compiler.Compile(mainID)
+	if err != nil {
+		t.Fatalf("compile schema %s: %v", schemaPath, err)
+	}
+
+	parsed, err := jsonschema.UnmarshalJSON(bytes.NewReader(body))
+	if err != nil {
+		t.Fatalf("unmarshal body for schema validation: %v\nbody: %s", err, string(body))
+	}
+	if err := schema.Validate(parsed); err != nil {
+		t.Errorf("schema validation failed (%s):\n%v\nbody: %s", schemaPath, err, string(body))
+	}
+}
+
+// loadSchemaResources adds every schema under schemasAbs to the
+// compiler so $ref resolution works across files even when the test
+// only validates against one of them.
+func loadSchemaResources(t *testing.T, c *jsonschema.Compiler, schemasAbs string) {
+	t.Helper()
+	files, err := filepath.Glob(filepath.Join(schemasAbs, "*.json"))
+	if err != nil {
+		t.Fatalf("glob schemas: %v", err)
+	}
+	for _, f := range files {
+		raw, err := readSchemaJSON(f)
+		if err != nil {
+			t.Fatalf("read schema %s: %v", f, err)
+		}
+		id, _ := raw.(map[string]any)["$id"].(string)
+		if id == "" {
+			id = "file:///" + filepath.Base(f)
+		}
+		if err := c.AddResource(id, raw); err != nil {
+			t.Fatalf("add resource %s: %v", f, err)
+		}
+	}
+}
+
+// schemaIDFromFile reads the $id field from a schema file. The main
+// compile target uses the $id so $ref-by-id works alongside file-based
+// loading.
+func schemaIDFromFile(t *testing.T, path string) string {
+	t.Helper()
+	raw, err := readSchemaJSON(path)
+	if err != nil {
+		t.Fatalf("read schema %s: %v", path, err)
+	}
+	id, _ := raw.(map[string]any)["$id"].(string)
+	if id == "" {
+		t.Fatalf("schema %s has no $id", path)
+	}
+	return id
+}
+
+func readSchemaJSON(path string) (any, error) {
+	data, err := os.ReadFile(path) // #nosec G304 -- test-local schema path
+	if err != nil {
+		return nil, err
+	}
+	return jsonschema.UnmarshalJSON(bytes.NewReader(data))
+}
+
+// NOTE: `repoRoot` is provided by tests/contract/fixtures_test.go,
+// which is in the same package and compiled in both default and
+// contract-tagged builds. We deliberately don't re-declare it here.
+
+// ---------------------------------------------------------------------------
+// Error envelope helpers
+// ---------------------------------------------------------------------------
+
+// restErrorEnvelope mirrors the rest-api.md §4.1 error shape returned
+// by `wserrors.WriteErrorEnvelope`. Tests decode response bodies into
+// this struct to assert on the typed `error.code`.
+type restErrorEnvelope struct {
+	Error struct {
+		Code    string `json:"code"`
+		Message string `json:"message"`
+	} `json:"error"`
+}
+
+// assertErrorCode decodes body and checks the typed error code matches
+// wantCode (e.g. "auth_failed", "not_found"). Fails the test with the
+// full body on mismatch so a regression points straight at the wire
+// shape.
+func assertErrorCode(t *testing.T, body []byte, wantCode string) {
+	t.Helper()
+	var env restErrorEnvelope
+	decodeJSON(t, body, &env)
+	if env.Error.Code != wantCode {
+		t.Errorf("error.code = %q, want %q\nbody: %s", env.Error.Code, wantCode, string(body))
+	}
+}

--- a/tests/contract/vehicle_drives_test.go
+++ b/tests/contract/vehicle_drives_test.go
@@ -1,0 +1,261 @@
+//go:build contract
+
+// Contract tests for GET /api/vehicles/{vehicleId}/drives
+// (rest-api.md §7.2).
+//
+// Scope (MYR-141 Phase 1):
+//   - Empty list: vehicle with zero drives -> 200 {items: [], hasMore: false}.
+//   - Pagination: 25 drives, default limit 20 -> 20 items + nextCursor
+//     + hasMore=true; following the cursor returns the remaining 5
+//     with hasMore=false.
+//   - Cursor opacity: the returned nextCursor round-trips through the
+//     pagination endpoint (we don't inspect its bytes — the contract
+//     guarantees opaque base64, not the encoding shape).
+//   - Ordering: items are sorted (startTime DESC, id DESC) per §4.2.2.
+//   - 401 missing token.
+//   - 403 vehicle_not_owned.
+//   - 404 not_found for unknown vehicleId. **This is the MYR-132 /
+//     MYR-130 regression case** — if the route stops being mounted,
+//     the response shape is the http.ServeMux 404 envelope (HTML or
+//     empty body), NOT our `{"error":{"code":"not_found"...}}` JSON
+//     envelope. assertErrorCode catches that drift.
+package contract_test
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"testing"
+)
+
+func TestContract_GETVehicleDrives(t *testing.T) {
+	ctx := context.Background()
+
+	const (
+		ownerID    = "user_owner_drives"
+		otherID    = "user_other_drives"
+		vehicleID  = "veh_drives_001"
+		vehicleVIN = "5YJ3E1EA1PF000301"
+	)
+
+	t.Run("empty list returns 200 with items: [] and hasMore: false", func(t *testing.T) {
+		srv, seeder := setupTestServer(t)
+		seeder.seedUser(ctx, t, ownerID)
+		seeder.seedVehicle(ctx, t, vehicleSeed{
+			ID:             vehicleID,
+			UserID:         ownerID,
+			VIN:            vehicleVIN,
+			Name:           "No-Drives",
+			Model:          "Model 3",
+			Year:           2024,
+			Color:          "Solid Black",
+			Status:         "parked",
+			ChargeLevel:    80,
+			EstimatedRange: 240,
+		})
+		token := mintToken(t, ownerID, nil)
+
+		resp := doGET(t, srv, "/api/vehicles/"+vehicleID+"/drives", token)
+		body := readBody(t, resp)
+
+		if resp.StatusCode != http.StatusOK {
+			t.Fatalf("status = %d, want 200; body: %s", resp.StatusCode, string(body))
+		}
+		var page drivesEnvelope
+		decodeJSON(t, body, &page)
+		if page.Items == nil {
+			t.Errorf("items must be a JSON array (not null) even when empty; body: %s", string(body))
+		}
+		if len(page.Items) != 0 {
+			t.Errorf("expected 0 items, got %d", len(page.Items))
+		}
+		if page.HasMore {
+			t.Errorf("hasMore = true on empty list; want false")
+		}
+		if page.NextCursor != nil {
+			t.Errorf("nextCursor = %v on empty list; want null", *page.NextCursor)
+		}
+	})
+
+	t.Run("pagination round-trip: 25 drives, default limit 20", func(t *testing.T) {
+		srv, seeder := setupTestServer(t)
+		seeder.seedUser(ctx, t, ownerID)
+		seeder.seedVehicle(ctx, t, vehicleSeed{
+			ID:             vehicleID,
+			UserID:         ownerID,
+			VIN:            vehicleVIN,
+			Name:           "Paged",
+			Model:          "Model 3",
+			Year:           2024,
+			Color:          "Solid Black",
+			Status:         "parked",
+			ChargeLevel:    80,
+			EstimatedRange: 240,
+		})
+
+		// Seed 25 drives with deterministic monotonically-decreasing
+		// startTime so the DESC ordering is unambiguous. IDs are
+		// zero-padded so the secondary id-DESC tiebreaker is stable.
+		const total = 25
+		for i := 0; i < total; i++ {
+			// drive_24 has the latest startTime, drive_00 the earliest.
+			seeder.seedDrive(ctx, t, driveSeed{
+				ID:               fmt.Sprintf("drive_%02d", i),
+				VehicleID:        vehicleID,
+				Date:             "2026-05-01",
+				StartTime:        fmt.Sprintf("2026-05-01T%02d:00:00Z", i),
+				EndTime:          fmt.Sprintf("2026-05-01T%02d:30:00Z", i),
+				DistanceMiles:    float64(10 + i),
+				DurationMinutes:  30,
+				AvgSpeedMph:      25.5,
+				MaxSpeedMph:      65.0,
+				StartChargeLevel: 80,
+				EndChargeLevel:   78,
+			})
+		}
+
+		token := mintToken(t, ownerID, nil)
+
+		// Page 1 — no cursor; expect the 20 newest items.
+		resp := doGET(t, srv, "/api/vehicles/"+vehicleID+"/drives", token)
+		body := readBody(t, resp)
+		if resp.StatusCode != http.StatusOK {
+			t.Fatalf("page 1 status = %d, want 200; body: %s", resp.StatusCode, string(body))
+		}
+		var page1 drivesEnvelope
+		decodeJSON(t, body, &page1)
+
+		if len(page1.Items) != 20 {
+			t.Errorf("page 1 items = %d, want 20", len(page1.Items))
+		}
+		if !page1.HasMore {
+			t.Errorf("page 1 hasMore = false, want true (25 drives total > 20 limit)")
+		}
+		if page1.NextCursor == nil || *page1.NextCursor == "" {
+			t.Fatalf("page 1 nextCursor missing; want opaque base64 string")
+		}
+
+		// Ordering: startTime DESC, id DESC per §4.2.2. The newest
+		// item (drive_24) must be first; the 20th-newest (drive_05)
+		// must be last.
+		if got := page1.Items[0]["id"]; got != "drive_24" {
+			t.Errorf("page 1 items[0].id = %v, want drive_24", got)
+		}
+		if got := page1.Items[19]["id"]; got != "drive_05" {
+			t.Errorf("page 1 items[19].id = %v, want drive_05", got)
+		}
+		assertStartTimesDescending(t, page1.Items)
+
+		// Page 2 — follow the cursor; expect the remaining 5 with
+		// hasMore=false. The cursor is treated as opaque: we don't
+		// decode it, we just round-trip it back into the next request.
+		nextURL := "/api/vehicles/" + vehicleID + "/drives?cursor=" + *page1.NextCursor
+		resp2 := doGET(t, srv, nextURL, token)
+		body2 := readBody(t, resp2)
+		if resp2.StatusCode != http.StatusOK {
+			t.Fatalf("page 2 status = %d, want 200; body: %s", resp2.StatusCode, string(body2))
+		}
+		var page2 drivesEnvelope
+		decodeJSON(t, body2, &page2)
+
+		if len(page2.Items) != 5 {
+			t.Errorf("page 2 items = %d, want 5", len(page2.Items))
+		}
+		if page2.HasMore {
+			t.Errorf("page 2 hasMore = true, want false (25 - 20 = 5 remaining)")
+		}
+		if page2.NextCursor != nil {
+			t.Errorf("page 2 nextCursor = %v, want null (final page)", *page2.NextCursor)
+		}
+		if got := page2.Items[0]["id"]; got != "drive_04" {
+			t.Errorf("page 2 items[0].id = %v, want drive_04", got)
+		}
+		if got := page2.Items[4]["id"]; got != "drive_00" {
+			t.Errorf("page 2 items[4].id = %v, want drive_00", got)
+		}
+	})
+
+	t.Run("missing Authorization header returns 401", func(t *testing.T) {
+		srv, seeder := setupTestServer(t)
+		seeder.seedUser(ctx, t, ownerID)
+		seeder.seedVehicle(ctx, t, vehicleSeed{
+			ID:     vehicleID,
+			UserID: ownerID,
+			VIN:    vehicleVIN,
+			Model:  "Model 3", Year: 2024, Color: "Black",
+			Status: "parked",
+		})
+
+		resp := doGET(t, srv, "/api/vehicles/"+vehicleID+"/drives", "")
+		body := readBody(t, resp)
+		if resp.StatusCode != http.StatusUnauthorized {
+			t.Fatalf("status = %d, want 401; body: %s", resp.StatusCode, string(body))
+		}
+		assertErrorCode(t, body, "auth_failed")
+	})
+
+	t.Run("vehicle owned by another user returns 403 vehicle_not_owned", func(t *testing.T) {
+		srv, seeder := setupTestServer(t)
+		seeder.seedUser(ctx, t, ownerID)
+		seeder.seedUser(ctx, t, otherID)
+		seeder.seedVehicle(ctx, t, vehicleSeed{
+			ID:     vehicleID,
+			UserID: otherID, // owned by someone else
+			VIN:    vehicleVIN,
+			Model:  "Model 3", Year: 2024, Color: "Black",
+			Status: "parked",
+		})
+
+		resp := doGET(t, srv, "/api/vehicles/"+vehicleID+"/drives", mintToken(t, ownerID, nil))
+		body := readBody(t, resp)
+		if resp.StatusCode != http.StatusForbidden {
+			t.Fatalf("status = %d, want 403; body: %s", resp.StatusCode, string(body))
+		}
+		assertErrorCode(t, body, "vehicle_not_owned")
+	})
+
+	t.Run("unknown vehicleId returns 404 not_found (MYR-132 regression)", func(t *testing.T) {
+		// The point of this case: if a future refactor un-mounts
+		// the route, http.ServeMux 404s with `404 page not found`
+		// (text/plain) instead of our typed JSON envelope. The
+		// assertErrorCode below decodes JSON and asserts on
+		// error.code; both halves fail if the route is missing.
+		srv, seeder := setupTestServer(t)
+		seeder.seedUser(ctx, t, ownerID)
+
+		resp := doGET(t, srv, "/api/vehicles/veh_does_not_exist/drives", mintToken(t, ownerID, nil))
+		body := readBody(t, resp)
+		if resp.StatusCode != http.StatusNotFound {
+			t.Fatalf("status = %d, want 404; body: %s", resp.StatusCode, string(body))
+		}
+		assertErrorCode(t, body, "not_found")
+	})
+}
+
+// drivesEnvelope is the local decode shape for the drives-page
+// response. Items stay as map[string]any so individual assertions can
+// inspect arbitrary fields without bringing in a full DriveSummary
+// struct (which would couple this file to internal/telemetry types).
+type drivesEnvelope struct {
+	Items      []map[string]any `json:"items"`
+	NextCursor *string          `json:"nextCursor"`
+	HasMore    bool             `json:"hasMore"`
+}
+
+// assertStartTimesDescending walks the page and fails if any item's
+// startTime is greater than the previous item's. The ISO 8601 strings
+// sort lexicographically the same way they sort chronologically, so a
+// string compare is sufficient.
+func assertStartTimesDescending(t *testing.T, items []map[string]any) {
+	t.Helper()
+	prev := ""
+	for i, item := range items {
+		st, _ := item["startTime"].(string)
+		if i > 0 && st > prev {
+			t.Errorf("items[%d].startTime (%s) > items[%d].startTime (%s); want DESC order",
+				i, st, i-1, prev)
+			return
+		}
+		prev = st
+	}
+}

--- a/tests/contract/vehicle_snapshot_test.go
+++ b/tests/contract/vehicle_snapshot_test.go
@@ -1,0 +1,214 @@
+//go:build contract
+
+// Contract tests for GET /api/vehicles/{vehicleId}/snapshot
+// (rest-api.md §7.1).
+//
+// Scope (MYR-141 Phase 1):
+//   - 200 owner happy path: body validates against the canonical
+//     `vehicle-state.schema.json`.
+//   - 200 owner happy path: body carries every MYR-24 promoted field
+//     (`model`, `year`, `color`, `fsdMilesSinceReset`, `locationName`,
+//     `locationAddress`). These were the spec-only fields the snapshot
+//     read path started writing in MYR-24 (2026-04-23); if a future
+//     refactor stops loading them, this test fails loudly.
+//   - 404 not_found for an unknown vehicleId.
+//   - 403 vehicle_not_owned for a vehicle owned by someone else.
+//   - 401 on missing Authorization header.
+package contract_test
+
+import (
+	"context"
+	"net/http"
+	"testing"
+)
+
+func TestContract_GETVehicleSnapshot(t *testing.T) {
+	ctx := context.Background()
+
+	const (
+		ownerID         = "user_owner_snap"
+		otherOwnerID    = "user_other_snap"
+		vehicleID       = "veh_snap_001"
+		otherVehicleID  = "veh_snap_other_001"
+		ownerVIN        = "5YJ3E1EA1PF000201"
+		otherVIN        = "5YJ3E1EA1PF000299"
+		unknownVehicle  = "veh_does_not_exist"
+		locName         = "Home"
+		locAddr         = "123 Market St, San Francisco, CA"
+		modelStr        = "Model 3"
+		colorStr        = "Midnight Silver Metallic"
+		modelYear       = 2024
+		fsdMilesSince   = 412.7
+		chargeLvl       = 78
+		rangeMiles      = 245
+	)
+
+	tests := []struct {
+		name       string
+		path       string
+		seed       func(t *testing.T, h *seedHelpers)
+		token      func(t *testing.T) string
+		wantStatus int
+		wantCode   string
+		assertBody func(t *testing.T, body []byte)
+	}{
+		{
+			name: "owner happy path validates VehicleState schema and carries MYR-24 fields",
+			path: "/api/vehicles/" + vehicleID + "/snapshot",
+			seed: func(t *testing.T, h *seedHelpers) {
+				h.seedUser(ctx, t, ownerID)
+				h.seedVehicle(ctx, t, vehicleSeed{
+					ID:              vehicleID,
+					UserID:          ownerID,
+					VIN:             ownerVIN,
+					Name:            "Stumpy",
+					Model:           modelStr,
+					Year:            modelYear,
+					Color:           colorStr,
+					Status:          "parked",
+					ChargeLevel:     chargeLvl,
+					EstimatedRange:  rangeMiles,
+					LocationName:    locName,
+					LocationAddress: locAddr,
+					FsdMilesReset:   fsdMilesSince,
+				})
+			},
+			token:      func(t *testing.T) string { return mintToken(t, ownerID, nil) },
+			wantStatus: http.StatusOK,
+			assertBody: func(t *testing.T, body []byte) {
+				// Canonical-shape gate: catches any future change to the
+				// snapshot wire format that drifts from the SDK schema.
+				validateAgainstSchema(t,
+					"docs/contracts/schemas/vehicle-state.schema.json", body)
+
+				var resp map[string]any
+				decodeJSON(t, body, &resp)
+
+				// MYR-24 promoted fields — every one of these MUST be
+				// present and non-empty after MYR-24 closed.
+				promoted := []string{
+					"model", "year", "color", "fsdMilesSinceReset",
+					"locationName", "locationAddress",
+				}
+				for _, k := range promoted {
+					if _, ok := resp[k]; !ok {
+						t.Errorf("MYR-24 promoted field %q missing from snapshot", k)
+					}
+				}
+
+				// Spot-check that values round-trip end-to-end (DB
+				// SELECT -> scan -> handler -> JSON encode) rather
+				// than just being present-but-zero.
+				if got, _ := resp["model"].(string); got != modelStr {
+					t.Errorf("model = %q, want %q", got, modelStr)
+				}
+				if got, _ := resp["color"].(string); got != colorStr {
+					t.Errorf("color = %q, want %q", got, colorStr)
+				}
+				if got, _ := resp["locationName"].(string); got != locName {
+					t.Errorf("locationName = %q, want %q", got, locName)
+				}
+				if got, _ := resp["locationAddress"].(string); got != locAddr {
+					t.Errorf("locationAddress = %q, want %q", got, locAddr)
+				}
+				// year and fsdMilesSinceReset come back as float64
+				// after json.Unmarshal — both are JSON numbers per the
+				// schema.
+				if got, _ := resp["year"].(float64); int(got) != modelYear {
+					t.Errorf("year = %v, want %d", got, modelYear)
+				}
+				if got, _ := resp["fsdMilesSinceReset"].(float64); got != fsdMilesSince {
+					t.Errorf("fsdMilesSinceReset = %v, want %v", got, fsdMilesSince)
+				}
+
+				// vehicleId in the body MUST match the path param —
+				// catches the MYR-139 class of identity drift.
+				if got, _ := resp["vehicleId"].(string); got != vehicleID {
+					t.Errorf("vehicleId = %q, want %q", got, vehicleID)
+				}
+			},
+		},
+		{
+			name: "unknown vehicleId returns 404 not_found",
+			path: "/api/vehicles/" + unknownVehicle + "/snapshot",
+			seed: func(t *testing.T, h *seedHelpers) {
+				h.seedUser(ctx, t, ownerID)
+			},
+			token:      func(t *testing.T) string { return mintToken(t, ownerID, nil) },
+			wantStatus: http.StatusNotFound,
+			wantCode:   "not_found",
+		},
+		{
+			name: "vehicle owned by another user returns 403 vehicle_not_owned",
+			path: "/api/vehicles/" + otherVehicleID + "/snapshot",
+			seed: func(t *testing.T, h *seedHelpers) {
+				h.seedUser(ctx, t, ownerID)
+				h.seedUser(ctx, t, otherOwnerID)
+				h.seedVehicle(ctx, t, vehicleSeed{
+					ID:             otherVehicleID,
+					UserID:         otherOwnerID,
+					VIN:            otherVIN,
+					Name:           "Not Mine",
+					Model:          "Model Y",
+					Year:           2023,
+					Color:          "Pearl White Multi-Coat",
+					Status:         "parked",
+					ChargeLevel:    50,
+					EstimatedRange: 200,
+				})
+			},
+			token:      func(t *testing.T) string { return mintToken(t, ownerID, nil) },
+			wantStatus: http.StatusForbidden,
+			wantCode:   "vehicle_not_owned",
+		},
+		{
+			name: "missing Authorization header returns 401",
+			path: "/api/vehicles/" + vehicleID + "/snapshot",
+			seed: func(t *testing.T, h *seedHelpers) {
+				h.seedUser(ctx, t, ownerID)
+				h.seedVehicle(ctx, t, vehicleSeed{
+					ID:             vehicleID,
+					UserID:         ownerID,
+					VIN:            ownerVIN,
+					Name:           "Stumpy",
+					Model:          modelStr,
+					Year:           modelYear,
+					Color:          colorStr,
+					Status:         "parked",
+					ChargeLevel:    chargeLvl,
+					EstimatedRange: rangeMiles,
+				})
+			},
+			token:      func(t *testing.T) string { return "" },
+			wantStatus: http.StatusUnauthorized,
+			wantCode:   "auth_failed",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			srv, seeder := setupTestServer(t)
+			if tc.seed != nil {
+				tc.seed(t, seeder)
+			}
+
+			tok := ""
+			if tc.token != nil {
+				tok = tc.token(t)
+			}
+
+			resp := doGET(t, srv, tc.path, tok)
+			body := readBody(t, resp)
+
+			if resp.StatusCode != tc.wantStatus {
+				t.Errorf("status = %d, want %d; body: %s", resp.StatusCode, tc.wantStatus, string(body))
+			}
+			if tc.wantCode != "" {
+				assertErrorCode(t, body, tc.wantCode)
+			}
+			if tc.assertBody != nil && resp.StatusCode == tc.wantStatus {
+				tc.assertBody(t, body)
+			}
+		})
+	}
+}

--- a/tests/contract/vehicles_list_test.go
+++ b/tests/contract/vehicles_list_test.go
@@ -1,0 +1,201 @@
+//go:build contract
+
+// Contract tests for GET /api/vehicles (rest-api.md §7.0).
+//
+// Scope (MYR-141 Phase 1):
+//   - Empty list shape: authenticated user with zero vehicles -> 200 {items: []}.
+//   - Single-vehicle owner: items[0] carries every VehicleSummary field
+//     declared in §7.0 / vehicle-summary.schema.json.
+//   - 401 on missing Authorization header.
+//   - 401 on malformed bearer token (wrong shape).
+//   - 401 on expired bearer token.
+//
+// Anchors MYR-132's class of failure (missing route returns 404) and
+// MYR-139's class (shape drift between the wire and the schema): if
+// the route stops being mounted or a required field disappears, this
+// suite fails on every PR.
+package contract_test
+
+import (
+	"context"
+	"net/http"
+	"testing"
+)
+
+func TestContract_GETVehicles(t *testing.T) {
+	ctx := context.Background()
+
+	const (
+		ownerID    = "user_owner_list"
+		vehicleID  = "veh_list_owner_001"
+		vehicleVIN = "5YJ3E1EA1PF000101"
+	)
+
+	tests := []struct {
+		name       string
+		seed       func(t *testing.T, h *seedHelpers)
+		token      func(t *testing.T) string
+		authHeader string // if non-empty, overrides whatever token() returns
+		wantStatus int
+		wantCode   string // rest-api.md error.code, empty for 200
+		assertBody func(t *testing.T, body []byte)
+	}{
+		{
+			name: "empty list returns 200 with items: []",
+			seed: func(t *testing.T, h *seedHelpers) {
+				h.seedUser(ctx, t, ownerID)
+			},
+			token:      func(t *testing.T) string { return mintToken(t, ownerID, nil) },
+			wantStatus: http.StatusOK,
+			assertBody: func(t *testing.T, body []byte) {
+				var resp struct {
+					Items []map[string]any `json:"items"`
+				}
+				decodeJSON(t, body, &resp)
+				if resp.Items == nil {
+					t.Errorf("items must be a JSON array (not null) even when empty; body: %s", string(body))
+				}
+				if len(resp.Items) != 0 {
+					t.Errorf("expected 0 items, got %d", len(resp.Items))
+				}
+			},
+		},
+		{
+			name: "owner sees own vehicle with all VehicleSummary fields",
+			seed: func(t *testing.T, h *seedHelpers) {
+				h.seedUser(ctx, t, ownerID)
+				h.seedVehicle(ctx, t, vehicleSeed{
+					ID:             vehicleID,
+					UserID:         ownerID,
+					VIN:            vehicleVIN,
+					Name:           "Stumpy",
+					Model:          "Model 3",
+					Year:           2024,
+					Color:          "Midnight Silver Metallic",
+					Status:         "parked",
+					ChargeLevel:    78,
+					EstimatedRange: 245,
+				})
+			},
+			token:      func(t *testing.T) string { return mintToken(t, ownerID, nil) },
+			wantStatus: http.StatusOK,
+			assertBody: func(t *testing.T, body []byte) {
+				var resp struct {
+					Items []map[string]any `json:"items"`
+				}
+				decodeJSON(t, body, &resp)
+				if len(resp.Items) != 1 {
+					t.Fatalf("expected 1 item, got %d; body: %s", len(resp.Items), string(body))
+				}
+				row := resp.Items[0]
+
+				// rest-api.md §7.0 declares ten required + one P1
+				// `name` field for owners. Assert presence for every
+				// required field — a missing key is the MYR-139 class
+				// of bug this suite exists to catch.
+				required := []string{
+					"vehicleId", "model", "year", "color", "vinLast4",
+					"status", "chargeLevel", "estimatedRange",
+					"lastUpdated", "role",
+				}
+				for _, k := range required {
+					if _, ok := row[k]; !ok {
+						t.Errorf("missing required field %q in items[0]; row keys: %v", k, keysOf(row))
+					}
+				}
+				// owner sees `name` per §5.2.0
+				if _, ok := row["name"]; !ok {
+					t.Errorf("owner-tier row missing P1 field `name`; row keys: %v", keysOf(row))
+				}
+				// VIN is redacted per data-classification.md §1.5: only
+				// the last 4 chars surface on the wire. The full VIN
+				// MUST NOT appear in the payload.
+				if got, _ := row["vinLast4"].(string); got != "0101" {
+					t.Errorf("vinLast4 = %q, want %q", got, "0101")
+				}
+				if got, _ := row["role"].(string); got != "owner" {
+					t.Errorf("role = %q, want %q", got, "owner")
+				}
+
+				// Cross-check against the canonical schema so any
+				// future field rename / type change surfaces here.
+				validateAgainstSchema(t, "docs/contracts/schemas/vehicle-summary.schema.json", marshalRow(t, row))
+			},
+		},
+		{
+			name: "missing Authorization header returns 401",
+			seed: func(t *testing.T, h *seedHelpers) {
+				h.seedUser(ctx, t, ownerID)
+			},
+			token:      func(t *testing.T) string { return "" },
+			wantStatus: http.StatusUnauthorized,
+			wantCode:   "auth_failed",
+		},
+		{
+			name: "malformed bearer token returns 401",
+			seed: func(t *testing.T, h *seedHelpers) {
+				h.seedUser(ctx, t, ownerID)
+			},
+			token:      func(t *testing.T) string { return "not.a.real.jwt" },
+			wantStatus: http.StatusUnauthorized,
+			wantCode:   "auth_failed",
+		},
+		{
+			name: "expired bearer token returns 401",
+			seed: func(t *testing.T, h *seedHelpers) {
+				h.seedUser(ctx, t, ownerID)
+			},
+			token:      func(t *testing.T) string { return mintExpiredToken(t, ownerID) },
+			wantStatus: http.StatusUnauthorized,
+			wantCode:   "auth_failed",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			srv, seeder := setupTestServer(t)
+			if tc.seed != nil {
+				tc.seed(t, seeder)
+			}
+
+			tok := ""
+			if tc.token != nil {
+				tok = tc.token(t)
+			}
+
+			resp := doGET(t, srv, "/api/vehicles", tok)
+			body := readBody(t, resp)
+
+			if resp.StatusCode != tc.wantStatus {
+				t.Errorf("status = %d, want %d; body: %s", resp.StatusCode, tc.wantStatus, string(body))
+			}
+			if tc.wantCode != "" {
+				assertErrorCode(t, body, tc.wantCode)
+			}
+			if tc.assertBody != nil && resp.StatusCode == tc.wantStatus {
+				tc.assertBody(t, body)
+			}
+		})
+	}
+}
+
+// keysOf returns the sorted-irrelevant keys of m for error messages.
+func keysOf(m map[string]any) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	return out
+}
+
+// marshalRow re-encodes a single VehicleSummary row so it can be passed
+// to the schema validator. The list-level decode (above) parsed the
+// whole envelope; the schema validator wants the row body on its own.
+func marshalRow(t *testing.T, row map[string]any) []byte {
+	t.Helper()
+	out, err := jsonMarshal(row)
+	if err != nil {
+		t.Fatalf("re-marshal row: %v", err)
+	}
+	return out
+}


### PR DESCRIPTION
First implementation of [MYR-141](https://linear.app/myrobotaxi/issue/MYR-141) (Quality 1 — contract conformance on every PR). Bootstraps the harness + tests for the 3 most critical REST endpoints, with a new \`Contract conformance\` CI job gating Build.

## Why

MYR-132 found \`/api/vehicles/{id}/drives\` 404'd because no test pinned its existence. MYR-139 found data-shape mismatches between paths reading the same data. A fixture-driven contract test on every PR catches both classes.

## What

### Harness (\`tests/contract/contract_test.go\`)

- Build tag \`//go:build contract\` — opt-in via \`go test -tags=contract\`
- Single testcontainers Postgres in \`TestMain\` (skip if Docker absent — same pattern as \`internal/store/db_test.go\`)
- Real handlers wired against real repos + JWTAuthenticator (in-test private adapters mirror \`cmd/telemetry-server/adapters.go\`)
- Seed helpers + minted JWT + JSON-schema validator (santhosh-tekuri/jsonschema/v6 — already vendored)
- Per-test \`cleanTables\` for ownership isolation

### Tests

| File | Endpoint | Cases |
|---|---|---|
| \`vehicles_list_test.go\` | \`GET /api/vehicles\` | 5 (empty, owner happy path + schema validation, missing/malformed/expired token) |
| \`vehicle_snapshot_test.go\` | \`GET /api/vehicles/{id}/snapshot\` | 4 (owner happy path + \`vehicle-state.schema.json\` validation + MYR-24 promoted-field roundtrip, 404, 403, 401) |
| \`vehicle_drives_test.go\` | \`GET /api/vehicles/{id}/drives\` | 5 (empty, 25→20+5 pagination + cursor roundtrip + DESC ordering, 401, 403, 404 — the MYR-132 regression case) |

### Schemas

- New \`docs/contracts/schemas/vehicle-summary.schema.json\` for the \`GET /api/vehicles\` row shape (§7.0)
- Reuses existing \`vehicle-state.schema.json\`

### CI

- New \`Contract conformance\` job in \`.github/workflows/ci.yml\`
- Added to Build's \`needs:\` so the deploy gate honors it

## Test plan

- [x] \`go vet ./...\` and \`go vet -tags=contract ./...\` clean
- [x] \`go test ./internal/... ./cmd/...\` passes
- [x] \`go test -tags=contract ./tests/contract/...\` skips cleanly without Docker
- [x] \`golangci-lint run ./...\` and \`--build-tags=contract\` → 0 issues
- [ ] CI green (Docker available on GH runners, so the contract job actually runs)

## Phase 1 vs follow-ups

This PR only covers 3 endpoints (the most critical). Remaining endpoints (\`/drives/{id}\`, \`/drives/{id}/route\`, invites, \`/users/me\` family) come in later phases, plus typescript-sdk + sdk-testbench Playwright (MYR-141 children).

🤖 Generated with [Claude Code](https://claude.com/claude-code)