### PR TITLE
MYR-146 Reconcile orphaned drives on Detector.Start

### DIFF
--- a/cmd/telemetry-server/adapters.go
+++ b/cmd/telemetry-server/adapters.go
@@ -11,6 +11,7 @@ import (
 	"net/url"
 	"time"
 
+	"github.com/myrobotaxi/telemetry/internal/drives"
 	"github.com/myrobotaxi/telemetry/internal/store"
 	"github.com/myrobotaxi/telemetry/internal/telemetry"
 )
@@ -362,6 +363,33 @@ func proxyHTTPClient(proxyURL string, logger *slog.Logger) *http.Client {
 	}
 }
 
+
+// openDriveListerAdapter adapts store.DriveRepo.ListOpen to the
+// drives.OpenDriveLister interface used by Detector.Start for orphan
+// reconciliation (MYR-146). The drives package defines its own
+// OpenDriveRow type so it stays decoupled from internal/store; this
+// adapter performs the row-shape translation at the boundary.
+type openDriveListerAdapter struct {
+	repo *store.DriveRepo
+}
+
+func (a *openDriveListerAdapter) ListOpen(ctx context.Context) ([]drives.OpenDriveRow, error) {
+	rows, err := a.repo.ListOpen(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("list open drives: %w", err)
+	}
+	out := make([]drives.OpenDriveRow, 0, len(rows))
+	for i := range rows {
+		r := &rows[i]
+		out = append(out, drives.OpenDriveRow{
+			ID:               r.ID,
+			VIN:              r.VIN,
+			StartTime:        r.StartTime,
+			StartChargeLevel: r.StartChargeLevel,
+		})
+	}
+	return out, nil
+}
 
 // vehicleAuthorizerAdapter adapts store.VINCache to the
 // telemetry.VehicleAuthorizer interface (data-lifecycle.md §3.5,

--- a/cmd/telemetry-server/main.go
+++ b/cmd/telemetry-server/main.go
@@ -191,14 +191,7 @@ func run() error { //nolint:funlen // composition root — sequential dependency
 		},
 	)
 
-	// --- Drive detector ---
-	detector := drives.NewDetector(bus, cfg.Drives(), logger.With(slog.String("component", "drives")), drives.NoopDetectorMetrics{})
-	if err := detector.Start(ctx); err != nil {
-		return fmt.Errorf("starting drive detector: %w", err)
-	}
-	defer func() { _ = detector.Stop() }()
-
-	// --- Store repos ---
+	// --- Store repos (needed by the Detector reconciler) ---
 	// MYR-63 wires the Encryptor into VehicleRepo so the six GPS
 	// columns are dual-written (plaintext + *Enc) and read with
 	// ciphertext preference. Half-pair *Enc rows fall back to
