### PR TITLE
MYR-148 (B) Geocoder: prefer POI within 50m, leave PlaceName empty for residential

### DIFF
--- a/internal/geocode/distance.go
+++ b/internal/geocode/distance.go
@@ -1,0 +1,24 @@
+package geocode
+
+import "math"
+
+// haversineMeters returns the great-circle distance in meters between
+// two (lat, lng) coordinates using the haversine formula. The 6_371_000
+// constant is the WGS-84 mean Earth radius in meters.
+//
+// This is package-private and intentionally duplicated from
+// internal/store/writer_location_address.go to avoid a cross-package
+// dependency from store → geocode (which would invert the established
+// dependency direction). The store package already owns its own copy.
+func haversineMeters(lat1, lng1, lat2, lng2 float64) float64 {
+	const earthRadiusMeters = 6_371_000.0
+	const deg2rad = math.Pi / 180.0
+
+	dLat := (lat2 - lat1) * deg2rad
+	dLng := (lng2 - lng1) * deg2rad
+	a := math.Sin(dLat/2)*math.Sin(dLat/2) +
+		math.Cos(lat1*deg2rad)*math.Cos(lat2*deg2rad)*
+			math.Sin(dLng/2)*math.Sin(dLng/2)
+	c := 2 * math.Atan2(math.Sqrt(a), math.Sqrt(1-a))
+	return earthRadiusMeters * c
+}

--- a/internal/geocode/geocode.go
+++ b/internal/geocode/geocode.go
@@ -41,6 +41,18 @@ const defaultRateLimit = rate.Limit(10)
 // without exceeding the steady-state cap.
 const defaultRateBurst = 10
 
+// poiDistanceThreshold is the maximum distance, in meters, between the
+// queried coordinate and a POI feature's center for that POI to be
+// treated as the place name. Roughly a one-minute walk — close enough
+// that the driver is plausibly *at* the POI, far enough to absorb GPS
+// jitter and Mapbox's own POI centroid placement.
+//
+// Tuned for residential drives: Mapbox often returns a street-name
+// "address" feature as the closest result, which makes a poor label
+// ("Tributary Way"). Falling back to an empty PlaceName lets downstream
+// consumers render the full street address instead.
+const poiDistanceThreshold = 50.0
+
 // Result holds the output of a reverse geocode lookup.
 type Result struct {
 	// PlaceName is the short place name (e.g. "Thompson Hotel").
@@ -57,12 +69,21 @@ type Geocoder interface {
 }
 
 // mapboxResponse is the minimal subset of the Mapbox Geocoding API
-// response that we parse.
+// response that we parse. Feature ordering, place_type, and center are
+// all load-bearing — see ReverseGeocode for how features are ranked.
 type mapboxResponse struct {
-	Features []struct {
-		Text      string `json:"text"`
-		PlaceName string `json:"place_name"`
-	} `json:"features"`
+	Features []mapboxFeature `json:"features"`
+}
+
+// mapboxFeature is a single feature in a Mapbox Geocoding v5 response.
+// PlaceType is a list because Mapbox can tag a feature with multiple
+// types (e.g. ["poi", "landmark"]). Center is [lng, lat] per the v5
+// GeoJSON convention — NOT [lat, lng].
+type mapboxFeature struct {
+	Text      string     `json:"text"`
+	PlaceName string     `json:"place_name"`
+	PlaceType []string   `json:"place_type"`
+	Center    [2]float64 `json:"center"`
 }
 
 // MapboxGeocoder calls the Mapbox Geocoding API for reverse geocoding.
@@ -118,8 +139,11 @@ func (g *MapboxGeocoder) ReverseGeocode(ctx context.Context, lat, lng float64) (
 		}
 	}
 
