### PR TITLE
MYR-151 Fix drives recording 0 FSD miles (baseline never captured)

### DIFF
--- a/internal/drives/detector.go
+++ b/internal/drives/detector.go
@@ -289,6 +289,15 @@ func (d *Detector) handleTelemetry(te events.VehicleTelemetryEvent) {
 		state.lastLocation = loc
 	}
 
+	// Cache FSD miles whenever present (including while idle) so startDrive
+	// can seed the drive baseline from the most recent value — the
+	// gear-change event that starts a drive almost never carries FSD miles
+	// because it streams on a much slower cadence than gear.
+	if fsd, ok := extractFloatField(te.Fields, telemetry.FieldFSDMiles); ok {
+		state.lastFSDMiles = fsd
+		state.fsdMilesKnown = true
+	}
+
 	switch state.status {
 	case StatusIdle:
 		d.handleIdle(state, vin, te)
@@ -296,4 +305,3 @@ func (d *Detector) handleTelemetry(te events.VehicleTelemetryEvent) {
 		d.handleDriving(state, vin, te)
 	}
 }
-

--- a/internal/drives/detector_test.go
+++ b/internal/drives/detector_test.go
@@ -636,6 +636,87 @@ func TestDetector_StatsAccuracy(t *testing.T) {
 	}
 }
 
