### PR TITLE
MYR-155 Add resend interval to FSD/odometer counters (fix cold-start 0 FSD)

### DIFF
--- a/internal/telemetry/fleet_api_fields.go
+++ b/internal/telemetry/fleet_api_fields.go
@@ -155,8 +155,20 @@ func DefaultFieldConfig() map[string]FieldConfig {
 		FleetFieldLocked:      {IntervalSeconds: 30},
 		FleetFieldSentryMode:  {IntervalSeconds: 30},
 
-		// Safety / ADAS — low frequency
-		FleetFieldMilesSinceReset:    {IntervalSeconds: 60, MinimumDelta: &oneMile},
-		FleetFieldFSDMilesSinceReset: {IntervalSeconds: 60, MinimumDelta: &oneMile},
+		// Safety / ADAS — low frequency.
+		//
+		// MYR-155: these two are cumulative "miles since reset" counters
+		// gated by MinimumDelta (1 mile), so they ONLY emit while the value
+		// is changing — i.e. while driving. They go silent the moment the
+		// car parks. A server that (re)starts while a vehicle is parked
+		// therefore never receives an FSD value until that car drives a full
+		// FSD mile, leaving the drive detector with no FSD baseline at the
+		// start of the first post-restart drive (it records 0). The
+		// ResendIntervalSeconds forces a periodic re-emit even when
+		// unchanged — exactly the "server that misses the initial emission"
+		// case the file header calls out — so the cache (and the snapshot)
+		// re-warm within a minute of any reconnect, before a drive begins.
+		FleetFieldMilesSinceReset:    {IntervalSeconds: 60, MinimumDelta: &oneMile, ResendIntervalSeconds: intPtr(60)},
+		FleetFieldFSDMilesSinceReset: {IntervalSeconds: 60, MinimumDelta: &oneMile, ResendIntervalSeconds: intPtr(60)},
 	}
 }

--- a/internal/telemetry/fleet_api_test.go
+++ b/internal/telemetry/fleet_api_test.go
@@ -507,6 +507,39 @@ func TestDefaultFieldConfig(t *testing.T) {
 	}
 }
 
+// TestDefaultFieldConfig_MileageCountersResend verifies the cumulative
+// "miles since reset" counters carry a ResendIntervalSeconds (MYR-155).
+// Without it, these delta-gated fields go silent while parked, so a
+// server that (re)starts during a parked window never receives an FSD
+// value until the car drives a full mile — leaving the drive detector
+// with no FSD baseline for the first post-restart drive (records 0).
+func TestDefaultFieldConfig_MileageCountersResend(t *testing.T) {
+	t.Parallel()
+
+	fields := DefaultFieldConfig()
+
+	for _, name := range []string{FleetFieldMilesSinceReset, FleetFieldFSDMilesSinceReset} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			fc, ok := fields[name]
+			if !ok {
+				t.Fatalf("field %q not found in default config", name)
+			}
+			if fc.ResendIntervalSeconds == nil {
+				t.Fatalf("field %q must set ResendIntervalSeconds so the value re-emits "+
+					"while parked / after reconnect (MYR-155)", name)
+			}
+			if *fc.ResendIntervalSeconds != 60 {
+				t.Errorf("resend_interval_seconds = %d, want 60", *fc.ResendIntervalSeconds)
+			}
+			// The delta gate must remain so live driving still emits on change.
+			if fc.MinimumDelta == nil || *fc.MinimumDelta != 1 {
+				t.Errorf("minimum_delta must stay 1 mile alongside the resend interval")
+			}
+		})
+	}
+}
+
 // TestDefaultFieldConfig_CoversAllTrackedFields ensures every field in
 // fieldMap has a corresponding entry in DefaultFieldConfig. This prevents
 // the bug where a field is decoded but never requested from the vehicle.


### PR DESCRIPTION
## Problem
The first FSD drive after a deploy recorded `fsdMiles = 0` despite FSD being used the whole way. Root cause is **not** a missing field — `FSD since reset = 6340 mi` is decoded fine. Timing proves it: server restarted `03:56:25Z`, drive started `04:01:03Z` (4m38s later) with cold per-vehicle state.

`SelfDrivingMilesSinceReset` is **delta-gated** (`IntervalSeconds: 60, MinimumDelta: 1mi`): it only emits while *changing* (i.e. driving) and goes silent when parked. So a freshly-restarted server has no FSD baseline for any vehicle until that car drives a full FSD mile — and the first post-restart drive records 0.

## Fix
Add `ResendIntervalSeconds: 60` to `FleetFieldFSDMilesSinceReset` and its sibling `FleetFieldMilesSinceReset`, so Tesla re-emits the current value even when unchanged. The in-memory cache (and the snapshot) re-warm within ~a minute of any reconnect, before a drive starts — MYR-151's existing baseline logic then works. This is exactly the *"server that misses the initial emission never receives the data"* case the field-config header already documents for the nav fields.

### Why this over the originally-planned DB-seed
Seeding the baseline from `Vehicle.fsdMilesSinceReset` on cold start was the other option, but it (a) risks seeding a stale `0` for never-reported vehicles → reintroduces the MYR-151 garbage-delta bug, (b) puts a DB read near the drive-start hot path, and (c) churns 35 constructor call sites. The resend interval is smaller, safer, fixes the same window, and improves snapshot freshness (helps MYR-137). The sub-60s "connect-and-immediately-drive" residual is already covered by MYR-151's lazy in-drive fallback.

## ⚠️ Operational requirement
The fleet config is **not auto-pushed** on deploy/connect — it's applied via `POST /api/fleet-config/{vin}` or `cmd/ops fleet-config push`. **This change has no effect until the config is re-pushed to each vehicle.** Re-push after deploy.

## Diagnostic value
If FSD still reads 0 after the config re-push + a clean drive, that would indicate the vehicle's FW/HW doesn't emit the field at all (Tesla-side), not a backend bug — escalates to MYR-137.

## Tests
- New `TestDefaultFieldConfig_MileageCountersResend` asserts both counters carry `resend_interval_seconds=60` and keep the 1-mile delta gate.
- `go vet`, `golangci-lint`, telemetry + `cmd/ops` config-snapshot + contract tests green.

Closes MYR-155.

🤖 Generated with [Claude Code](https://claude.com/claude-code)