### PR TITLE
MYR-147 Reconciler: group orphans by VIN, end older synchronously

### DIFF
--- a/cmd/telemetry-server/adapters.go
+++ b/cmd/telemetry-server/adapters.go
@@ -364,11 +364,18 @@ func proxyHTTPClient(proxyURL string, logger *slog.Logger) *http.Client {
 }
 
 
-// openDriveListerAdapter adapts store.DriveRepo.ListOpen to the
+// openDriveListerAdapter adapts store.DriveRepo to the
 // drives.OpenDriveLister interface used by Detector.Start for orphan
 // reconciliation (MYR-146). The drives package defines its own
 // OpenDriveRow type so it stays decoupled from internal/store; this
 // adapter performs the row-shape translation at the boundary.
+//
+// MYR-147: also exposes MarkOrphanEnded so the reconciler can close
+// older same-VIN orphans synchronously instead of silently dropping
+// them. The implementation reuses DriveRepo.Complete with zero stats
+// and EndTime=now — the only path that doesn't require non-zero
+// distance/duration (which we don't have for a drive that never
+// resumed telemetry).
 type openDriveListerAdapter struct {
 	repo *store.DriveRepo
 }
@@ -389,6 +396,27 @@ func (a *openDriveListerAdapter) ListOpen(ctx context.Context) ([]drives.OpenDri
 		})
 	}
 	return out, nil
+}
+
+// MarkOrphanEnded closes the Drive row identified by driveID with
+// zero stats and EndTime set to "now" (RFC3339, UTC). Called by the
+// reconciler for older same-VIN orphans — drives that pre-date the
+// most recent open drive for the same VIN and are therefore
+// definitively over.
+//
+// We pass zero values for all numeric fields because the row never
+// accumulated post-restart telemetry (the in-memory state was lost on
+// redeploy and the Detector now reattaches only the LATEST per VIN).
+// The endTime column is what unblocks the existing
+// "endTime IS NULL OR endTime = ''" ListOpen predicate; the zero
+// stats are the honest representation of "we don't know what
+// happened between start and now".
+func (a *openDriveListerAdapter) MarkOrphanEnded(ctx context.Context, driveID string) error {
+	endedAt := time.Now().UTC().Format(time.RFC3339)
+	if err := a.repo.Complete(ctx, driveID, store.DriveCompletion{EndTime: endedAt}); err != nil {
+		return fmt.Errorf("mark orphan ended (drive_id=%s): %w", driveID, err)
+	}
+	return nil
 }
 
 // vehicleAuthorizerAdapter adapts store.VINCache to the