+// TestDetector_FSDMilesAcrossCadenceMismatch reproduces the real-world field
+// cadence: gear streams every 1s but FSD miles only arrives on a much slower
+// cadence (60s / 1-mile delta), so the gear-change frame that starts a drive
+// carries no FSD value. The detector must seed the FSD baseline from the most
+// recent value cached while idle (or, failing that, the first in-drive sample)
+// rather than recording zero. Regression test for the bug where FSD miles was
+// always reported as 0 because startFSDMiles was never captured.
+func TestDetector_FSDMilesAcrossCadenceMismatch(t *testing.T) {
+	bus := testBus()
+	defer bus.Close(context.Background())
+
+	cfg := testConfig()
+	cfg.EndDebounce = 20 * time.Millisecond
+	cfg.MinDuration = 0
+	cfg.MinDistanceMiles = 0
+
+	d := NewDetector(bus, cfg, testLogger(), NoopDetectorMetrics{}, nil)
+	if err := d.Start(context.Background()); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	defer func() { _ = d.Stop() }()
+
+	startedCh := subscribeTopic(t, bus, events.TopicDriveStarted)
+	endedCh := subscribeTopic(t, bus, events.TopicDriveEnded)
+
+	now := time.Now()
+
+	// Idle FSD tick: the vehicle reports an FSD value while parked. This is
+	// the baseline the next drive should use.
+	idleFields := map[string]events.TelemetryValue{
+		string(telemetry.FieldGear):     {StringVal: ptr("P")},
+		string(telemetry.FieldFSDMiles): {FloatVal: ptr(200.0)},
+	}
+	publishTelemetry(t, bus, telemetryEvent("VIN_FSD", now, idleFields))
+
+	// Drive starts on a gear-change frame that carries NO FSD field — the
+	// realistic case given the 1s gear / 60s FSD cadence mismatch.
+	startFields := map[string]events.TelemetryValue{
+		string(telemetry.FieldGear):     {StringVal: ptr("D")},
+		string(telemetry.FieldSpeed):    {FloatVal: ptr(0.0)},
+		string(telemetry.FieldLocation): {LocationVal: &events.Location{Latitude: 33.0, Longitude: -96.0}},
+	}
+	publishTelemetry(t, bus, telemetryEvent("VIN_FSD", now.Add(1*time.Second), startFields))
+	if _, ok := waitForEvent(startedCh); !ok {
+		t.Fatal("timed out waiting for DriveStartedEvent")
+	}
+
+	// A later in-drive frame carries an updated FSD value (next 60s tick).
+	midFields := map[string]events.TelemetryValue{
+		string(telemetry.FieldGear):     {StringVal: ptr("D")},
+		string(telemetry.FieldSpeed):    {FloatVal: ptr(60.0)},
+		string(telemetry.FieldLocation): {LocationVal: &events.Location{Latitude: 33.2, Longitude: -96.2}},
+		string(telemetry.FieldFSDMiles): {FloatVal: ptr(208.0)},
+	}
+	publishTelemetry(t, bus, telemetryEvent("VIN_FSD", now.Add(61*time.Second), midFields))
+
+	// Park to end the drive, at a distinct location so the route has nonzero
+	// distance (needed to exercise the FSD-percentage calculation).
+	stopFields := map[string]events.TelemetryValue{
+		string(telemetry.FieldGear):     {StringVal: ptr("P")},
+		string(telemetry.FieldSpeed):    {FloatVal: ptr(0.0)},
+		string(telemetry.FieldLocation): {LocationVal: &events.Location{Latitude: 33.3, Longitude: -96.3}},
+	}
+	publishTelemetry(t, bus, telemetryEvent("VIN_FSD", now.Add(120*time.Second), stopFields))
+
+	evt, ok := waitForEvent(endedCh)
+	if !ok {
+		t.Fatal("timed out waiting for DriveEndedEvent")
+	}
+	stats := evt.Payload.(events.DriveEndedEvent).Stats
+
+	// Baseline 200 (from the idle tick) → 208 = 8 FSD miles. Before the fix
+	// this was 0 because the gear-change start frame carried no FSD field.
+	if want := 8.0; stats.FSDMiles != want {
+		t.Errorf("FSDMiles: got %f, want %f", stats.FSDMiles, want)
+	}
+	if stats.FSDPercentage <= 0 {
+		t.Errorf("FSDPercentage: got %f, want > 0", stats.FSDPercentage)
+	}
+}
+
 func TestDetector_DisconnectEndsDrive(t *testing.T) {
 	bus := testBus()
 	defer bus.Close(context.Background())
@@ -1041,7 +1122,7 @@ func TestExtractLocation_IgnoresOriginLocation(t *testing.T) {
 			name: "both location and originLocation present, returns GPS location",
 			fields: map[string]events.TelemetryValue{
 				string(telemetry.FieldLocation):       {LocationVal: gpsLoc},
-				string(telemetry.FieldOriginLocation):  {LocationVal: navOrigin},
+				string(telemetry.FieldOriginLocation): {LocationVal: navOrigin},
 			},
 			want: gpsLoc,
 		},
@@ -1102,10 +1183,10 @@ func TestDetector_DriveStartUsesGPSNotNavOrigin(t *testing.T) {
 
 	// Send telemetry with both GPS location and nav origin — GPS should win.
 	fields := map[string]events.TelemetryValue{
-		string(telemetry.FieldGear):            {StringVal: ptr("D")},
-		string(telemetry.FieldSpeed):           {FloatVal: ptr(10.0)},
-		string(telemetry.FieldLocation):        {LocationVal: &events.Location{Latitude: 32.95, Longitude: -96.73}},
-		string(telemetry.FieldOriginLocation):  {LocationVal: &events.Location{Latitude: 33.09, Longitude: -96.82}},
+		string(telemetry.FieldGear):           {StringVal: ptr("D")},
+		string(telemetry.FieldSpeed):          {FloatVal: ptr(10.0)},
+		string(telemetry.FieldLocation):       {LocationVal: &events.Location{Latitude: 32.95, Longitude: -96.73}},
+		string(telemetry.FieldOriginLocation): {LocationVal: &events.Location{Latitude: 33.09, Longitude: -96.82}},
 	}
 	publishTelemetry(t, bus, telemetryEvent("VIN_NAV", now, fields))
 
@@ -1163,32 +1244,32 @@ func TestDetector_OriginLocationOnlyDoesNotCacheLocation(t *testing.T) {
 
 func TestHaversine(t *testing.T) {
 	tests := []struct {
-		name     string
-		lat1     float64
-		lon1     float64
-		lat2     float64
-		lon2     float64
-		wantMi   float64
+		name      string
+		lat1      float64
+		lon1      float64
+		lat2      float64
+		lon2      float64
+		wantMi    float64
 		tolerance float64
 	}{
 		{
-			name:      "same point",
-			lat1:      33.09, lon1: -96.82,
-			lat2:      33.09, lon2: -96.82,
+			name: "same point",
+			lat1: 33.09, lon1: -96.82,
+			lat2: 33.09, lon2: -96.82,
 			wantMi:    0,
 			tolerance: 0.001,
 		},
 		{
-			name:      "short distance (Frisco to Plano ~5mi)",
-			lat1:      33.15, lon1: -96.82,
-			lat2:      33.02, lon2: -96.77,
+			name: "short distance (Frisco to Plano ~5mi)",
+			lat1: 33.15, lon1: -96.82,
+			lat2: 33.02, lon2: -96.77,
 			wantMi:    9.3, // approximate
 			tolerance: 1.0,
 		},
 		{
-			name:      "moderate distance (Dallas to Austin ~182mi great circle)",
-			lat1:      32.78, lon1: -96.80,
-			lat2:      30.27, lon2: -97.74,
+			name: "moderate distance (Dallas to Austin ~182mi great circle)",
+			lat1: 32.78, lon1: -96.80,
+			lat2: 30.27, lon2: -97.74,
 			wantMi:    182.0,
 			tolerance: 5.0,
 		},
@@ -1276,9 +1357,10 @@ func TestRedactVIN(t *testing.T) {
 
 func TestCalculateStats_FSDClampedToZero(t *testing.T) {
 	drive := &activeDrive{
-		startedAt:     time.Now(),
-		startFSDMiles: 100.0,
-		lastFSDMiles:  50.0, // counter reset mid-drive
+		startedAt:      time.Now(),
+		startFSDMiles:  100.0,
+		lastFSDMiles:   50.0, // counter reset mid-drive
+		fsdBaselineSet: true,
 		lastTimestamp:  time.Now().Add(5 * time.Minute),
 	}
 
@@ -1288,11 +1370,28 @@ func TestCalculateStats_FSDClampedToZero(t *testing.T) {
 	}
 }
 
+// TestCalculateStats_FSDBaselineUnset verifies that when no FSD value was ever
+// observed for a drive, FSD miles is reported as zero rather than the full
+// cumulative "miles since reset" counter.
+func TestCalculateStats_FSDBaselineUnset(t *testing.T) {
+	drive := &activeDrive{
+		startedAt:     time.Now(),
+		lastFSDMiles:  5000.0, // cumulative counter — must NOT be reported as-is
+		lastTimestamp: time.Now().Add(5 * time.Minute),
+		// fsdBaselineSet defaults to false.
+	}
+
+	stats := calculateStats(drive)
+	if stats.FSDMiles != 0 {
+		t.Errorf("FSDMiles: got %f, want 0 (no baseline observed)", stats.FSDMiles)
+	}
+}
+
 func TestCalculateStats_ZeroSpeedCount(t *testing.T) {
 	drive := &activeDrive{
-		startedAt:    time.Now(),
-		speedCount:   0,
-		speedSum:     0,
+		startedAt:     time.Now(),
+		speedCount:    0,
+		speedSum:      0,
 		lastTimestamp: time.Now().Add(5 * time.Minute),
 	}
 

--- a/internal/drives/state.go
+++ b/internal/drives/state.go
@@ -53,6 +53,17 @@ type vehicleState struct {
 	// start without a location in the triggering event.
 	lastLocation *events.Location
 
+	// lastFSDMiles caches the most recent fsdMilesSinceReset value seen for
+	// this vehicle, including while idle. fsdMilesKnown reports whether a
+	// value has ever been observed. FSD miles is a cumulative "miles since
+	// reset" counter streamed on a slow cadence (60s / 1-mile delta) while
+	// gear streams every 1s, so the gear-change event that starts a drive
+	// almost never carries FSD miles. Caching it here lets startDrive seed
+	// the drive baseline from the last value seen before the drive began —
+	// the correct baseline, since FSD miles do not accumulate while parked.
+	lastFSDMiles  float64
+	fsdMilesKnown bool
+
 	// lastTelemetryAt records the wall-clock time of the most recently
 	// received telemetry event for this vehicle (any field, gear-bearing
 	// or not). The end-condition watchdog uses this to detect drives
@@ -63,22 +74,23 @@ type vehicleState struct {
 
 // activeDrive accumulates data during an in-progress drive.
 type activeDrive struct {
-	id            string
-	startedAt     time.Time
-	startLocation events.Location
-	routePoints   []events.RoutePoint
-	maxSpeed      float64
-	speedSum      float64 // running sum for average calculation
-	speedCount    int     // number of speed samples
-	startCharge   float64 // SOC at drive start (percent)
-	startOdometer float64 // odometer at drive start (miles)
-	startEnergy   float64 // energyRemaining at drive start (kWh)
-	startFSDMiles float64 // fsdMilesSinceReset at drive start
-	lastFSDMiles  float64 // most recent fsdMilesSinceReset seen
-	lastLocation  events.Location
-	lastTimestamp time.Time
-	lastSOC       float64 // most recent SOC for EndChargeLevel
-	lastEnergy    float64 // most recent energyRemaining for EnergyDelta
+	id             string
+	startedAt      time.Time
+	startLocation  events.Location
+	routePoints    []events.RoutePoint
+	maxSpeed       float64
+	speedSum       float64 // running sum for average calculation
+	speedCount     int     // number of speed samples
+	startCharge    float64 // SOC at drive start (percent)
+	startOdometer  float64 // odometer at drive start (miles)
+	startEnergy    float64 // energyRemaining at drive start (kWh)
+	startFSDMiles  float64 // fsdMilesSinceReset baseline for this drive
+	lastFSDMiles   float64 // most recent fsdMilesSinceReset seen
+	fsdBaselineSet bool    // true once startFSDMiles holds a real observed value
+	lastLocation   events.Location
+	lastTimestamp  time.Time
+	lastSOC        float64 // most recent SOC for EndChargeLevel
+	lastEnergy     float64 // most recent energyRemaining for EnergyDelta
 
 	// reconciled is true when this drive was reattached from a DB row
 	// orphaned by a previous restart (MYR-146). endDrive bypasses the

--- a/internal/drives/stats.go
+++ b/internal/drives/stats.go
@@ -65,13 +65,15 @@ func calculateStats(drive *activeDrive) events.DriveStats {
 		energyDelta = 0
 	}
 
-	fsdMiles := drive.lastFSDMiles - drive.startFSDMiles
-	if fsdMiles < 0 {
-		fsdMiles = 0
-	}
-	// If start FSD miles was not captured, report zero.
-	if drive.startFSDMiles == 0 {
-		fsdMiles = 0
+	// FSD miles is the delta of the cumulative "miles since reset" counter
+	// over the drive. Only meaningful if a baseline was actually observed;
+	// otherwise report zero rather than the full cumulative counter.
+	var fsdMiles float64
+	if drive.fsdBaselineSet {
+		fsdMiles = drive.lastFSDMiles - drive.startFSDMiles
+		if fsdMiles < 0 {
+			fsdMiles = 0
+		}
 	}
 
 	var fsdPercentage float64

--- a/internal/drives/transitions.go
+++ b/internal/drives/transitions.go
@@ -51,8 +51,14 @@ func (d *Detector) handleDriving(state *vehicleState, vin string, te events.Vehi
 		}
 	}
 
-	// Update FSD miles tracking.
+	// Update FSD miles tracking. If the baseline was never seeded at drive
+	// start (no FSD value had been observed yet), lazily capture it from the
+	// first in-drive sample so the end-of-drive diff has a valid reference.
 	if fsd, ok := extractFloatField(te.Fields, telemetry.FieldFSDMiles); ok {
+		if !drive.fsdBaselineSet {
+			drive.startFSDMiles = fsd
+			drive.fsdBaselineSet = true
+		}
 		drive.lastFSDMiles = fsd
 	}
 
@@ -126,25 +132,27 @@ func (d *Detector) startDrive(state *vehicleState, vin string, te events.Vehicle
 		startEnergy = energy
 	}
 
-	var startFSDMiles float64
-	if fsd, ok := extractFloatField(te.Fields, telemetry.FieldFSDMiles); ok {
-		startFSDMiles = fsd
-	}
-
+	// Seed the FSD baseline from the most recent value seen for this vehicle
+	// (cached in handleTelemetry, including while idle). FSD miles is a
+	// cumulative "miles since reset" counter that does not advance while
+	// parked, so the last value before the drive is the correct baseline.
+	// If no value has ever been observed, leave the baseline unset —
+	// handleDriving lazily captures it from the first in-drive FSD sample.
 	drive := &activeDrive{
-		id:            driveID,
-		startedAt:     te.CreatedAt,
-		startLocation: startLoc,
-		maxSpeed:      0,
-		startCharge:   startCharge,
-		startOdometer: startOdometer,
-		startEnergy:   startEnergy,
-		startFSDMiles: startFSDMiles,
-		lastFSDMiles:  startFSDMiles,
-		lastLocation:  startLoc,
+		id:             driveID,
+		startedAt:      te.CreatedAt,
+		startLocation:  startLoc,
+		maxSpeed:       0,
+		startCharge:    startCharge,
+		startOdometer:  startOdometer,
+		startEnergy:    startEnergy,
+		startFSDMiles:  state.lastFSDMiles,
+		lastFSDMiles:   state.lastFSDMiles,
+		fsdBaselineSet: state.fsdMilesKnown,
+		lastLocation:   startLoc,
 		lastTimestamp:  te.CreatedAt,
-		lastSOC:       startCharge,
-		lastEnergy:    startEnergy,
+		lastSOC:        startCharge,
+		lastEnergy:     startEnergy,
 	}
 
 	state.status = StatusDriving
@@ -206,4 +214,3 @@ func (d *Detector) cancelDebounce(state *vehicleState, vin string) {
 		slog.String("vin", redactVIN(vin)),
 	)
 }
-


### PR DESCRIPTION
## Summary

Every completed drive recorded `fsdMiles = 0` (and `fsdPercentage = 0`) even when the vehicle drove on FSD. The data **is** streaming from Tesla — the bug was in how the drive detector captured the FSD baseline.

`SelfDrivingMilesSinceReset` is a cumulative "miles since reset" counter, so a drive's FSD = `end − start`. But gear streams every **1s** while FSD streams every **60s (1-mile delta)**, so the gear-change frame that starts a drive almost never carried FSD → `startFSDMiles` was `0`, and a guard zeroed the result to avoid reporting the full cumulative counter.

## Fix
- `detector.go` — cache the latest FSD value per vehicle, including while idle.
- `transitions.go` — seed the drive baseline from that cache at start (last idle value is the correct baseline; FSD doesn't accrue while parked), with a lazy fallback to the first in-drive sample.
- `state.go` — explicit `fsdBaselineSet` flag, replacing the `== 0` sentinel.
- `stats.go` — only compute the delta when a baseline was actually observed.

## Tests
- New: cadence-mismatch regression (drive starts with no FSD field, FSD arrives mid-drive → correct delta of 8 mi, not 0).
- New: unset-baseline (no FSD ever observed → 0, not the raw cumulative counter).
- Updated the existing clamp test to set `fsdBaselineSet` so it exercises the real negative-delta path.
- `go vet`, `golangci-lint`, full `go test ./...` green.

## Scope
No schema/contract change — `fsdMiles`/`fsdPercentage` columns already exist (P0). This only corrects computation. Exposing FSD on `drives.list` (MYR-152), the TS SDK (MYR-153), and the testbench UI (MYR-154) are tracked separately.

Closes MYR-151.

🤖 Generated with [Claude Code](https://claude.com/claude-code)