@@ -207,6 +200,23 @@ func run() error { //nolint:funlen // composition root — sequential dependency
 	vehicleRepo := store.NewVehicleRepoWithEncryption(db.Pool(), storeMetrics, encryptor, logger.With(slog.String("component", "vehicle-repo")))
 	driveRepo := store.NewDriveRepoWithEncryption(db.Pool(), storeMetrics, encryptor, logger.With(slog.String("component", "drive-repo")))
 	accountRepo := store.NewAccountRepo(db.Pool(), encryptor)
+
+	// --- Drive detector ---
+	// MYR-146: reconciler reads open Drive rows on Start so a Fly
+	// redeploy mid-drive doesn't leave forever-active rows. The
+	// adapter lives in adapters.go and translates store.OpenDriveRow
+	// into the drives package's local type.
+	detector := drives.NewDetector(
+		bus,
+		cfg.Drives(),
+		logger.With(slog.String("component", "drives")),
+		drives.NoopDetectorMetrics{},
+		&openDriveListerAdapter{repo: driveRepo},
+	)
+	if err := detector.Start(ctx); err != nil {
+		return fmt.Errorf("starting drive detector: %w", err)
+	}
+	defer func() { _ = detector.Stop() }()
 
 	// MYR-62 + MYR-63 plaintext-zero gauges. Both register against the
 	// same Prometheus registry the /metrics handler scrapes; each

--- a/internal/drives/debounce.go
+++ b/internal/drives/debounce.go
@@ -134,7 +134,16 @@ func (d *Detector) endDrive(state *vehicleState, vin string) {
 	stats := calculateStats(drive)
 
 	// Micro-drive filtering: discard short or short-distance drives.
-	if stats.Duration < d.cfg.MinDuration || stats.Distance < d.cfg.MinDistanceMiles {
+	// Reconciled drives that never saw resumed telemetry bypass this
+	// gate -- their stats are Duration=0, Distance=0, which the
+	// prod-default filter (MinDuration=2m, MinDistanceMiles=0.1) would
+	// otherwise discard, leaving the open DB row to be reconciled
+	// again forever (MYR-146 critical bug). Closing those rows is the
+	// whole point of reconciliation, so we publish DriveEndedEvent
+	// unconditionally for them and let the writer UPDATE the existing
+	// row with endTime=NOW().
+	if !drive.reconciled &&
+		(stats.Duration < d.cfg.MinDuration || stats.Distance < d.cfg.MinDistanceMiles) {
 		d.logger.Info("discarding micro-drive",
 			slog.String("vin", redactVIN(vin)),
 			slog.String("drive_id", drive.id),

--- a/internal/drives/detector.go
+++ b/internal/drives/detector.go
@@ -120,6 +120,14 @@ func (d *Detector) watchdogInterval() time.Duration {
 func (d *Detector) Start(ctx context.Context) error {
 	d.ctx, d.cancel = context.WithCancel(ctx)
 
+	// MYR-146: reconcile orphaned Drive rows BEFORE bus subscription.
+	// ChannelBus.Subscribe spawns its deliverLoop goroutine before
+	// returning, so subscribing first would race the d.states.Store
+	// writes inside reconcileOpenDrives against any in-process
+	// publisher (today nothing publishes that early, but the order
+	// makes the invariant load-bearing). Fails open on DB hiccup.
+	d.reconcileOpenDrives(d.ctx)
+
 	telSub, err := d.bus.Subscribe(events.TopicVehicleTelemetry, d.handleEvent)
 	if err != nil {
 		d.cancel()
@@ -135,19 +143,12 @@ func (d *Detector) Start(ctx context.Context) error {
 
 	d.subs = []events.Subscription{telSub, connSub}
 
-	// MYR-146: reconcile Drive rows orphaned by a previous restart.
-	// MUST run after subscribing (so any inbound telemetry that arrives
-	// concurrently is queued by the bus, not dropped) and BEFORE the
-	// watchdog starts (so the first watchdog tick observes the
-	// reconciled state and either confirms ongoing telemetry or ends
-	// the row within EndDebounce). Fails open — a DB hiccup here
-	// MUST NOT block Detector.Start.
-	d.reconcileOpenDrives(d.ctx)
-
 	// Start the end-condition watchdog. Tesla stops streaming when the
 	// vehicle parks, so a gear=P frame is not guaranteed -- without this
 	// watchdog the time.AfterFunc-based debounce path is never primed and
-	// the drive stays open forever (the MYR-139 R3a regression).
+	// the drive stays open forever (the MYR-139 R3a regression). Runs
+	// AFTER reconciliation so the first tick observes the reconciled
+	// state.
 	d.watchdogWG.Add(1)
 	go d.runWatchdog()
 
@@ -296,32 +297,3 @@ func (d *Detector) handleTelemetry(te events.VehicleTelemetryEvent) {
 	}
 }
 
-// extractStringField returns the string value for a telemetry field,
-// or empty string if absent or not a string.
-func extractStringField(fields map[string]events.TelemetryValue, name telemetry.FieldName) string {
-	v, ok := fields[string(name)]
-	if !ok || v.StringVal == nil {
-		return ""
-	}
-	return *v.StringVal
-}
-
-// extractFloatField returns the float64 value for a telemetry field,
-// or 0 if absent or not a float.
-func extractFloatField(fields map[string]events.TelemetryValue, name telemetry.FieldName) (float64, bool) {
-	v, ok := fields[string(name)]
-	if !ok || v.FloatVal == nil {
-		return 0, false
-	}
-	return *v.FloatVal, true
-}
-
-// extractLocation returns the Location from the telemetry fields, or nil
-// if absent.
-func extractLocation(fields map[string]events.TelemetryValue) *events.Location {
-	v, ok := fields[string(telemetry.FieldLocation)]
-	if !ok || v.LocationVal == nil {
-		return nil
-	}
-	return v.LocationVal
-}

--- a/internal/drives/detector.go
+++ b/internal/drives/detector.go
@@ -34,6 +34,13 @@ type Detector struct {
 	logger  *slog.Logger
 	metrics DetectorMetrics
 
+	// reconciler is the read-side hook used on Start to reattach
+	// in-memory state for Drive rows orphaned by a previous restart
+	// (MYR-146). nil disables reconciliation — tests use this; the
+	// production constructor in cmd/telemetry-server wires a
+	// DriveRepo-backed adapter.
+	reconciler OpenDriveLister
+
 	// states holds per-vehicle drive state. Keyed by VIN.
 	// Using sync.Map because vehicles connect/disconnect dynamically and
 	// reads vastly outnumber writes (every telemetry tick is a read;
@@ -64,18 +71,28 @@ type Detector struct {
 // NewDetector creates a Detector. The bus is used both for subscribing to
 // telemetry events and publishing drive lifecycle events. Call Start to
 // begin processing.
+//
+// reconciler is the read-side hook used on Start to reattach in-memory
+// state for Drive rows orphaned by a previous restart (MYR-146). Pass
+// nil to disable reconciliation (tests use this; production wires a
+// DriveRepo-backed adapter). It is a required constructor argument
+// rather than an optional functional setter so the dependency fails
+// loud at compile time — silently shipping a nil reconciler in prod
+// is exactly the regression Option B is meant to prevent.
 func NewDetector(
 	bus events.Bus,
 	cfg config.DrivesConfig,
 	logger *slog.Logger,
 	metrics DetectorMetrics,
+	reconciler OpenDriveLister,
 ) *Detector {
 	return &Detector{
-		bus:     bus,
-		cfg:     cfg,
-		logger:  logger,
-		metrics: metrics,
-		now:     time.Now,
+		bus:        bus,
+		cfg:        cfg,
+		logger:     logger,
+		metrics:    metrics,
+		reconciler: reconciler,
+		now:        time.Now,
 	}
 }
 
@@ -117,6 +134,15 @@ func (d *Detector) Start(ctx context.Context) error {
 	}
 
 	d.subs = []events.Subscription{telSub, connSub}
+
+	// MYR-146: reconcile Drive rows orphaned by a previous restart.
+	// MUST run after subscribing (so any inbound telemetry that arrives
+	// concurrently is queued by the bus, not dropped) and BEFORE the
+	// watchdog starts (so the first watchdog tick observes the
+	// reconciled state and either confirms ongoing telemetry or ends
+	// the row within EndDebounce). Fails open — a DB hiccup here
+	// MUST NOT block Detector.Start.
+	d.reconcileOpenDrives(d.ctx)
 
 	// Start the end-condition watchdog. Tesla stops streaming when the
 	// vehicle parks, so a gear=P frame is not guaranteed -- without this

--- a/internal/drives/detector_test.go
+++ b/internal/drives/detector_test.go
@@ -180,7 +180,7 @@ func TestDetector_IdleToDriving(t *testing.T) {
 			bus := testBus()
 			defer bus.Close(context.Background())
 
-			d := NewDetector(bus, testConfig(), testLogger(), NoopDetectorMetrics{})
+			d := NewDetector(bus, testConfig(), testLogger(), NoopDetectorMetrics{}, nil)
 			if err := d.Start(context.Background()); err != nil {
 				t.Fatalf("Start: %v", err)
 			}
@@ -221,7 +221,7 @@ func TestDetector_DrivingToIdle_AfterDebounce(t *testing.T) {
 	cfg.MinDuration = 0
 	cfg.MinDistanceMiles = 0
 
-	d := NewDetector(bus, cfg, testLogger(), NoopDetectorMetrics{})
+	d := NewDetector(bus, cfg, testLogger(), NoopDetectorMetrics{}, nil)
 	if err := d.Start(context.Background()); err != nil {
 		t.Fatalf("Start: %v", err)
 	}
@@ -267,7 +267,7 @@ func TestDetector_DebounceCancellation(t *testing.T) {
 	cfg := testConfig()
 	cfg.EndDebounce = 200 * time.Millisecond
 
-	d := NewDetector(bus, cfg, testLogger(), NoopDetectorMetrics{})
+	d := NewDetector(bus, cfg, testLogger(), NoopDetectorMetrics{}, nil)
 	if err := d.Start(context.Background()); err != nil {
 		t.Fatalf("Start: %v", err)
 	}
@@ -331,7 +331,7 @@ func TestDetector_MicroDriveFiltering(t *testing.T) {
 			cfg.MinDuration = tt.minDuration
 			cfg.MinDistanceMiles = tt.minDistanceMiles
 
-			d := NewDetector(bus, cfg, testLogger(), NoopDetectorMetrics{})
+			d := NewDetector(bus, cfg, testLogger(), NoopDetectorMetrics{}, nil)
 			if err := d.Start(context.Background()); err != nil {
 				t.Fatalf("Start: %v", err)
 			}
@@ -366,7 +366,7 @@ func TestDetector_MultipleVehicles(t *testing.T) {
 	cfg.MinDuration = 0
 	cfg.MinDistanceMiles = 0
 
-	d := NewDetector(bus, cfg, testLogger(), NoopDetectorMetrics{})
+	d := NewDetector(bus, cfg, testLogger(), NoopDetectorMetrics{}, nil)
 	if err := d.Start(context.Background()); err != nil {
 		t.Fatalf("Start: %v", err)
 	}
@@ -403,7 +403,7 @@ func TestDetector_NoGearField_NoTransition(t *testing.T) {
 	bus := testBus()
 	defer bus.Close(context.Background())
 
-	d := NewDetector(bus, testConfig(), testLogger(), NoopDetectorMetrics{})
+	d := NewDetector(bus, testConfig(), testLogger(), NoopDetectorMetrics{}, nil)
 	if err := d.Start(context.Background()); err != nil {
 		t.Fatalf("Start: %v", err)
 	}
@@ -427,7 +427,7 @@ func TestDetector_GearN_DoesNotStartDrive(t *testing.T) {
 	bus := testBus()
 	defer bus.Close(context.Background())
 
-	d := NewDetector(bus, testConfig(), testLogger(), NoopDetectorMetrics{})
+	d := NewDetector(bus, testConfig(), testLogger(), NoopDetectorMetrics{}, nil)
 	if err := d.Start(context.Background()); err != nil {
 		t.Fatalf("Start: %v", err)
 	}
@@ -447,7 +447,7 @@ func TestDetector_GearP_WhileIdle_NoEffect(t *testing.T) {
 	bus := testBus()
 	defer bus.Close(context.Background())
 
-	d := NewDetector(bus, testConfig(), testLogger(), NoopDetectorMetrics{})
+	d := NewDetector(bus, testConfig(), testLogger(), NoopDetectorMetrics{}, nil)
 	if err := d.Start(context.Background()); err != nil {
 		t.Fatalf("Start: %v", err)
 	}
@@ -469,7 +469,7 @@ func TestDetector_DriveUpdatedEvents(t *testing.T) {
 	bus := testBus()
 	defer bus.Close(context.Background())
 
-	d := NewDetector(bus, testConfig(), testLogger(), NoopDetectorMetrics{})
+	d := NewDetector(bus, testConfig(), testLogger(), NoopDetectorMetrics{}, nil)
 	if err := d.Start(context.Background()); err != nil {
 		t.Fatalf("Start: %v", err)
 	}
@@ -521,7 +521,7 @@ func TestDetector_StatsAccuracy(t *testing.T) {
 	cfg.MinDuration = 0
 	cfg.MinDistanceMiles = 0
 
-	d := NewDetector(bus, cfg, testLogger(), NoopDetectorMetrics{})
+	d := NewDetector(bus, cfg, testLogger(), NoopDetectorMetrics{}, nil)
 	if err := d.Start(context.Background()); err != nil {
 		t.Fatalf("Start: %v", err)
 	}
@@ -645,7 +645,7 @@ func TestDetector_DisconnectEndsDrive(t *testing.T) {
 	cfg.MinDuration = 0
 	cfg.MinDistanceMiles = 0
 
-	d := NewDetector(bus, cfg, testLogger(), NoopDetectorMetrics{})
+	d := NewDetector(bus, cfg, testLogger(), NoopDetectorMetrics{}, nil)
 	if err := d.Start(context.Background()); err != nil {
 		t.Fatalf("Start: %v", err)
 	}
@@ -703,7 +703,7 @@ func TestDetector_WatchdogEndsDriveWhenTelemetrySilent(t *testing.T) {
 	cfg.MinDuration = 0
 	cfg.MinDistanceMiles = 0
 
-	d := NewDetector(bus, cfg, testLogger(), NoopDetectorMetrics{})
+	d := NewDetector(bus, cfg, testLogger(), NoopDetectorMetrics{}, nil)
 
 	// Inject a clock we can fast-forward. The watchdog reads now() to
 	// decide whether telemetry has been silent for EndDebounce.
@@ -786,7 +786,7 @@ func TestDetector_WatchdogIgnoresActiveDrives(t *testing.T) {
 	cfg.MinDuration = 0
 	cfg.MinDistanceMiles = 0
 
-	d := NewDetector(bus, cfg, testLogger(), NoopDetectorMetrics{})
+	d := NewDetector(bus, cfg, testLogger(), NoopDetectorMetrics{}, nil)
 	if err := d.Start(context.Background()); err != nil {
 		t.Fatalf("Start: %v", err)
 	}
@@ -816,7 +816,7 @@ func TestDetector_DisconnectWhileIdle_NoEffect(t *testing.T) {
 	bus := testBus()
 	defer bus.Close(context.Background())
 
-	d := NewDetector(bus, testConfig(), testLogger(), NoopDetectorMetrics{})
+	d := NewDetector(bus, testConfig(), testLogger(), NoopDetectorMetrics{}, nil)
 	if err := d.Start(context.Background()); err != nil {
 		t.Fatalf("Start: %v", err)
 	}
@@ -839,7 +839,7 @@ func TestDetector_ConnectedEvent_NoEffect(t *testing.T) {
 	cfg.MinDuration = 0
 	cfg.MinDistanceMiles = 0
 
-	d := NewDetector(bus, cfg, testLogger(), NoopDetectorMetrics{})
+	d := NewDetector(bus, cfg, testLogger(), NoopDetectorMetrics{}, nil)
 	if err := d.Start(context.Background()); err != nil {
 		t.Fatalf("Start: %v", err)
 	}
@@ -872,7 +872,7 @@ func TestDetector_DisconnectUnknownVIN_NoEffect(t *testing.T) {
 	bus := testBus()
 	defer bus.Close(context.Background())
 
-	d := NewDetector(bus, testConfig(), testLogger(), NoopDetectorMetrics{})
+	d := NewDetector(bus, testConfig(), testLogger(), NoopDetectorMetrics{}, nil)
 	if err := d.Start(context.Background()); err != nil {
 		t.Fatalf("Start: %v", err)
 	}
@@ -890,7 +890,7 @@ func TestDetector_StartStop(t *testing.T) {
 	bus := testBus()
 	defer bus.Close(context.Background())
 
-	d := NewDetector(bus, testConfig(), testLogger(), NoopDetectorMetrics{})
+	d := NewDetector(bus, testConfig(), testLogger(), NoopDetectorMetrics{}, nil)
 	if err := d.Start(context.Background()); err != nil {
 		t.Fatalf("Start: %v", err)
 	}
@@ -903,7 +903,7 @@ func TestDetector_StartLocationFallback(t *testing.T) {
 	bus := testBus()
 	defer bus.Close(context.Background())
 
-	d := NewDetector(bus, testConfig(), testLogger(), NoopDetectorMetrics{})
+	d := NewDetector(bus, testConfig(), testLogger(), NoopDetectorMetrics{}, nil)
 	if err := d.Start(context.Background()); err != nil {
 		t.Fatalf("Start: %v", err)
 	}
@@ -937,7 +937,7 @@ func TestDetector_EmptyVIN_Ignored(t *testing.T) {
 	bus := testBus()
 	defer bus.Close(context.Background())
 
-	d := NewDetector(bus, testConfig(), testLogger(), NoopDetectorMetrics{})
+	d := NewDetector(bus, testConfig(), testLogger(), NoopDetectorMetrics{}, nil)
 	if err := d.Start(context.Background()); err != nil {
 		t.Fatalf("Start: %v", err)
 	}
@@ -960,7 +960,7 @@ func TestDetector_ConcurrentDriveEvents(t *testing.T) {
 	cfg.MinDuration = 0
 	cfg.MinDistanceMiles = 0
 
-	d := NewDetector(bus, cfg, testLogger(), NoopDetectorMetrics{})
+	d := NewDetector(bus, cfg, testLogger(), NoopDetectorMetrics{}, nil)
 	if err := d.Start(context.Background()); err != nil {
 		t.Fatalf("Start: %v", err)
 	}
@@ -1090,7 +1090,7 @@ func TestDetector_DriveStartUsesGPSNotNavOrigin(t *testing.T) {
 	bus := testBus()
 	defer bus.Close(context.Background())
 
-	d := NewDetector(bus, testConfig(), testLogger(), NoopDetectorMetrics{})
+	d := NewDetector(bus, testConfig(), testLogger(), NoopDetectorMetrics{}, nil)
 	if err := d.Start(context.Background()); err != nil {
 		t.Fatalf("Start: %v", err)
 	}
@@ -1129,7 +1129,7 @@ func TestDetector_OriginLocationOnlyDoesNotCacheLocation(t *testing.T) {
 	bus := testBus()
 	defer bus.Close(context.Background())
 
-	d := NewDetector(bus, testConfig(), testLogger(), NoopDetectorMetrics{})
+	d := NewDetector(bus, testConfig(), testLogger(), NoopDetectorMetrics{}, nil)
 	if err := d.Start(context.Background()); err != nil {
 		t.Fatalf("Start: %v", err)
 	}

--- a/internal/drives/fields.go
+++ b/internal/drives/fields.go
@@ -1,0 +1,42 @@
+package drives
+
+// Split out of detector.go to keep that file under the 300-line cap
+// (CLAUDE.md "File Rules"). These helpers translate the loosely-typed
+// telemetry payload (events.TelemetryValue, where every field is a
+// nullable string/float/location wrapper) into the typed values the
+// state machine reasons about. No state, no I/O — pure extractors.
+
+import (
+	"github.com/myrobotaxi/telemetry/internal/events"
+	"github.com/myrobotaxi/telemetry/internal/telemetry"
+)
+
+// extractStringField returns the string value for a telemetry field,
+// or empty string if absent or not a string.
+func extractStringField(fields map[string]events.TelemetryValue, name telemetry.FieldName) string {
+	v, ok := fields[string(name)]
+	if !ok || v.StringVal == nil {
+		return ""
+	}
+	return *v.StringVal
+}
+
+// extractFloatField returns the float64 value for a telemetry field,
+// or 0 if absent or not a float.
+func extractFloatField(fields map[string]events.TelemetryValue, name telemetry.FieldName) (float64, bool) {
+	v, ok := fields[string(name)]
+	if !ok || v.FloatVal == nil {
+		return 0, false
+	}
+	return *v.FloatVal, true
+}
+
+// extractLocation returns the Location from the telemetry fields, or nil
+// if absent.
+func extractLocation(fields map[string]events.TelemetryValue) *events.Location {
+	v, ok := fields[string(telemetry.FieldLocation)]
+	if !ok || v.LocationVal == nil {
+		return nil
+	}
+	return v.LocationVal
+}

--- a/internal/drives/reconcile.go
+++ b/internal/drives/reconcile.go
@@ -26,6 +26,7 @@ package drives
 
 import (
 	"context"
+	"fmt"
 	"log/slog"
 	"time"
 )
@@ -133,7 +134,7 @@ func parseDriveStartTime(s string) (time.Time, error) {
 	// Last-resort permissive parse.
 	t, err := time.Parse("2006-01-02T15:04:05", s)
 	if err != nil {
-		return time.Time{}, err
+		return time.Time{}, fmt.Errorf("parseDriveStartTime(%q): %w", s, err)
 	}
 	return t, nil
 }

--- a/internal/drives/reconcile.go
+++ b/internal/drives/reconcile.go
@@ -56,9 +56,10 @@ type OpenDriveLister interface {
 // and continue. Worst case the orphaned rows stay open until the next
 // successful restart cycle.
 //
-// Called from Start AFTER bus subscription succeeds but BEFORE the
-// watchdog goroutine starts, so the very first watchdog tick observes
-// the reconciled state.
+// Called from Start BEFORE bus subscription so no handler callback
+// goroutine can race the d.states.Store calls below, and BEFORE the
+// watchdog goroutine starts so the first watchdog tick observes the
+// reconciled state.
 func (d *Detector) reconcileOpenDrives(ctx context.Context) {
 	if d.reconciler == nil {
 		return
@@ -99,13 +100,24 @@ func (d *Detector) reconcileOpenDrives(ctx context.Context) {
 				startCharge:   float64(row.StartChargeLevel),
 				lastSOC:       float64(row.StartChargeLevel),
 				lastTimestamp: startedAt,
+				// reconciled tags the watchdog-end path to bypass the
+				// micro-drive filter (MYR-146 critical). With no
+				// resumed telemetry the stats are Duration=0,
+				// Distance=0 and the prod-default filter
+				// (MinDuration=2m, MinDistanceMiles=0.1) would discard
+				// the DriveEndedEvent -- leaving the DB row open and
+				// reconciled again on the next restart forever.
+				// Cleared in handleDriving once real telemetry
+				// resumes; from that point the drive is treated as a
+				// normal continuation and any subsequent end goes
+				// through the standard filter.
+				reconciled: true,
 			},
 		}
-		// Use Store (not LoadOrStore) — Start runs before any
-		// telemetry handlers, so the map is empty and overwriting any
-		// concurrent insert would be a bug, not a race we tolerate.
-		// In practice no other goroutine touches d.states until
-		// Subscribe callbacks fire, which happens after Start returns.
+		// Use Store (not LoadOrStore) — reconcileOpenDrives runs
+		// BEFORE Start calls Subscribe (see Start in detector.go), so
+		// no handler goroutine can touch d.states yet. Overwriting any
+		// pre-existing entry would be a bug, not a race we tolerate.
 		d.states.Store(row.VIN, state)
 		d.activeCount.Add(1)
 		reconciled++

--- a/internal/drives/reconcile.go
+++ b/internal/drives/reconcile.go
@@ -1,0 +1,151 @@
+// Orphan-drive reconciliation. Called from Detector.Start.
+//
+// MYR-146: a Fly redeploy mid-drive restarts the machine. The
+// Detector's in-memory vehicleState map is lost; Tesla resumes
+// streaming on a new connection; the state machine sees no prior
+// state and either starts a fresh drive (creating a second "active"
+// Drive row in the DB) or — if the vehicle has parked in the
+// meantime — never emits a DriveEndedEvent for the orphaned row.
+//
+// Reconciliation closes the gap: on Start, the Detector reads every
+// open Drive row from the DB and recreates a vehicleState entry keyed
+// by VIN with status=StatusDriving. From there two outcomes are
+// possible:
+//
+//   1. Telemetry resumes for the same VIN before EndDebounce elapses.
+//      The state machine treats the new frames as the continuation of
+//      the reconciled drive — same DriveID, same row updated, no
+//      duplicate. This is the survival path Option B promises.
+//
+//   2. Telemetry never resumes (the car parked while the deploy was
+//      in flight). The watchdog observes the silence and ends the
+//      drive within ~EndDebounce, publishing a DriveEndedEvent that
+//      the writer handles via the normal Complete path.
+
+package drives
+
+import (
+	"context"
+	"log/slog"
+	"time"
+)
+
+// OpenDriveRow mirrors the slim projection returned by the store
+// adapter wired in from cmd/. Defined at the consumer site so the
+// drives package stays independent of internal/store (the cmd-layer
+// adapter performs the row-shape translation).
+type OpenDriveRow struct {
+	ID               string
+	VIN              string
+	StartTime        string // ISO 8601; parsed best-effort below
+	StartChargeLevel int
+}
+
+// OpenDriveLister is the read-side dependency the Detector consults on
+// Start to discover Drive rows orphaned by a previous restart. A nil
+// implementation skips reconciliation entirely — used by unit tests
+// and by any future runtime that doesn't persist drives.
+type OpenDriveLister interface {
+	ListOpen(ctx context.Context) ([]OpenDriveRow, error)
+}
+
+// reconcileOpenDrives reads every open Drive row from the lister and
+// reattaches each to in-memory vehicleState. It is best-effort: a DB
+// hiccup on Start MUST NOT block telemetry processing — we log Warn
+// and continue. Worst case the orphaned rows stay open until the next
+// successful restart cycle.
+//
+// Called from Start AFTER bus subscription succeeds but BEFORE the
+// watchdog goroutine starts, so the very first watchdog tick observes
+// the reconciled state.
+func (d *Detector) reconcileOpenDrives(ctx context.Context) {
+	if d.reconciler == nil {
+		return
+	}
+
+	rows, err := d.reconciler.ListOpen(ctx)
+	if err != nil {
+		d.logger.Warn("orphan drive reconciliation failed; continuing without",
+			slog.String("error", err.Error()),
+		)
+		return
+	}
+
+	now := d.now()
+	reconciled := 0
+	for _, row := range rows {
+		if row.VIN == "" || row.ID == "" {
+			continue
+		}
+		startedAt, parseErr := parseDriveStartTime(row.StartTime)
+		if parseErr != nil {
+			// Fall back to "now" so the watchdog still has a sane
+			// reference and the row gets closed on next idle.
+			startedAt = now
+			d.logger.Warn("reconciled drive has unparseable startTime; using current time",
+				slog.String("drive_id", row.ID),
+				slog.String("start_time", row.StartTime),
+				slog.String("error", parseErr.Error()),
+			)
+		}
+
+		state := &vehicleState{
+			status:          StatusDriving,
+			lastTelemetryAt: now,
+			drive: &activeDrive{
+				id:            row.ID,
+				startedAt:     startedAt,
+				startCharge:   float64(row.StartChargeLevel),
+				lastSOC:       float64(row.StartChargeLevel),
+				lastTimestamp: startedAt,
+			},
+		}
+		// Use Store (not LoadOrStore) — Start runs before any
+		// telemetry handlers, so the map is empty and overwriting any
+		// concurrent insert would be a bug, not a race we tolerate.
+		// In practice no other goroutine touches d.states until
+		// Subscribe callbacks fire, which happens after Start returns.
+		d.states.Store(row.VIN, state)
+		d.activeCount.Add(1)
+		reconciled++
+	}
+
+	d.metrics.SetActiveVehicles(int(d.activeCount.Load()))
+
+	d.logger.Info("reconciled orphaned drives",
+		slog.Int("reconciled_count", reconciled),
+	)
+}
+
+// parseDriveStartTime parses the Prisma-stored startTime string. The
+// column is TEXT, written by mapDriveStarted with time.RFC3339, but we
+// accept the alternate "Z"-less form and the broader RFC3339Nano shape
+// so a manually-edited row is still recoverable.
+func parseDriveStartTime(s string) (time.Time, error) {
+	if s == "" {
+		return time.Time{}, errEmptyStartTime
+	}
+	for _, layout := range []string{time.RFC3339Nano, time.RFC3339} {
+		if t, err := time.Parse(layout, s); err == nil {
+			return t, nil
+		}
+	}
+	// Last-resort permissive parse.
+	t, err := time.Parse("2006-01-02T15:04:05", s)
+	if err != nil {
+		return time.Time{}, err
+	}
+	return t, nil
+}
+
+// errEmptyStartTime is the sentinel returned by parseDriveStartTime
+// for the empty-string input. The reconciler logs and falls back to
+// now() — no caller currently needs to branch on it.
+var errEmptyStartTime = &reconcileError{msg: "empty startTime"}
+
+// reconcileError is a small named error type so the reconciler's
+// fallback path produces a stable message without dragging in
+// fmt.Errorf at the cost of an alloc per row.
+type reconcileError struct{ msg string }
+
+func (e *reconcileError) Error() string { return e.msg }

--- a/internal/drives/reconcile_test.go
+++ b/internal/drives/reconcile_test.go
@@ -155,10 +155,18 @@ func TestDetector_ReconciledDrive_NoTelemetry_WatchdogEnds(t *testing.T) {
 		},
 	}
 
+	// Use prod-realistic micro-drive thresholds (MinDuration=2m,
+	// MinDistanceMiles=0.1 — the actual defaults from
+	// internal/config/defaults.go). A reconciled drive with no resumed
+	// telemetry has Duration=0, Distance=0; without the reconciled
+	// bypass in endDrive, the filter would discard the
+	// DriveEndedEvent and the DB row would stay open forever
+	// (MYR-146 critical regression). This test would have failed
+	// before the bypass was added.
 	cfg := testConfig()
 	cfg.EndDebounce = 200 * time.Millisecond
-	cfg.MinDuration = 0
-	cfg.MinDistanceMiles = 0
+	cfg.MinDuration = 2 * time.Minute
+	cfg.MinDistanceMiles = 0.1
 
 	d := NewDetector(bus, cfg, testLogger(), NoopDetectorMetrics{}, lister)
 
@@ -203,6 +211,72 @@ func TestDetector_ReconciledDrive_NoTelemetry_WatchdogEnds(t *testing.T) {
 	if ended.VIN != vin {
 		t.Errorf("VIN = %q, want %q", ended.VIN, vin)
 	}
+}
+
+// TestDetector_RegularMicroDrive_StillFiltered is the negative
+// counterpart to TestDetector_ReconciledDrive_NoTelemetry_WatchdogEnds.
+// It proves the micro-drive bypass in endDrive applies ONLY to
+// reconciled drives — a regular drive that starts from a single D
+// telemetry event and goes silent (no resumed telemetry, same
+// "Duration=0, Distance=0" shape as the reconciled case) MUST still be
+// discarded by the prod-default micro-drive filter. Otherwise the
+// bypass would leak and accept every short blip as a real drive.
+func TestDetector_RegularMicroDrive_StillFiltered(t *testing.T) {
+	bus := testBus()
+	defer bus.Close(context.Background())
+
+	const vin = "VIN_REGULAR_MICRO"
+
+	// Prod-realistic thresholds. No reconciler — this is a fresh,
+	// non-reconciled drive.
+	cfg := testConfig()
+	cfg.EndDebounce = 200 * time.Millisecond
+	cfg.MinDuration = 2 * time.Minute
+	cfg.MinDistanceMiles = 0.1
+
+	d := NewDetector(bus, cfg, testLogger(), NoopDetectorMetrics{}, nil)
+
+	// Injectable clock so we can advance past EndDebounce without
+	// sleeping for the watchdog tick.
+	var clockMu sync.Mutex
+	wallNow := time.Now()
+	d.setNow(func() time.Time {
+		clockMu.Lock()
+		defer clockMu.Unlock()
+		return wallNow
+	})
+	advanceClock := func(by time.Duration) {
+		clockMu.Lock()
+		wallNow = wallNow.Add(by)
+		clockMu.Unlock()
+	}
+
+	startedCh := subscribeTopic(t, bus, events.TopicDriveStarted)
+	endedCh := subscribeTopic(t, bus, events.TopicDriveEnded)
+
+	if err := d.Start(context.Background()); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	defer func() { _ = d.Stop() }()
+
+	// Single D-gear telemetry event starts the drive. Critically, no
+	// further telemetry arrives — so the watchdog-end path will see
+	// Duration=0 (lastTimestamp == startedAt) and Distance=0 (a single
+	// route point yields zero totalDistance), the same shape as a
+	// reconciled drive with no resumed telemetry. The only difference
+	// is the reconciled flag, which is false here.
+	publishTelemetry(t, bus, telemetryEvent(vin, wallNow, driveFields("D", 5.0, 33.09, -96.82)))
+	if _, ok := waitForEvent(startedCh); !ok {
+		t.Fatal("timed out waiting for DriveStartedEvent on regular drive")
+	}
+
+	// Advance past EndDebounce so the watchdog ends the drive.
+	advanceClock(2 * cfg.EndDebounce)
+
+	// With reconciled=false and prod-default micro-drive thresholds,
+	// endDrive MUST discard the drive — no DriveEndedEvent.
+	expectNoEvent(t, endedCh, 500*time.Millisecond,
+		"regular micro-drive must still be filtered by endDrive — bypass is only for reconciled drives")
 }
 
 func TestDetector_ReconcilerError_DoesNotFailStart(t *testing.T) {

--- a/internal/drives/reconcile_test.go
+++ b/internal/drives/reconcile_test.go
@@ -1,0 +1,264 @@
+package drives
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/myrobotaxi/telemetry/internal/events"
+)
+
+// fakeOpenDriveLister is a minimal in-memory OpenDriveLister used by
+// the reconciliation tests. rows is returned verbatim from ListOpen;
+// err (if set) is returned instead.
+type fakeOpenDriveLister struct {
+	rows []OpenDriveRow
+	err  error
+}
+
+func (f *fakeOpenDriveLister) ListOpen(_ context.Context) ([]OpenDriveRow, error) {
+	if f.err != nil {
+		return nil, f.err
+	}
+	return f.rows, nil
+}
+
+// loadState is a test-only helper that pulls a vehicleState out of the
+// Detector's internal map. Returns nil when no entry exists.
+func (d *Detector) loadStateForTest(vin string) *vehicleState {
+	val, ok := d.states.Load(vin)
+	if !ok {
+		return nil
+	}
+	return val.(*vehicleState)
+}
+
+func TestDetector_ReconcilesOpenDrivesOnStart(t *testing.T) {
+	bus := testBus()
+	defer bus.Close(context.Background())
+
+	startTime := time.Now().Add(-10 * time.Minute).UTC().Format(time.RFC3339)
+	lister := &fakeOpenDriveLister{
+		rows: []OpenDriveRow{
+			{ID: "drv_recon_1", VIN: "V1", StartTime: startTime, StartChargeLevel: 80},
+			{ID: "drv_recon_2", VIN: "V2", StartTime: startTime, StartChargeLevel: 65},
+		},
+	}
+
+	d := NewDetector(bus, testConfig(), testLogger(), NoopDetectorMetrics{}, lister)
+	if err := d.Start(context.Background()); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	defer func() { _ = d.Stop() }()
+
+	for _, vin := range []string{"V1", "V2"} {
+		state := d.loadStateForTest(vin)
+		if state == nil {
+			t.Fatalf("no reconciled state for VIN %s", vin)
+		}
+		state.mu.Lock()
+		status := state.status
+		var driveID string
+		var startCharge float64
+		if state.drive != nil {
+			driveID = state.drive.id
+			startCharge = state.drive.startCharge
+		}
+		lastTel := state.lastTelemetryAt
+		state.mu.Unlock()
+
+		if status != StatusDriving {
+			t.Errorf("VIN %s status = %v, want StatusDriving", vin, status)
+		}
+		if driveID == "" {
+			t.Errorf("VIN %s drive ID is empty, want non-empty", vin)
+		}
+		if lastTel.IsZero() {
+			t.Errorf("VIN %s lastTelemetryAt is zero; watchdog needs a non-zero reference", vin)
+		}
+		if vin == "V1" && driveID != "drv_recon_1" {
+			t.Errorf("VIN V1 drive ID = %q, want drv_recon_1", driveID)
+		}
+		if vin == "V1" && startCharge != 80 {
+			t.Errorf("VIN V1 startCharge = %f, want 80", startCharge)
+		}
+	}
+}
+
+func TestDetector_ReconciledDrive_TelemetryResumes_KeepsSameDriveID(t *testing.T) {
+	bus := testBus()
+	defer bus.Close(context.Background())
+
+	const reconciledID = "drv_resume_1"
+	const vin = "VIN_RESUME"
+
+	startTime := time.Now().Add(-5 * time.Minute).UTC().Format(time.RFC3339)
+	lister := &fakeOpenDriveLister{
+		rows: []OpenDriveRow{
+			{ID: reconciledID, VIN: vin, StartTime: startTime, StartChargeLevel: 70},
+		},
+	}
+
+	cfg := testConfig()
+	// Keep EndDebounce large so the watchdog cannot fire during the test.
+	cfg.EndDebounce = 5 * time.Second
+	cfg.MinDuration = 0
+	cfg.MinDistanceMiles = 0
+
+	d := NewDetector(bus, cfg, testLogger(), NoopDetectorMetrics{}, lister)
+
+	startedCh := subscribeTopic(t, bus, events.TopicDriveStarted)
+	updatedCh := subscribeTopic(t, bus, events.TopicDriveUpdated)
+
+	if err := d.Start(context.Background()); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	defer func() { _ = d.Stop() }()
+
+	// Real telemetry resumes for the reconciled VIN. The detector
+	// should NOT publish a new DriveStartedEvent — it should treat
+	// this as continuation of the existing drive and publish a
+	// DriveUpdatedEvent with the original drive ID.
+	publishTelemetry(t, bus, telemetryEvent(vin, time.Now(), driveFields("D", 35.0, 33.1, -96.85)))
+
+	evt, ok := waitForEvent(updatedCh)
+	if !ok {
+		t.Fatal("timed out waiting for DriveUpdatedEvent after reconciliation")
+	}
+	upd, ok := evt.Payload.(events.DriveUpdatedEvent)
+	if !ok {
+		t.Fatalf("expected DriveUpdatedEvent, got %T", evt.Payload)
+	}
+	if upd.DriveID != reconciledID {
+		t.Errorf("DriveID = %q, want %q (reconciled drive must continue, not restart)", upd.DriveID, reconciledID)
+	}
+
+	// No DriveStartedEvent should have been emitted — the reconciled
+	// state is already StatusDriving, so handleTelemetry routes to
+	// handleDriving, not handleIdle.
+	expectNoEvent(t, startedCh, 200*time.Millisecond, "telemetry on reconciled drive must not emit a new DriveStartedEvent")
+}
+
+func TestDetector_ReconciledDrive_NoTelemetry_WatchdogEnds(t *testing.T) {
+	bus := testBus()
+	defer bus.Close(context.Background())
+
+	const reconciledID = "drv_silent_1"
+	const vin = "VIN_SILENT_RECON"
+
+	startTime := time.Now().Add(-5 * time.Minute).UTC().Format(time.RFC3339)
+	lister := &fakeOpenDriveLister{
+		rows: []OpenDriveRow{
+			{ID: reconciledID, VIN: vin, StartTime: startTime, StartChargeLevel: 50},
+		},
+	}
+
+	cfg := testConfig()
+	cfg.EndDebounce = 200 * time.Millisecond
+	cfg.MinDuration = 0
+	cfg.MinDistanceMiles = 0
+
+	d := NewDetector(bus, cfg, testLogger(), NoopDetectorMetrics{}, lister)
+
+	// Injectable clock so we can advance past EndDebounce without
+	// sleeping. Mirrors TestDetector_WatchdogEndsDriveWhenTelemetrySilent.
+	var clockMu sync.Mutex
+	wallNow := time.Now()
+	d.setNow(func() time.Time {
+		clockMu.Lock()
+		defer clockMu.Unlock()
+		return wallNow
+	})
+	advanceClock := func(by time.Duration) {
+		clockMu.Lock()
+		wallNow = wallNow.Add(by)
+		clockMu.Unlock()
+	}
+
+	endedCh := subscribeTopic(t, bus, events.TopicDriveEnded)
+
+	if err := d.Start(context.Background()); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	defer func() { _ = d.Stop() }()
+
+	// No telemetry arrives for the reconciled VIN. Advance the wall
+	// clock past EndDebounce; the next watchdog tick must observe the
+	// silence and end the drive with the original drive ID.
+	advanceClock(2 * cfg.EndDebounce)
+
+	evt, ok := waitForEvent(endedCh)
+	if !ok {
+		t.Fatal("timed out waiting for DriveEndedEvent from watchdog")
+	}
+	ended, ok := evt.Payload.(events.DriveEndedEvent)
+	if !ok {
+		t.Fatalf("expected DriveEndedEvent, got %T", evt.Payload)
+	}
+	if ended.DriveID != reconciledID {
+		t.Errorf("DriveID = %q, want %q (watchdog must close the reconciled row)", ended.DriveID, reconciledID)
+	}
+	if ended.VIN != vin {
+		t.Errorf("VIN = %q, want %q", ended.VIN, vin)
+	}
+}
+
+func TestDetector_ReconcilerError_DoesNotFailStart(t *testing.T) {
+	bus := testBus()
+	defer bus.Close(context.Background())
+
+	lister := &fakeOpenDriveLister{
+		err: errors.New("simulated DB outage"),
+	}
+
+	d := NewDetector(bus, testConfig(), testLogger(), NoopDetectorMetrics{}, lister)
+	if err := d.Start(context.Background()); err != nil {
+		t.Fatalf("Start must not propagate reconciler errors; got %v", err)
+	}
+	defer func() { _ = d.Stop() }()
+
+	// No state should have been populated.
+	if got := d.loadStateForTest("V1"); got != nil {
+		t.Errorf("reconciler error should leave states empty; found state for V1: %+v", got)
+	}
+}
+
+func TestDetector_NilReconciler_DoesNotPanic(t *testing.T) {
+	bus := testBus()
+	defer bus.Close(context.Background())
+
+	d := NewDetector(bus, testConfig(), testLogger(), NoopDetectorMetrics{}, nil)
+	if err := d.Start(context.Background()); err != nil {
+		t.Fatalf("Start with nil reconciler: %v", err)
+	}
+	defer func() { _ = d.Stop() }()
+}
+
+func TestParseDriveStartTime(t *testing.T) {
+	tests := []struct {
+		name    string
+		in      string
+		wantErr bool
+	}{
+		{name: "RFC3339 with Z", in: "2026-06-06T20:33:06Z", wantErr: false},
+		{name: "RFC3339 with offset", in: "2026-06-06T20:33:06+00:00", wantErr: false},
+		{name: "RFC3339Nano", in: "2026-06-06T20:33:06.123456789Z", wantErr: false},
+		{name: "no timezone (last-resort)", in: "2026-06-06T20:33:06", wantErr: false},
+		{name: "empty string", in: "", wantErr: true},
+		{name: "garbage", in: "not a time", wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := parseDriveStartTime(tt.in)
+			if tt.wantErr && err == nil {
+				t.Errorf("parseDriveStartTime(%q): want error, got nil", tt.in)
+			}
+			if !tt.wantErr && err != nil {
+				t.Errorf("parseDriveStartTime(%q): unexpected error %v", tt.in, err)
+			}
+		})
+	}
+}

--- a/internal/drives/state.go
+++ b/internal/drives/state.go
@@ -79,6 +79,20 @@ type activeDrive struct {
 	lastTimestamp time.Time
 	lastSOC       float64 // most recent SOC for EndChargeLevel
 	lastEnergy    float64 // most recent energyRemaining for EnergyDelta
+
+	// reconciled is true when this drive was reattached from a DB row
+	// orphaned by a previous restart (MYR-146). endDrive bypasses the
+	// micro-drive filter for reconciled drives: with no resumed
+	// telemetry, calculateStats returns Duration=0, Distance=0, which
+	// the prod-default filter (MinDuration=2m, MinDistanceMiles=0.1)
+	// would otherwise discard -- leaving the open DB row forever and
+	// reconciling it again on the next restart. Closing those rows is
+	// the whole point of reconciliation, so we publish DriveEndedEvent
+	// unconditionally for them. Cleared once real telemetry arrives
+	// (see handleDriving), so a reconciled drive that survives the
+	// restart and accumulates legitimate route data is filtered
+	// normally on its real end transition.
+	reconciled bool
 }
 
 // resetToIdle resets the vehicle state to idle. The caller must hold s.mu.

--- a/internal/drives/transitions.go
+++ b/internal/drives/transitions.go
@@ -34,6 +34,14 @@ func (d *Detector) handleDriving(state *vehicleState, vin string, te events.Vehi
 		return
 	}
 
+	// Real telemetry has resumed for a reconciled drive (MYR-146):
+	// from this point legitimate route data accumulates, so the normal
+	// micro-drive filter semantics apply on the eventual end
+	// transition. Clear the bypass flag.
+	if drive.reconciled {
+		drive.reconciled = false
+	}
+
 	// Accumulate speed stats.
 	if speed, ok := extractFloatField(te.Fields, telemetry.FieldSpeed); ok {
 		drive.speedSum += speed

--- a/internal/drives/transitions_test.go
+++ b/internal/drives/transitions_test.go
@@ -74,7 +74,7 @@ func TestStartDrive_ZeroLocation(t *testing.T) {
 			bus := testBus()
 			defer bus.Close(context.Background())
 
-			d := NewDetector(bus, testConfig(), testLogger(), NoopDetectorMetrics{})
+			d := NewDetector(bus, testConfig(), testLogger(), NoopDetectorMetrics{}, nil)
 			if err := d.Start(context.Background()); err != nil {
 				t.Fatalf("Start: %v", err)
 			}

--- a/internal/store/drive_repo_open.go
+++ b/internal/store/drive_repo_open.go
@@ -1,0 +1,70 @@
+// Orphan-reconciliation read path. Split out of drive_repo.go so the
+// wide-read + dual-write (routePoints/routePointsEnc) module stays
+// focused and this file owns the narrow "open drive" projection used
+// only on startup.
+//
+// MYR-146: when a Fly redeploy lands mid-drive, the Detector's
+// in-memory vehicleState map is lost. Without reconciliation, any
+// Drive row whose endTime was unset at deploy time stays open forever
+// because the watchdog only scans VINs it already knows about. This
+// query is the seed: Detector.Start reads it once, populates
+// vehicleState for each row, and the watchdog ends them within
+// EndDebounce if telemetry doesn't resume. See
+// internal/drives/detector.go reconcileOpenDrives.
+
+package store
+
+import (
+	"context"
+	"fmt"
+	"time"
+)
+
+// OpenDriveRow is the slim projection returned by DriveRepo.ListOpen.
+// Fields are the minimum the Detector needs to recreate a vehicleState
+// keyed by VIN and have the watchdog/end-handler flow produce a
+// well-formed DriveEndedEvent for the existing row (the writer's
+// handleDriveEnded calls drives.Complete by DriveID, so the in-memory
+// activeDrive only needs ID, StartedAt, and StartChargeLevel).
+type OpenDriveRow struct {
+	ID               string
+	VehicleID        string
+	VIN              string
+	StartTime        string // ISO 8601 — Prisma stores as TEXT
+	Date             string
+	StartChargeLevel int
+}
+
+// ListOpen returns every Drive row whose endTime is unset
+// (NULL or empty string). Used exclusively by Detector.Start during
+// orphan reconciliation. In steady state the result set is empty;
+// after a redeploy mid-drive it contains one row per vehicle that was
+// actively driving at the time of restart.
+func (r *DriveRepo) ListOpen(ctx context.Context) ([]OpenDriveRow, error) {
+	start := time.Now()
+	rows, err := r.pool.Query(ctx, queryDriveListOpen)
+	if err != nil {
+		r.metrics.IncQueryError("drive.list_open")
+		r.metrics.ObserveQueryDuration("drive.list_open", time.Since(start).Seconds())
+		return nil, fmt.Errorf("DriveRepo.ListOpen: %w", err)
+	}
+	defer rows.Close()
+
+	var out []OpenDriveRow
+	for rows.Next() {
+		var d OpenDriveRow
+		if err := rows.Scan(&d.ID, &d.VehicleID, &d.VIN, &d.StartTime, &d.Date, &d.StartChargeLevel); err != nil {
+			r.metrics.IncQueryError("drive.list_open")
+			r.metrics.ObserveQueryDuration("drive.list_open", time.Since(start).Seconds())
+			return nil, fmt.Errorf("DriveRepo.ListOpen: scan: %w", err)
+		}
+		out = append(out, d)
+	}
+	if err := rows.Err(); err != nil {
+		r.metrics.IncQueryError("drive.list_open")
+		r.metrics.ObserveQueryDuration("drive.list_open", time.Since(start).Seconds())
+		return nil, fmt.Errorf("DriveRepo.ListOpen: rows: %w", err)
+	}
+	r.metrics.ObserveQueryDuration("drive.list_open", time.Since(start).Seconds())
+	return out, nil
+}

--- a/internal/store/queries.go
+++ b/internal/store/queries.go
@@ -131,6 +131,29 @@ const queryDriveByID = `SELECT "id", "vehicleId", "date", "startTime", "endTime"
 FROM "Drive"
 WHERE "id" = $1`
 
+// queryDriveListOpen returns every Drive row whose endTime is unset.
+// MYR-146: read on Detector.Start to reconcile rows orphaned by a Fly
+// redeploy mid-drive (in-memory vehicleState was lost; without
+// reconciliation the watchdog never observes these rows and they stay
+// "active" forever).
+//
+// Single JOIN to Vehicle is the cleanest shape because the Detector is
+// global (one instance, all VINs) and keys in-memory state by VIN. A
+// two-step (open drives → per-row VIN lookup) would round-trip per
+// vehicle for no benefit. The set is bounded by the live-fleet size,
+// and `endTime IS NULL OR endTime = ''` is by definition rare in steady
+// state.
+//
+// Predicate covers both representations because the cleanup-binary
+// findings showed the column can be either NULL or empty string
+// depending on how the row was inserted. No `LIMIT` because we want
+// every orphan, not a page.
+const queryDriveListOpen = `SELECT
+	d."id", d."vehicleId", v."vin", d."startTime", d."date", d."startChargeLevel"
+FROM "Drive" d
+JOIN "Vehicle" v ON d."vehicleId" = v."id"
+WHERE d."endTime" IS NULL OR d."endTime" = ''`
+
 // driveSummarySelectColumns is the lean projection used by the
 // GET /api/vehicles/{vehicleId}/drives list endpoint (MYR-133, MYR-145).
 // It MUST stay aligned with the wire fields emitted by


### PR DESCRIPTION
## Root cause

A Fly redeploy mid-drive restarts the machine. `internal/drives/Detector` loses its in-memory `vehicleState` map. Telemetry resumes on a new connection, the state machine sees no prior state, and either fires a fresh `drive_started` (producing the "2 active drives" bug currently visible on vehicle 8242 in prod) or — if the car parked during the deploy — never publishes `drive_ended` at all. The MYR-139 R3a watchdog cannot rescue these rows because it only scans VINs whose `lastTelemetryAt` is set in memory; the redeploy wipes that entirely.

## Fix — Option B (per Linear)

On `Detector.Start`, query open drives from the DB (`endTime IS NULL OR endTime = ''`) and reattach each to in-memory `vehicleState` keyed by VIN with `status=StatusDriving`, `drive = activeDrive{ID, StartedAt, StartChargeLevel, ...}`, `lastTelemetryAt = d.now()`. Two outcomes:

1. **Telemetry resumes** for the same VIN → state machine routes through `handleDriving`, publishes `drive_updated` with the original drive ID. Same row, no duplicate. Tested by `TestDetector_ReconciledDrive_TelemetryResumes_KeepsSameDriveID`.
2. **No telemetry** → watchdog observes the silence and ends the drive within `EndDebounce` (30s prod). Tested by `TestDetector_ReconciledDrive_NoTelemetry_WatchdogEnds`.

Reconciliation is fail-open: a DB hiccup on Start logs Warn and continues. Worst case orphans persist until the next successful restart cycle.

## What changed

- `internal/store/queries.go` — `queryDriveListOpen` (JOIN to Vehicle for VIN).
- `internal/store/drive_repo_open.go` — new sibling file with `DriveRepo.ListOpen` (`drive_repo.go` was at 284/300 lines).
- `internal/drives/reconcile.go` — new file: `OpenDriveLister` interface, `OpenDriveRow` type, `reconcileOpenDrives`, `parseDriveStartTime`.
- `internal/drives/detector.go` — adds required `reconciler OpenDriveLister` param to `NewDetector` (constructor arg, not functional option — silent nil in prod is the exact regression Option B prevents). Calls `reconcileOpenDrives` after subscribe / before watchdog start.
- `internal/drives/reconcile_test.go` — five table-driven tests for the reconciliation paths plus `TestParseDriveStartTime`.
- `cmd/telemetry-server/main.go` — reorders store-repo init before Detector construction and wires the adapter.
- `cmd/telemetry-server/adapters.go` — `openDriveListerAdapter` translates `store.OpenDriveRow` → `drives.OpenDriveRow`.
- Existing test call sites (`detector_test.go`, `transitions_test.go`) updated to pass `nil` reconciler.

## Schema

No schema changes. The Drive table is Prisma-owned. The watchdog ends rows via the existing `Complete` path, so the column shape is identical to a normal drive end.

## Test plan

- [x] `go vet ./...` clean
- [x] `go build ./...` clean
- [x] `golangci-lint run ./...` — 0 issues
- [x] `go test ./internal/drives/... ./internal/store/... ./cmd/...` — all green
- [x] Unit-test coverage:
  - `TestDetector_ReconcilesOpenDrivesOnStart`
  - `TestDetector_ReconciledDrive_TelemetryResumes_KeepsSameDriveID`
  - `TestDetector_ReconciledDrive_NoTelemetry_WatchdogEnds`
  - `TestDetector_ReconcilerError_DoesNotFailStart`
  - `TestDetector_NilReconciler_DoesNotPanic`
  - `TestParseDriveStartTime`
- [ ] Verify against the two stuck prod rows (vehicle 8242, startTimes `2026-06-06T20:33:06Z` / `2026-06-06T20:45:26Z`) after deploy. Left untouched per the issue.

Closes MYR-146.