+	// limit=5 gives us a small candidate set so we can prefer a nearby
+	// POI over the closest address-only feature when one is in walking
+	// range; see the post-decode ranking below.
 	url := fmt.Sprintf(
-		"https://api.mapbox.com/geocoding/v5/mapbox.places/%f,%f.json?access_token=%s&limit=1&types=poi,address",
+		"https://api.mapbox.com/geocoding/v5/mapbox.places/%f,%f.json?access_token=%s&limit=5&types=poi,address",
 		lng, lat, g.token,
 	)
 
@@ -148,10 +172,68 @@ func (g *MapboxGeocoder) ReverseGeocode(ctx context.Context, lat, lng float64) (
 		return nil, ErrNoResult
 	}
 
+	return buildResult(lat, lng, data.Features), nil
+}
+
+// buildResult selects the best PlaceName and Address from a Mapbox
+// response.
+//
+// PlaceName: returns the FIRST POI feature (in Mapbox's relevance order)
+// whose center is within poiDistanceThreshold of the queried coord. If
+// no POI qualifies, PlaceName is empty so downstream consumers fall
+// back to the street address — Mapbox's "address" features carry only
+// the street name in Text (e.g. "Tributary Way"), which makes a poor
+// label for a residential drive.
+//
+// Address: prefers the first address feature's full place_name; if none
+// is present, falls back to features[0].place_name so we never return
+// an empty address when the API gave us something.
+func buildResult(lat, lng float64, features []mapboxFeature) *Result {
+	var (
+		placeName   string
+		addressLine string
+		haveAddress bool
+	)
+
+	for _, f := range features {
+		if placeName == "" && isPOI(f.PlaceType) {
+			featLng, featLat := f.Center[0], f.Center[1]
+			if haversineMeters(lat, lng, featLat, featLng) <= poiDistanceThreshold {
+				placeName = f.Text
+			}
+		}
+		if !haveAddress && containsType(f.PlaceType, "address") {
+			addressLine = f.PlaceName
+			haveAddress = true
+		}
+	}
+
+	if !haveAddress {
+		addressLine = features[0].PlaceName
+	}
+
 	return &Result{
-		PlaceName: data.Features[0].Text,
-		Address:   data.Features[0].PlaceName,
-	}, nil
+		PlaceName: placeName,
+		Address:   addressLine,
+	}
+}
+
+// isPOI reports whether a Mapbox feature's place_type list includes the
+// "poi" tag.
+func isPOI(types []string) bool {
+	return containsType(types, "poi")
+}
+
+// containsType reports whether want appears in the given place_type
+// list. Mapbox features routinely carry multiple types
+// (e.g. ["poi", "landmark"]), so we cannot rely on the first element.
+func containsType(types []string, want string) bool {
+	for _, t := range types {
+		if t == want {
+			return true
+		}
+	}
+	return false
 }
 
 // NoopGeocoder always returns ErrNoResult, effectively disabling