--- a/internal/drives/reconcile.go
+++ b/internal/drives/reconcile.go
@@ -46,8 +46,16 @@ type OpenDriveRow struct {
 // Start to discover Drive rows orphaned by a previous restart. A nil
 // implementation skips reconciliation entirely — used by unit tests
 // and by any future runtime that doesn't persist drives.
+//
+// MYR-147: MarkOrphanEnded closes an open Drive row immediately
+// (endTime = now, zero stats). The reconciler invokes it for the
+// OLDER orphans in a same-VIN group — those drives are definitively
+// over because a newer open drive exists for the same VIN, so there
+// is nothing left for the watchdog to do. The most recent orphan per
+// VIN still flows through the in-memory reattach + watchdog-end path.
 type OpenDriveLister interface {
 	ListOpen(ctx context.Context) ([]OpenDriveRow, error)
+	MarkOrphanEnded(ctx context.Context, driveID string) error
 }
 
 // reconcileOpenDrives reads every open Drive row from the lister and
@@ -73,61 +81,149 @@ func (d *Detector) reconcileOpenDrives(ctx context.Context) {
 		return
 	}
 
+	groups := groupOrphansByVIN(rows)
+
 	now := d.now()
 	reconciled := 0
-	for _, row := range rows {
-		if row.VIN == "" || row.ID == "" {
-			continue
-		}
-		startedAt, parseErr := parseDriveStartTime(row.StartTime)
-		if parseErr != nil {
-			// Fall back to "now" so the watchdog still has a sane
-			// reference and the row gets closed on next idle.
-			startedAt = now
-			d.logger.Warn("reconciled drive has unparseable startTime; using current time",
-				slog.String("drive_id", row.ID),
-				slog.String("start_time", row.StartTime),
-				slog.String("error", parseErr.Error()),
-			)
-		}
-
-		state := &vehicleState{
-			status:          StatusDriving,
-			lastTelemetryAt: now,
-			drive: &activeDrive{
-				id:            row.ID,
-				startedAt:     startedAt,
-				startCharge:   float64(row.StartChargeLevel),
-				lastSOC:       float64(row.StartChargeLevel),
-				lastTimestamp: startedAt,
-				// reconciled tags the watchdog-end path to bypass the
-				// micro-drive filter (MYR-146 critical). With no
-				// resumed telemetry the stats are Duration=0,
-				// Distance=0 and the prod-default filter
-				// (MinDuration=2m, MinDistanceMiles=0.1) would discard
-				// the DriveEndedEvent -- leaving the DB row open and
-				// reconciled again on the next restart forever.
-				// Cleared in handleDriving once real telemetry
-				// resumes; from that point the drive is treated as a
-				// normal continuation and any subsequent end goes
-				// through the standard filter.
-				reconciled: true,
-			},
-		}
-		// Use Store (not LoadOrStore) — reconcileOpenDrives runs
-		// BEFORE Start calls Subscribe (see Start in detector.go), so
-		// no handler goroutine can touch d.states yet. Overwriting any
-		// pre-existing entry would be a bug, not a race we tolerate.
-		d.states.Store(row.VIN, state)
-		d.activeCount.Add(1)
+	ended := 0
+	for vin, g := range groups {
+		// In-memory reattach for the MOST RECENT orphan per VIN.
+		// The watchdog (or resumed telemetry) closes this one.
+		d.reattachOrphan(vin, g.latest, now)
 		reconciled++
+
+		// Close OLDER same-VIN orphans synchronously. They pre-date
+		// the most recent open drive for the same VIN, so by
+		// definition no telemetry will ever resume on them — the
+		// watchdog path that the reattached drive uses cannot apply
+		// here (only one in-memory entry per VIN). Without this,
+		// MYR-146's reconciler silently overwrote prior d.states
+		// entries and the older rows stayed open forever.
+		for i := range g.older {
+			row := &g.older[i]
+			if err := d.reconciler.MarkOrphanEnded(d.ctx, row.ID); err != nil {
+				// Fail open, same posture as ListOpen. The row stays
+				// open and will be retried on next restart.
+				d.logger.Warn("failed to mark older same-VIN orphan ended; will retry on next restart",
+					slog.String("drive_id", row.ID),
+					slog.String("error", err.Error()),
+				)
+				continue
+			}
+			ended++
+		}
 	}
 
 	d.metrics.SetActiveVehicles(int(d.activeCount.Load()))
 
 	d.logger.Info("reconciled orphaned drives",
 		slog.Int("reconciled_count", reconciled),
+		slog.Int("ended_count", ended),
 	)
+}
+
+// reattachOrphan installs in-memory vehicleState for a single orphan
+// row and increments the active-vehicle counter. Extracted from
+// reconcileOpenDrives so the same-VIN grouping path can call it once
+// per group without duplicating the construction.
+//
+// The caller guarantees row.VIN and row.ID are non-empty (filtered in
+// groupOrphansByVIN).
+func (d *Detector) reattachOrphan(vin string, row *OpenDriveRow, now time.Time) {
+	startedAt, parseErr := parseDriveStartTime(row.StartTime)
+	if parseErr != nil {
+		// Fall back to "now" so the watchdog still has a sane
+		// reference and the row gets closed on next idle.
+		startedAt = now
+		d.logger.Warn("reconciled drive has unparseable startTime; using current time",
+			slog.String("drive_id", row.ID),
+			slog.String("start_time", row.StartTime),
+			slog.String("error", parseErr.Error()),
+		)
+	}
+
+	state := &vehicleState{
+		status:          StatusDriving,
+		lastTelemetryAt: now,
+		drive: &activeDrive{
+			id:            row.ID,
+			startedAt:     startedAt,
+			startCharge:   float64(row.StartChargeLevel),
+			lastSOC:       float64(row.StartChargeLevel),
+			lastTimestamp: startedAt,
+			// reconciled tags the watchdog-end path to bypass the
+			// micro-drive filter (MYR-146 critical). With no
+			// resumed telemetry the stats are Duration=0,
+			// Distance=0 and the prod-default filter
+			// (MinDuration=2m, MinDistanceMiles=0.1) would discard
+			// the DriveEndedEvent -- leaving the DB row open and
+			// reconciled again on the next restart forever.
+			// Cleared in handleDriving once real telemetry
+			// resumes; from that point the drive is treated as a
+			// normal continuation and any subsequent end goes
+			// through the standard filter.
+			reconciled: true,
+		},
+	}
+	// Use Store (not LoadOrStore) — reconcileOpenDrives runs
+	// BEFORE Start calls Subscribe (see Start in detector.go), so
+	// no handler goroutine can touch d.states yet. Overwriting any
+	// pre-existing entry would be a bug, not a race we tolerate.
+	d.states.Store(vin, state)
+	d.activeCount.Add(1)
+}
+
+// orphanGroup partitions the open-drive rows for a single VIN into
+// the most recent (latest) and everything older. The latest goes
+// through the in-memory reattach path; the older entries are closed
+// synchronously via MarkOrphanEnded.
+//
+// MYR-147: prod confirmed 3 simultaneously-open Drive rows for the
+// same VIN. The MYR-146 reconciler stored them all under d.states
+// keyed by VIN and the last write won — earlier rows were silently
+// dropped and never closed.
+type orphanGroup struct {
+	latest *OpenDriveRow
+	older  []OpenDriveRow
+}
+
+// groupOrphansByVIN partitions the open-drive rows by VIN and, within
+// each VIN, picks the lexicographically-greatest StartTime as the
+// "latest" orphan. Empty VIN/ID rows are filtered out (matches the
+// pre-grouping guard in the original loop).
+//
+// String comparison on StartTime is safe because every value is RFC3339
+// (YYYY-MM-DDTHH:MM:SSZ), which is lexicographically sortable. If a
+// future writer ever stores a non-Z offset we'd want to parse first,
+// but the only producer today is mapDriveStarted which always emits Z.
+func groupOrphansByVIN(rows []OpenDriveRow) map[string]*orphanGroup {
+	groups := make(map[string]*orphanGroup)
+	for i := range rows {
+		row := rows[i]
+		if row.VIN == "" || row.ID == "" {
+			continue
+		}
+		g, ok := groups[row.VIN]
+		if !ok {
+			g = &orphanGroup{}
+			groups[row.VIN] = g
+		}
+		if g.latest == nil {
+			// First row for this VIN — promote unconditionally.
+			r := row
+			g.latest = &r
+			continue
+		}
+		if row.StartTime > g.latest.StartTime {
+			// Newer than the current latest — demote the old latest.
+			g.older = append(g.older, *g.latest)
+			r := row
+			g.latest = &r
+			continue
+		}
+		g.older = append(g.older, row)
+	}
+	return groups
 }
 
 // parseDriveStartTime parses the Prisma-stored startTime string. The

--- a/internal/drives/reconcile_test.go
+++ b/internal/drives/reconcile_test.go
@@ -13,9 +13,19 @@ import (
 // fakeOpenDriveLister is a minimal in-memory OpenDriveLister used by
 // the reconciliation tests. rows is returned verbatim from ListOpen;
 // err (if set) is returned instead.
+//
+// MYR-147: also captures MarkOrphanEnded calls. endedIDs records every
+// drive ID the reconciler asked us to close (in call order); when
+// markEndedErr is non-nil it is returned to the reconciler instead,
+// exercising the fail-open path.
 type fakeOpenDriveLister struct {
+	mu sync.Mutex
+
 	rows []OpenDriveRow
 	err  error
+
+	endedIDs     []string
+	markEndedErr error
 }
 
 func (f *fakeOpenDriveLister) ListOpen(_ context.Context) ([]OpenDriveRow, error) {
@@ -23,6 +33,26 @@ func (f *fakeOpenDriveLister) ListOpen(_ context.Context) ([]OpenDriveRow, error
 		return nil, f.err
 	}
 	return f.rows, nil
+}
+
+func (f *fakeOpenDriveLister) MarkOrphanEnded(_ context.Context, driveID string) error {
+	if f.markEndedErr != nil {
+		return f.markEndedErr
+	}
+	f.mu.Lock()
+	f.endedIDs = append(f.endedIDs, driveID)
+	f.mu.Unlock()
+	return nil
+}
+
+// endedSnapshot returns a copy of the captured drive IDs in call order,
+// safe to inspect without holding f.mu.
+func (f *fakeOpenDriveLister) endedSnapshot() []string {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	out := make([]string, len(f.endedIDs))
+	copy(out, f.endedIDs)
+	return out
 }
 
 // loadState is a test-only helper that pulls a vehicleState out of the

--- a/internal/drives/reconcile_test.go
+++ b/internal/drives/reconcile_test.go
@@ -340,6 +340,237 @@ func TestDetector_NilReconciler_DoesNotPanic(t *testing.T) {
 	defer func() { _ = d.Stop() }()
 }
 
+// TestDetector_MultipleOrphansSameVIN_KeepsLatestEndsOlder is the
+// regression test for MYR-147. The MYR-146 reconciler keyed d.states
+// by VIN with a Store-not-LoadOrStore, so when ListOpen returned
+// multiple open Drive rows for the same VIN only the LAST one
+// survived in memory; the rest were silently dropped and stayed open
+// in the DB forever. Prod confirmed 3 such rows for the same VIN
+// before the fix landed.
+//
+// After MYR-147: the reconciler groups by VIN, picks the most recent
+// orphan (lexicographic StartTime, RFC3339-safe) for the in-memory
+// reattach path, and synchronously closes every older row via
+// MarkOrphanEnded. activeCount counts only the reattached drives —
+// the side-channel end path doesn't go through the watchdog so it
+// must not bump the counter.
+func TestDetector_MultipleOrphansSameVIN_KeepsLatestEndsOlder(t *testing.T) {
+	bus := testBus()
+	defer bus.Close(context.Background())
+
+	const vin = "V1"
+	const (
+		idT1 = "drv_t1_oldest"
+		idT2 = "drv_t2_middle"
+		idT3 = "drv_t3_latest"
+	)
+
+	now := time.Now().UTC()
+	t1 := now.Add(-30 * time.Minute).Format(time.RFC3339)
+	t2 := now.Add(-20 * time.Minute).Format(time.RFC3339)
+	t3 := now.Add(-10 * time.Minute).Format(time.RFC3339)
+
+	// Intentionally seed in a non-sorted order so the grouping logic
+	// can't rely on input ordering.
+	lister := &fakeOpenDriveLister{
+		rows: []OpenDriveRow{
+			{ID: idT2, VIN: vin, StartTime: t2, StartChargeLevel: 70},
+			{ID: idT3, VIN: vin, StartTime: t3, StartChargeLevel: 65},
+			{ID: idT1, VIN: vin, StartTime: t1, StartChargeLevel: 80},
+		},
+	}
+
+	d := NewDetector(bus, testConfig(), testLogger(), NoopDetectorMetrics{}, lister)
+	if err := d.Start(context.Background()); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	defer func() { _ = d.Stop() }()
+
+	// In-memory state must reflect the LATEST orphan only.
+	state := d.loadStateForTest(vin)
+	if state == nil {
+		t.Fatalf("no reconciled state for VIN %s", vin)
+	}
+	state.mu.Lock()
+	gotID := ""
+	if state.drive != nil {
+		gotID = state.drive.id
+	}
+	state.mu.Unlock()
+	if gotID != idT3 {
+		t.Errorf("reconciled drive ID = %q, want %q (latest by StartTime)", gotID, idT3)
+	}
+
+	// The two older drives must have been ended synchronously, in any
+	// order.
+	ended := lister.endedSnapshot()
+	if len(ended) != 2 {
+		t.Fatalf("MarkOrphanEnded calls = %d (%v), want 2 (%s and %s)", len(ended), ended, idT1, idT2)
+	}
+	endedSet := map[string]bool{ended[0]: true, ended[1]: true}
+	if !endedSet[idT1] || !endedSet[idT2] {
+		t.Errorf("MarkOrphanEnded called for %v, want both %s and %s", ended, idT1, idT2)
+	}
+	if endedSet[idT3] {
+		t.Errorf("MarkOrphanEnded must NOT be called for the LATEST orphan %s", idT3)
+	}
+
+	// activeCount counts only the in-memory reattach (one per VIN).
+	if got := d.activeCount.Load(); got != 1 {
+		t.Errorf("activeCount = %d, want 1 (only the reattached drive)", got)
+	}
+}
+
+// TestDetector_SingleOrphan_StillReattaches is the regression guard for
+// the MYR-146 single-orphan path. With one open drive per VIN, the
+// new grouping must behave identically: state populated,
+// MarkOrphanEnded NOT called, activeCount == 1.
+func TestDetector_SingleOrphan_StillReattaches(t *testing.T) {
+	bus := testBus()
+	defer bus.Close(context.Background())
+
+	const (
+		vin   = "V1"
+		drvID = "drv_solo"
+	)
+	startTime := time.Now().Add(-10 * time.Minute).UTC().Format(time.RFC3339)
+	lister := &fakeOpenDriveLister{
+		rows: []OpenDriveRow{
+			{ID: drvID, VIN: vin, StartTime: startTime, StartChargeLevel: 75},
+		},
+	}
+
+	d := NewDetector(bus, testConfig(), testLogger(), NoopDetectorMetrics{}, lister)
+	if err := d.Start(context.Background()); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	defer func() { _ = d.Stop() }()
+
+	state := d.loadStateForTest(vin)
+	if state == nil {
+		t.Fatalf("no reconciled state for VIN %s", vin)
+	}
+	state.mu.Lock()
+	gotID := ""
+	if state.drive != nil {
+		gotID = state.drive.id
+	}
+	state.mu.Unlock()
+	if gotID != drvID {
+		t.Errorf("reconciled drive ID = %q, want %q", gotID, drvID)
+	}
+
+	if got := lister.endedSnapshot(); len(got) != 0 {
+		t.Errorf("MarkOrphanEnded must not be called when there is no older same-VIN orphan; got %v", got)
+	}
+	if got := d.activeCount.Load(); got != 1 {
+		t.Errorf("activeCount = %d, want 1", got)
+	}
+}
+
+// TestDetector_OrphansAcrossDifferentVINs proves grouping doesn't
+// break the cross-VIN case: three orphans, three different VINs →
+// all three reattached, none ended synchronously, activeCount == 3.
+func TestDetector_OrphansAcrossDifferentVINs(t *testing.T) {
+	bus := testBus()
+	defer bus.Close(context.Background())
+
+	startTime := time.Now().Add(-15 * time.Minute).UTC().Format(time.RFC3339)
+	lister := &fakeOpenDriveLister{
+		rows: []OpenDriveRow{
+			{ID: "drv_v1", VIN: "V1", StartTime: startTime, StartChargeLevel: 80},
+			{ID: "drv_v2", VIN: "V2", StartTime: startTime, StartChargeLevel: 60},
+			{ID: "drv_v3", VIN: "V3", StartTime: startTime, StartChargeLevel: 40},
+		},
+	}
+
+	d := NewDetector(bus, testConfig(), testLogger(), NoopDetectorMetrics{}, lister)
+	if err := d.Start(context.Background()); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	defer func() { _ = d.Stop() }()
+
+	want := map[string]string{
+		"V1": "drv_v1",
+		"V2": "drv_v2",
+		"V3": "drv_v3",
+	}
+	for vin, wantID := range want {
+		state := d.loadStateForTest(vin)
+		if state == nil {
+			t.Errorf("no reconciled state for VIN %s", vin)
+			continue
+		}
+		state.mu.Lock()
+		gotID := ""
+		if state.drive != nil {
+			gotID = state.drive.id
+		}
+		state.mu.Unlock()
+		if gotID != wantID {
+			t.Errorf("VIN %s drive ID = %q, want %q", vin, gotID, wantID)
+		}
+	}
+
+	if got := lister.endedSnapshot(); len(got) != 0 {
+		t.Errorf("MarkOrphanEnded must not be called across different VINs; got %v", got)
+	}
+	if got := d.activeCount.Load(); got != 3 {
+		t.Errorf("activeCount = %d, want 3 (one per VIN)", got)
+	}
+}
+
+// TestDetector_MarkOrphanEndedError_DoesNotFailStart mirrors the
+// existing fail-open posture of ListOpen: a DB hiccup on the side
+// channel must not block Detector.Start. The older orphan stays open
+// in the DB and gets retried on the next restart.
+func TestDetector_MarkOrphanEndedError_DoesNotFailStart(t *testing.T) {
+	bus := testBus()
+	defer bus.Close(context.Background())
+
+	const vin = "V1"
+	startTime := time.Now().UTC()
+	t1 := startTime.Add(-30 * time.Minute).Format(time.RFC3339)
+	t2 := startTime.Add(-10 * time.Minute).Format(time.RFC3339)
+
+	lister := &fakeOpenDriveLister{
+		rows: []OpenDriveRow{
+			{ID: "drv_older", VIN: vin, StartTime: t1, StartChargeLevel: 50},
+			{ID: "drv_latest", VIN: vin, StartTime: t2, StartChargeLevel: 45},
+		},
+		markEndedErr: errors.New("simulated DB outage on UPDATE Drive SET endTime"),
+	}
+
+	d := NewDetector(bus, testConfig(), testLogger(), NoopDetectorMetrics{}, lister)
+	if err := d.Start(context.Background()); err != nil {
+		t.Fatalf("Start must not propagate MarkOrphanEnded errors; got %v", err)
+	}
+	defer func() { _ = d.Stop() }()
+
+	// Latest still reattached — the fail-open path is per-older-row,
+	// not whole-reconciler.
+	state := d.loadStateForTest(vin)
+	if state == nil {
+		t.Fatalf("latest orphan must still be reattached when MarkOrphanEnded fails")
+	}
+	state.mu.Lock()
+	gotID := ""
+	if state.drive != nil {
+		gotID = state.drive.id
+	}
+	state.mu.Unlock()
+	if gotID != "drv_latest" {
+		t.Errorf("reconciled drive ID = %q, want %q", gotID, "drv_latest")
+	}
+
+	// activeCount still counts the reattach. We don't end-count the
+	// failed call, so the metric reflects "row is still open" without
+	// over-counting.
+	if got := d.activeCount.Load(); got != 1 {
+		t.Errorf("activeCount = %d, want 1 (reattach still counted on side-channel failure)", got)
+	}
+}
+
 func TestParseDriveStartTime(t *testing.T) {
 	tests := []struct {
 		name    string


### PR DESCRIPTION
## Prod evidence

`psql` against prod (post-MYR-146) returned 3 simultaneously-open `Drive` rows ALL for VIN `cmpulr5tc0003jr04322vfdea` — same vehicle ("My Tesla …8242"). Every one satisfies the `endTime IS NULL OR endTime = ''` predicate that `DriveRepo.ListOpen` uses on startup.

## Root cause (one-liner)

`reconcile.go:121` stored the reattached `vehicleState` keyed by VIN — when `ListOpen` returned >1 row for the same VIN, every iteration overwrote the previous; only the LAST orphan in iteration order survived. The dropped rows stayed open forever, reconciled-and-dropped again on every restart.

## Fix (sketch)

1. **Group orphans by VIN.** Within each group, the lexicographically-greatest `StartTime` is the "latest" (every writer today emits RFC3339 with a `Z` suffix, which is lex-sortable).
2. **In-memory reattach for the latest only** — existing watchdog/end path with `reconciled=true` so the MYR-146 micro-drive bypass continues to apply.
3. **Synchronous end for older orphans** via a new `OpenDriveLister.MarkOrphanEnded(ctx, driveID)` side channel. The cmd adapter implements it by calling `DriveRepo.Complete` with zero stats and `EndTime=now` — no new SQL, no schema change.
4. **`activeCount` increments only on the in-memory reattach path** (one per VIN). The side-channel end path doesn't go through the watchdog so it must not bump the metric.
5. **Fail-open on side-channel errors**, per-row. Matches the existing `ListOpen` posture: log Warn with the drive ID and continue. The row stays open and gets retried on the next restart.

The structural refactor splits the per-orphan `vehicleState` construction into `reattachOrphan` and the grouping into `groupOrphansByVIN`, keeping `reconcileOpenDrives` itself readable.

## Logging

The existing `reconciled orphaned drives` INFO log gains a second field:

- `reconciled_count` — VINs with at least one orphan (i.e. drives reattached in memory). Unchanged semantically.
- `ended_count` — NEW: older same-VIN orphans closed synchronously.

Ops can now see how often the duplicate case actually fires.

## Test summary

`internal/drives/reconcile_test.go` adds four cases on top of the existing MYR-146 coverage:

| Test | What it proves |
|------|----------------|
| `TestDetector_MultipleOrphansSameVIN_KeepsLatestEndsOlder` | Direct regression. 3 orphans for one VIN (input order shuffled) → latest in `d.states`, other two flow through `MarkOrphanEnded`, `activeCount == 1`. |
| `TestDetector_SingleOrphan_StillReattaches` | Guard for the existing MYR-146 happy path. 1 orphan → state populated, `MarkOrphanEnded` NOT called, `activeCount == 1`. |
| `TestDetector_OrphansAcrossDifferentVINs` | Grouping doesn't break cross-VIN. 3 orphans / 3 VINs → 3 reattaches, 0 ended, `activeCount == 3`. |
| `TestDetector_MarkOrphanEndedError_DoesNotFailStart` | Fail-open posture. Side-channel error → `Start` returns nil, latest still reattached, `activeCount == 1`. |

All four use prod-default `MinDuration` / `MinDistanceMiles` from `testConfig` (no zero overrides) per the MYR-146 review.

The `fakeOpenDriveLister` gains `endedIDs`/`markEndedErr` fields under a `sync.Mutex` so future parallel tests don't race the record path.

## Verification

```
go vet ./...                                    # ok
go build ./...                                  # ok
golangci-lint run ./...                         # 0 issues
go test ./internal/drives/... ./internal/store/... ./cmd/... -count=1   # all ok
```

File sizes (per the 300-line cap):

- `internal/drives/reconcile.go` — 260 (was 165)
- `internal/drives/detector.go` — 299 (unchanged)
- `internal/store/drive_repo_open.go` — 70 (unchanged)
- `cmd/telemetry-server/adapters.go` — 450 (was 423; **pre-existing condition** — file was already over the cap before MYR-147, only added the new adapter method)

## What this does NOT do

- No DB-schema changes.
- No new SQL. `DriveCompletion`'s zero-value path already produces a well-formed `UPDATE`.
- No changes to `MinDuration` / `MinDistanceMiles` defaults.
- The 3 currently-stuck DB rows are NOT manually touched — they get cleaned up by the next deploy after this merges (that is the live verification path).

Closes MYR-147