--- a/internal/geocode/geocode_test.go
+++ b/internal/geocode/geocode_test.go
@@ -6,11 +6,21 @@ import (
 	"errors"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"sync/atomic"
 	"testing"
 	"time"
 
 	"golang.org/x/time/rate"
+)
+
+// queryLat / queryLng are the coordinates used as inputs across the
+// table-driven tests below. Other coordinates referenced in tests are
+// expressed as offsets from these so the haversine distance is
+// predictable: at this latitude, ~0.00009 deg in lng ≈ 10m.
+const (
+	queryLat = 30.2672
+	queryLng = -97.7431
 )
 
 func TestMapboxGeocoder_ReverseGeocode(t *testing.T) {
@@ -22,20 +32,121 @@ func TestMapboxGeocoder_ReverseGeocode(t *testing.T) {
 		wantErr    error
 	}{
 		{
-			name:       "successful geocode",
+			// POI ~11m east of the query coord (well within the 50m
+			// threshold) followed by an address feature. PlaceName
+			// should be the POI's text; Address should come from the
+			// address feature's place_name.
+			name:       "POI within threshold",
 			statusCode: http.StatusOK,
 			body: `{
-				"features": [{
-					"text": "Thompson Hotel",
-					"place_name": "Thompson Hotel, 506 San Jacinto Blvd, Austin, TX 78701"
-				}]
+				"features": [
+					{
+						"text": "Whole Foods Market",
+						"place_name": "Whole Foods Market, 525 N Lamar Blvd, Austin, TX 78703",
+						"place_type": ["poi"],
+						"center": [-97.7430, 30.2672]
+					},
+					{
+						"text": "525 N Lamar Blvd",
+						"place_name": "525 N Lamar Blvd, Austin, TX 78703",
+						"place_type": ["address"],
+						"center": [-97.7431, 30.2672]
+					}
+				]
 			}`,
 			wantResult: &Result{
-				PlaceName: "Thompson Hotel",
-				Address:   "Thompson Hotel, 506 San Jacinto Blvd, Austin, TX 78701",
+				PlaceName: "Whole Foods Market",
+				Address:   "525 N Lamar Blvd, Austin, TX 78703",
 			},
 		},
 		{
+			// POI ~200m north of the query coord (outside threshold);
+			// an address feature is at the query coord. PlaceName must
+			// be empty so downstream consumers fall back to the street
+			// address.
+			name:       "POI too far",
+			statusCode: http.StatusOK,
+			body: `{
+				"features": [
+					{
+						"text": "Far Away Cafe",
+						"place_name": "Far Away Cafe, 999 Elsewhere St, Austin, TX",
+						"place_type": ["poi"],
+						"center": [-97.7431, 30.2690]
+					},
+					{
+						"text": "100 Tributary Way",
+						"place_name": "100 Tributary Way, Austin, TX 78703",
+						"place_type": ["address"],
+						"center": [-97.7431, 30.2672]
+					}
+				]
+			}`,
+			wantResult: &Result{
+				PlaceName: "",
+				Address:   "100 Tributary Way, Austin, TX 78703",
+			},
+		},
+		{
+			// No POI features at all (residential drive). PlaceName
+			// stays empty; Address comes from the first address
+			// feature's place_name.
+			name:       "no POI at all",
+			statusCode: http.StatusOK,
+			body: `{
+				"features": [
+					{
+						"text": "Tributary Way",
+						"place_name": "1234 Tributary Way, Austin, TX 78704",
+						"place_type": ["address"],
+						"center": [-97.7431, 30.2672]
+					}
+				]
+			}`,
+			wantResult: &Result{
+				PlaceName: "",
+				Address:   "1234 Tributary Way, Austin, TX 78704",
+			},
+		},
+		{
+			// Multiple POIs in the response: POI "A" is within
+			// threshold and appears FIRST in Mapbox's relevance order;
+			// POI "B" is also within threshold but listed later. We
+			// trust Mapbox's ranking and pick the FIRST qualifying POI
+			// (not the geometrically closest), so PlaceName == "A".
+			name:       "multiple POIs, first qualifying wins",
+			statusCode: http.StatusOK,
+			body: `{
+				"features": [
+					{
+						"text": "A",
+						"place_name": "A, 100 Main St",
+						"place_type": ["poi"],
+						"center": [-97.7428, 30.2672]
+					},
+					{
+						"text": "B",
+						"place_name": "B, 200 Side St",
+						"place_type": ["poi"],
+						"center": [-97.74305, 30.2672]
+					},
+					{
+						"text": "100 Main St",
+						"place_name": "100 Main St, Austin, TX",
+						"place_type": ["address"],
+						"center": [-97.7431, 30.2672]
+					}
+				]
+			}`,
+			wantResult: &Result{
+				PlaceName: "A",
+				Address:   "100 Main St, Austin, TX",
+			},
+		},
+		{
+			// API returns zero features — preserved ErrNoResult
+			// behavior so callers (writer_drives, writer_location_address)
+			// can treat it as a soft-fail and skip persistence.
 			name:       "no features returned",
 			statusCode: http.StatusOK,
 			body:       `{"features": []}`,
@@ -80,15 +191,12 @@ func TestMapboxGeocoder_ReverseGeocode(t *testing.T) {
 				token:  "test-token",
 				client: srv.Client(),
 			}
-			// Override the API URL by using a custom transport that
-			// redirects requests to the test server.
-			origURL := srv.URL
 			g.client.Transport = &rewriteTransport{
 				base:    srv.Client().Transport,
-				baseURL: origURL,
+				baseURL: srv.URL,
 			}
 
-			result, err := g.ReverseGeocode(context.Background(), 30.2672, -97.7431)
+			result, err := g.ReverseGeocode(context.Background(), queryLat, queryLng)
 
 			if tt.wantErr != nil {
 				if err == nil {
@@ -113,17 +221,58 @@ func TestMapboxGeocoder_ReverseGeocode(t *testing.T) {
 	}
 }
 
+// TestMapboxGeocoder_AddressFallbackToFirstFeature exercises the
+// fallback branch in buildResult: if no feature is tagged "address",
+// we use features[0].place_name so the caller always gets something
+// rather than an empty string.
+func TestMapboxGeocoder_AddressFallbackToFirstFeature(t *testing.T) {
+	body := `{
+		"features": [
+			{
+				"text": "Lonely POI",
+				"place_name": "Lonely POI, somewhere",
+				"place_type": ["poi"],
+				"center": [-97.7431, 30.2690]
+			}
+		]
+	}`
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(body))
+	}))
+	defer srv.Close()
+
+	g := &MapboxGeocoder{token: "test-token", client: srv.Client()}
+	g.client.Transport = &rewriteTransport{base: srv.Client().Transport, baseURL: srv.URL}
+
+	result, err := g.ReverseGeocode(context.Background(), queryLat, queryLng)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// POI is 200m away, so PlaceName is empty.
+	if result.PlaceName != "" {
+		t.Errorf("PlaceName = %q, want empty", result.PlaceName)
+	}
+	// No address-typed feature, so Address falls back to features[0].
+	if result.Address != "Lonely POI, somewhere" {
+		t.Errorf("Address = %q, want fallback to features[0].place_name", result.Address)
+	}
+}
+
 func TestMapboxGeocoder_RequestFormat(t *testing.T) {
 	var capturedPath string
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		capturedPath = r.URL.String()
 		w.Header().Set("Content-Type", "application/json")
 		_ = json.NewEncoder(w).Encode(mapboxResponse{
-			Features: []struct {
-				Text      string `json:"text"`
-				PlaceName string `json:"place_name"`
-			}{
-				{Text: "Test", PlaceName: "Test Place"},
+			Features: []mapboxFeature{
+				{
+					Text:      "Test",
+					PlaceName: "Test Place",
+					PlaceType: []string{"address"},
+					Center:    [2]float64{-96.8518, 33.0860},
+				},
 			},
 		})
 	}))
@@ -144,12 +293,16 @@ func TestMapboxGeocoder_RequestFormat(t *testing.T) {
 	}
 
 	// Verify the URL contains the correct coordinates in lng,lat order
-	// (Mapbox expects lng,lat, not lat,lng).
+	// (Mapbox expects lng,lat, not lat,lng) and the bumped limit param.
 	if capturedPath == "" {
 		t.Fatal("no request was captured")
 	}
-	// The URL should have lng (-96.8518) before lat (33.0860).
-	// Just verify the token is present and types param is set.
+	if !strings.Contains(capturedPath, "limit=5") {
+		t.Errorf("expected limit=5 in URL, got: %s", capturedPath)
+	}
+	if !strings.Contains(capturedPath, "types=poi,address") {
+		t.Errorf("expected types=poi,address in URL, got: %s", capturedPath)
+	}
 	t.Logf("captured path: %s", capturedPath)
 }
 
@@ -255,7 +408,7 @@ func TestMapboxGeocoder_InvalidCoordinate(t *testing.T) {
 func TestMapboxGeocoder_ClientSideRateLimiter(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
-		_, _ = w.Write([]byte(`{"features":[{"text":"X","place_name":"X"}]}`))
+		_, _ = w.Write([]byte(`{"features":[{"text":"X","place_name":"X","place_type":["address"],"center":[-97,30]}]}`))
 	}))
 	defer srv.Close()
 
@@ -293,7 +446,7 @@ func TestMapboxGeocoder_ClientSideRateLimiter(t *testing.T) {
 func TestMapboxGeocoder_RateLimiterCancelledContext(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
-		_, _ = w.Write([]byte(`{"features":[{"text":"X","place_name":"X"}]}`))
+		_, _ = w.Write([]byte(`{"features":[{"text":"X","place_name":"X","place_type":["address"],"center":[-97,30]}]}`))
 	}))
 	defer srv.Close()
 


### PR DESCRIPTION
## Symptom

Residential drives in the UI label as "Tributary Way" (or similar street-name-only strings) instead of a useful place name. Root cause: `internal/geocode/geocode.go` queried Mapbox with `limit=1&types=poi,address` and unconditionally used `features[0].text` as the PlaceName. For residential coords the closest feature is an `address` result whose `text` is the street name — a poor label.

## Fix

- Bump Mapbox query `limit=1` → `limit=5` (still `types=poi,address`).
- Extend the response struct to parse `place_type []string` and `center [2]float64` (Mapbox v5 ships `[lng, lat]`).
- Walk the feature list and pick the FIRST POI feature whose center is within **50m** of the queried coordinate as `Result.PlaceName`. If no POI qualifies, leave `PlaceName` empty.
- Address selection prefers the first `address`-typed feature's `place_name`; falls back to `features[0].place_name` if none is present.
- `ErrNoResult` behavior for zero features is preserved.

The empty-`PlaceName` → omit-JSON-key plumbing in `writer_drives.go` and `writer_location_address.go` is already correct (mask spec emits `,omitempty`, `toMaskMap` drops empties). Those files are untouched.

`haversineMeters` is duplicated package-private in `internal/geocode` to avoid an upward dependency from `internal/store` on `internal/geocode`.

### Threshold value

**50m** — roughly a one-minute walk. Tight enough that "you're at the Whole Foods" stays true even with GPS jitter and Mapbox centroid offset; loose enough that we don't reject a real POI hit because the Mapbox centroid is on the far side of the parking lot.

## Sample expected output

**Whole Foods Market parking lot** (~10m from Mapbox POI centroid):
```
PlaceName: "Whole Foods Market"
Address:   "525 N Lamar Blvd, Austin, TX 78703"
```

**Residential street, 1234 Tributary Way** (no POI within 50m):
```
PlaceName: ""                                  // omitted in JSON output
Address:   "1234 Tributary Way, Austin, TX 78704"
```

Downstream consumers (testbench, SDK clients) fall back to `Address` when `PlaceName` is missing.

## Test plan

- [x] `go vet ./...`
- [x] `go build ./...`
- [x] `golangci-lint run ./...` (0 issues)
- [x] `go test ./internal/geocode/... ./internal/store/... -count=1` (all pass)
- [x] Table-driven coverage:
  - POI within 50m → POI text wins
  - POI 200m away + address feature → empty PlaceName, address feature's place_name
  - No POI features → empty PlaceName, features[0].place_name
  - Multiple POIs in threshold → first-in-relevance-order wins
  - Zero features → ErrNoResult preserved
  - Address fallback to features[0] when no address-typed feature is present
- [x] Existing rate-limiter, context-cancellation, invalid-coord, and noop-geocoder tests still pass

## Out of scope

- Testbench display changes — handled by the sibling agent's MYR-148 (A) PR.
- `writer_drives.go` / `writer_location_address.go` — pass-through, unchanged.
- Schema changes / migrations — none needed.

Closes MYR-148

🤖 Generated with [Claude Code](https://claude.com/claude-code)