### PR TITLE
DV-20: GET /api/drives/{driveId}/route — recorded route polyline

### DIFF
--- a/cmd/telemetry-server/adapters.go
+++ b/cmd/telemetry-server/adapters.go
@@ -287,6 +287,28 @@ func (a *driveListerAdapter) ListByVehicleID(ctx context.Context, vehicleID stri
 	return telemetry.DriveListPage{Items: items, HasMore: page.HasMore}, nil
 }
 
+// driveRouteAdapter adapts store.DriveRepo.GetByID to the
+// telemetry.DriveRouteFetcher interface used by the drive-route handler
+// (DV-20). GetByID already resolves the routePointsEnc shadow into the
+// decrypted RoutePoints, so the handler sees plaintext. store.ErrDriveNotFound
+// wraps sdk.ErrNotFound, so passing the error through with %w lets the
+// handler map an unknown drive to a 404.
+type driveRouteAdapter struct {
+	repo *store.DriveRepo
+}
+
+func (a *driveRouteAdapter) GetDriveRoute(ctx context.Context, driveID string) (telemetry.DriveRouteData, error) {
+	rec, err := a.repo.GetByID(ctx, driveID)
+	if err != nil {
+		return telemetry.DriveRouteData{}, fmt.Errorf("get drive by id: %w", err)
+	}
+	return telemetry.DriveRouteData{
+		DriveID:     rec.ID,
+		VehicleID:   rec.VehicleID,
+		RoutePoints: rec.RoutePoints,
+	}, nil
+}
+
 // teslaTokenAdapter adapts store.AccountRepo to the
 // telemetry.TeslaTokenProvider interface, converting the store-layer
 // TeslaOAuthToken (Unix epoch) to the telemetry-layer TeslaToken (time.Time).

--- a/cmd/telemetry-server/wiring.go
+++ b/cmd/telemetry-server/wiring.go
@@ -232,6 +232,20 @@ func setupHTTPHandlers(deps httpRouteDeps) {
 	)
 	deps.srv.HandleFunc("GET /api/vehicles/{vehicleId}/drives", drivesHandler.ServeHTTP)
 
+	// DV-20 (FR-3.3): GET /api/drives/{driveId}/route — the recorded
+	// breadcrumb polyline for a completed drive. Same auth + ownership +
+	// role-mask flow as the drives list; the route's vehicleId comes off
+	// the drive record, then snapshotAdapter checks ownership.
+	driveRouteHandler := telemetry.NewDriveRouteHandler(
+		deps.authenticator,
+		snapshotAdapter,
+		&driveRouteAdapter{repo: deps.driveRepo},
+		deps.logger.With(slog.String("component", "drive-route")),
+		telemetry.WithDriveRouteRoleResolver(deps.authenticator),
+		telemetry.WithDriveRouteMaskAudit(deps.auditEmitter, deps.auditMetrics, "/api/drives/{driveId}/route"),
+	)
+	deps.srv.HandleFunc("GET /api/drives/{driveId}/route", driveRouteHandler.ServeHTTP)
+
 	setupFleetConfigEndpoint(deps.cfg, deps.srv, deps.authenticator, deps.vinCache, deps.accountRepo, deps.logger)
 
 	// Mounted when resolveDebugFieldsGate says so — either because the

--- a/internal/telemetry/drive_route_handler.go
+++ b/internal/telemetry/drive_route_handler.go
@@ -1,0 +1,286 @@
+package telemetry
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"log/slog"
+	"net/http"
+
+	"github.com/myrobotaxi/telemetry/internal/auth"
+	"github.com/myrobotaxi/telemetry/internal/mask"
+	"github.com/myrobotaxi/telemetry/internal/wserrors"
+	"github.com/myrobotaxi/telemetry/pkg/sdk"
+)
+
+// DriveRouteData is the handler-layer view of a single drive's recorded
+// route, decoupled from internal/store (the cmd adapter maps a
+// store.DriveRecord into it). RoutePoints is the already-decrypted JSONB
+// breadcrumb array — the store's GetByID resolves the routePointsEnc
+// shadow before the handler ever sees it.
+type DriveRouteData struct {
+	DriveID     string
+	VehicleID   string
+	RoutePoints json.RawMessage
+}
+
+// DriveRouteFetcher fetches a single drive's route by drive id.
+// Implementations MUST return an error wrapping sdk.ErrNotFound when the
+// driveId is unknown (the handler maps that to 404). store.ErrDriveNotFound
+// already wraps sdk.ErrNotFound, so the adapter only needs to pass it
+// through with %w.
+type DriveRouteFetcher interface {
+	GetDriveRoute(ctx context.Context, driveID string) (DriveRouteData, error)
+}
+
+// driveRouteResponse is the wire shape for GET /api/drives/{driveId}/route
+// (rest-api.md §7.4): the drive id plus the breadcrumb polyline. The
+// route points are passed through as raw JSON — their per-point shape
+// ({lat,lng,speed,heading,timestamp}) is owned by the writer that
+// persisted them, not re-marshaled here.
+type driveRouteResponse struct {
+	DriveID     string          `json:"driveId"`
+	RoutePoints json.RawMessage `json:"routePoints"`
+}
+
+// DriveRouteHandler handles GET /api/drives/{driveId}/route. It validates
+// the caller's JWT, looks up the drive (404 if unknown), verifies the
+// caller owns the drive's vehicle, projects the response through the
+// role-based DriveRoute mask, and returns the polyline per rest-api.md
+// §7.4 / §5.2.4. Mirrors VehicleDrivesHandler's auth/ownership/mask flow.
+type DriveRouteHandler struct {
+	auth     tokenValidator
+	vehicles VehicleSnapshotReader // owner check via GetByID(vehicleId)
+	drives   DriveRouteFetcher
+	roles    roleResolver // optional: nil disables role-based mask plumbing
+
+	// Mask-audit fields (MYR-71, rest-api.md §5.3). All optional —
+	// nil auditEmitter disables emit.
+	auditEmitter  mask.AuditEmitter
+	auditMetrics  mask.AuditMetrics
+	auditEndpoint string
+
+	logger *slog.Logger
+}
+
+// DriveRouteOption configures optional dependencies on DriveRouteHandler.
+type DriveRouteOption func(*DriveRouteHandler)
+
+// WithDriveRouteRoleResolver enables role-based field masking on the
+// handler. Owners and viewers share the DriveRoute allow-list (just
+// `routePoints`) per rest-api.md §5.2.4, so this is plumbed for FR-5.1
+// sharing readiness — the mask is a no-op for both roles today.
+func WithDriveRouteRoleResolver(roles roleResolver) DriveRouteOption {
+	return func(h *DriveRouteHandler) {
+		h.roles = roles
+	}
+}
+
+// WithDriveRouteMaskAudit attaches a mask-audit emitter (MYR-71,
+// rest-api.md §5.3). endpoint is the route pattern written to
+// metadata.endpoint. emitter MAY be nil — in which case this is a no-op.
+func WithDriveRouteMaskAudit(emitter mask.AuditEmitter, metrics mask.AuditMetrics, endpoint string) DriveRouteOption {
+	return func(h *DriveRouteHandler) {
+		if emitter == nil {
+			return
+		}
+		h.auditEmitter = emitter
+		if metrics == nil {
+			metrics = mask.NoopAuditMetrics{}
+		}
+		h.auditMetrics = metrics
+		h.auditEndpoint = endpoint
+	}
+}
+
+// NewDriveRouteHandler creates a handler that serves
+// GET /api/drives/{driveId}/route.
+func NewDriveRouteHandler(
+	tokens tokenValidator,
+	vehicles VehicleSnapshotReader,
+	drives DriveRouteFetcher,
+	logger *slog.Logger,
+	opts ...DriveRouteOption,
+) *DriveRouteHandler {
+	h := &DriveRouteHandler{
+		auth:     tokens,
+		vehicles: vehicles,
+		drives:   drives,
+		logger:   logger,
+	}
+	for _, opt := range opts {
+		opt(h)
+	}
+	return h
+}
+
+// ServeHTTP handles GET /api/drives/{driveId}/route.
+func (h *DriveRouteHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	driveID := r.PathValue("driveId")
+	if driveID == "" {
+		h.writeError(w, http.StatusBadRequest, wserrors.ErrCodeInvalidRequest, "missing driveId")
+		return
+	}
+
+	token := extractBearerToken(r)
+	if token == "" {
+		h.writeError(w, http.StatusUnauthorized, wserrors.ErrCodeAuthFailed, "missing Authorization header")
+		return
+	}
+
+	ctx := r.Context()
+
+	userID, err := h.auth.ValidateToken(ctx, token)
+	if err != nil {
+		h.logger.Warn("drive route: invalid token", slog.String("error", err.Error()))
+		h.writeError(w, http.StatusUnauthorized, wserrors.ErrCodeAuthFailed, "invalid or expired token")
+		return
+	}
+
+	// Fetch the drive first — we need its vehicleId to authorize. A
+	// missing drive is a 404 before we reveal anything else.
+	data, err := h.drives.GetDriveRoute(ctx, driveID)
+	if err != nil {
+		if errors.Is(err, sdk.ErrNotFound) {
+			h.writeError(w, http.StatusNotFound, wserrors.ErrCodeNotFound, "drive not found")
+			return
+		}
+		h.logger.Error("drive route: fetch failed",
+			slog.String("drive_id", driveID),
+			slog.String("error", err.Error()),
+		)
+		h.writeError(w, http.StatusInternalServerError, wserrors.ErrCodeInternalError, "internal error")
+		return
+	}
+
+	if !h.verifyOwnership(ctx, w, driveID, data.VehicleID, userID) {
+		return
+	}
+
+	h.writeMaskedRoute(r, w, userID, data)
+}
+
+// verifyOwnership checks that userID owns the drive's vehicle. Returns
+// true on success; on failure writes an HTTP error and returns false.
+// A drive that points at a missing vehicle is a data-integrity fault
+// (500), distinct from an ownership mismatch (403, vehicle_not_owned).
+func (h *DriveRouteHandler) verifyOwnership(ctx context.Context, w http.ResponseWriter, driveID, vehicleID, userID string) bool {
+	row, err := h.vehicles.GetByID(ctx, vehicleID)
+	if err != nil {
+		if errors.Is(err, sdk.ErrNotFound) {
+			// The drive resolved but its vehicle did not — inconsistent
+			// data, not a client error.
+			h.logger.Error("drive route: drive's vehicle not found",
+				slog.String("drive_id", driveID),
+				slog.String("vehicle_id", vehicleID),
+			)
+			h.writeError(w, http.StatusInternalServerError, wserrors.ErrCodeInternalError, "internal error")
+			return false
+		}
+		h.logger.Error("drive route: vehicle lookup failed",
+			slog.String("vehicle_id", vehicleID),
+			slog.String("error", err.Error()),
+		)
+		h.writeError(w, http.StatusInternalServerError, wserrors.ErrCodeInternalError, "internal error")
+		return false
+	}
+
+	if row.UserID != userID {
+		h.logger.Warn("drive route: ownership mismatch",
+			slog.String("drive_id", driveID),
+			slog.String("vehicle_id", vehicleID),
+			slog.String("user_id", userID),
+		)
+		h.writeError(w, http.StatusForbidden, wserrors.ErrCodeVehicleNotOwned, "you do not own this drive")
+		return false
+	}
+
+	return true
+}
+
+// writeMaskedRoute resolves the caller's role, projects the route through
+// the DriveRoute mask, and writes the response. When no roleResolver is
+// configured the projection runs against auth.RoleOwner.
+func (h *DriveRouteHandler) writeMaskedRoute(r *http.Request, w http.ResponseWriter, userID string, data DriveRouteData) {
+	role := auth.RoleOwner
+	if h.roles != nil {
+		resolved, err := h.roles.ResolveRole(r.Context(), userID, data.VehicleID)
+		if err != nil {
+			h.logger.Error("drive route: role resolution failed",
+				slog.String("vehicle_id", data.VehicleID),
+				slog.String("error", err.Error()),
+			)
+			h.writeError(w, http.StatusInternalServerError, wserrors.ErrCodeInternalError, "internal error")
+			return
+		}
+		role = resolved
+	}
+
+	// Empty/absent breadcrumb → an empty array, never null.
+	routePoints := data.RoutePoints
+	if len(routePoints) == 0 {
+		routePoints = json.RawMessage("[]")
+	}
+
+	maskSpec := mask.For(mask.ResourceDriveRoute, role)
+	projected, fieldsMasked := mask.Apply(map[string]any{"routePoints": routePoints}, maskSpec)
+
+	h.maybeEmitAudit(r, userID, data.VehicleID, role, fieldsMasked)
+
+	// Honor the mask: if a (future) role strips routePoints, return [].
+	out := json.RawMessage("[]")
+	if v, ok := projected["routePoints"].(json.RawMessage); ok {
+		out = v
+	}
+
+	h.writeJSON(w, http.StatusOK, driveRouteResponse{DriveID: data.DriveID, RoutePoints: out})
+}
+
+// maybeEmitAudit evaluates the REST audit-emit gate. Audit emits once per
+// request per rest-api.md §5.3. For DriveRoute both roles see the single
+// `routePoints` field, so this never fires today — it's plumbed for when
+// sharing/viewer masking lands (FR-5.1), mirroring the drives-list handler.
+func (h *DriveRouteHandler) maybeEmitAudit(r *http.Request, userID, vehicleID string, role auth.Role, fieldsMasked []string) {
+	if h.auditEmitter == nil {
+		return
+	}
+	if len(fieldsMasked) == 0 {
+		return
+	}
+	requestID := requestIDFromRequest(r)
+	if !mask.ShouldAuditREST(userID, requestID, vehicleID) {
+		return
+	}
+
+	entry, err := mask.BuildEntry(
+		userID,
+		mask.TargetRESTResponse,
+		vehicleID,
+		role,
+		mask.AuditChannelREST,
+		fieldsMasked,
+		h.auditEndpoint,
+	)
+	if err != nil {
+		h.logger.Warn("drive route: BuildEntry failed",
+			slog.String("user_id", userID),
+			slog.String("error", err.Error()),
+		)
+		return
+	}
+	mask.EmitAsync(r.Context(), h.auditEmitter, h.auditMetrics, h.logger, entry)
+}
+
+// writeJSON marshals v as JSON with the given status code.
+func (h *DriveRouteHandler) writeJSON(w http.ResponseWriter, status int, v any) {
+	w.Header().Set("Content-Type", "application/json; charset=utf-8")
+	w.WriteHeader(status)
+	if err := json.NewEncoder(w).Encode(v); err != nil {
+		h.logger.Error("drive route: writeJSON encode failed", slog.String("error", err.Error()))
+	}
+}
+
+// writeError writes the REST error envelope (rest-api.md §4.1).
+func (h *DriveRouteHandler) writeError(w http.ResponseWriter, status int, code wserrors.ErrorCode, msg string) {
+	wserrors.WriteErrorEnvelope(w, h.logger, status, code, msg)
+}

--- a/internal/telemetry/drive_route_handler_test.go
+++ b/internal/telemetry/drive_route_handler_test.go
@@ -1,0 +1,187 @@
+package telemetry
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/myrobotaxi/telemetry/internal/wserrors"
+	"github.com/myrobotaxi/telemetry/pkg/sdk"
+)
+
+// --- Test double for DriveRouteFetcher ---
+
+type stubDriveRouteFetcher struct {
+	data DriveRouteData
+	err  error
+}
+
+func (s *stubDriveRouteFetcher) GetDriveRoute(_ context.Context, _ string) (DriveRouteData, error) {
+	if s.err != nil {
+		return DriveRouteData{}, s.err
+	}
+	return s.data, nil
+}
+
+func TestDriveRouteHandler_ServeHTTP(t *testing.T) {
+	const (
+		driveID = "clmno9876543210zyxw0001"
+		userID  = "user-123"
+		authOK  = "Bearer valid-token"
+	)
+	routeJSON := json.RawMessage(
+		`[{"lat":32.98246,"lng":-96.90867,"speed":0,"heading":357,"timestamp":"2026-06-06T18:22:00Z"}]`,
+	)
+
+	tests := []struct {
+		name            string
+		authHeader      string
+		tokenValidator  *stubTokenValidator
+		reader          *stubVehicleSnapshotReader
+		fetcher         *stubDriveRouteFetcher
+		wantStatus      int
+		wantErrCode     wserrors.ErrorCode
+		wantRoutePoints string // happy-path: expected routePoints JSON
+	}{
+		{
+			name:           "missing Authorization header",
+			authHeader:     "",
+			tokenValidator: &stubTokenValidator{userID: userID},
+			reader:         &stubVehicleSnapshotReader{row: fixtureSnapshotRow(userID)},
+			fetcher:        &stubDriveRouteFetcher{},
+			wantStatus:     http.StatusUnauthorized,
+			wantErrCode:    wserrors.ErrCodeAuthFailed,
+		},
+		{
+			name:           "invalid token",
+			authHeader:     authOK,
+			tokenValidator: &stubTokenValidator{err: errors.New("expired")},
+			reader:         &stubVehicleSnapshotReader{row: fixtureSnapshotRow(userID)},
+			fetcher:        &stubDriveRouteFetcher{},
+			wantStatus:     http.StatusUnauthorized,
+			wantErrCode:    wserrors.ErrCodeAuthFailed,
+		},
+		{
+			name:           "drive not found",
+			authHeader:     authOK,
+			tokenValidator: &stubTokenValidator{userID: userID},
+			reader:         &stubVehicleSnapshotReader{row: fixtureSnapshotRow(userID)},
+			fetcher:        &stubDriveRouteFetcher{err: fmt.Errorf("get drive by id: %w", sdk.ErrNotFound)},
+			wantStatus:     http.StatusNotFound,
+			wantErrCode:    wserrors.ErrCodeNotFound,
+		},
+		{
+			name:           "drive fetch internal error",
+			authHeader:     authOK,
+			tokenValidator: &stubTokenValidator{userID: userID},
+			reader:         &stubVehicleSnapshotReader{row: fixtureSnapshotRow(userID)},
+			fetcher:        &stubDriveRouteFetcher{err: errors.New("db boom")},
+			wantStatus:     http.StatusInternalServerError,
+			wantErrCode:    wserrors.ErrCodeInternalError,
+		},
+		{
+			name:           "ownership mismatch",
+			authHeader:     authOK,
+			tokenValidator: &stubTokenValidator{userID: userID},
+			reader:         &stubVehicleSnapshotReader{row: fixtureSnapshotRow("other-user")},
+			fetcher: &stubDriveRouteFetcher{data: DriveRouteData{
+				DriveID: driveID, VehicleID: fixtureSnapshotRowID, RoutePoints: routeJSON,
+			}},
+			wantStatus:  http.StatusForbidden,
+			wantErrCode: wserrors.ErrCodeVehicleNotOwned,
+		},
+		{
+			name:           "drive's vehicle missing is an internal fault",
+			authHeader:     authOK,
+			tokenValidator: &stubTokenValidator{userID: userID},
+			reader:         &stubVehicleSnapshotReader{err: fmt.Errorf("get vehicle by id: %w", sdk.ErrNotFound)},
+			fetcher: &stubDriveRouteFetcher{data: DriveRouteData{
+				DriveID: driveID, VehicleID: "missing", RoutePoints: routeJSON,
+			}},
+			wantStatus:  http.StatusInternalServerError,
+			wantErrCode: wserrors.ErrCodeInternalError,
+		},
+		{
+			name:           "happy path returns the polyline",
+			authHeader:     authOK,
+			tokenValidator: &stubTokenValidator{userID: userID},
+			reader:         &stubVehicleSnapshotReader{row: fixtureSnapshotRow(userID)},
+			fetcher: &stubDriveRouteFetcher{data: DriveRouteData{
+				DriveID: driveID, VehicleID: fixtureSnapshotRowID, RoutePoints: routeJSON,
+			}},
+			wantStatus:      http.StatusOK,
+			wantRoutePoints: string(routeJSON),
+		},
+		{
+			name:           "empty route serializes as []",
+			authHeader:     authOK,
+			tokenValidator: &stubTokenValidator{userID: userID},
+			reader:         &stubVehicleSnapshotReader{row: fixtureSnapshotRow(userID)},
+			fetcher: &stubDriveRouteFetcher{data: DriveRouteData{
+				DriveID: driveID, VehicleID: fixtureSnapshotRowID, RoutePoints: nil,
+			}},
+			wantStatus:      http.StatusOK,
+			wantRoutePoints: "[]",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			h := NewDriveRouteHandler(
+				tt.tokenValidator,
+				tt.reader,
+				tt.fetcher,
+				discardLogger(),
+			)
+
+			mux := http.NewServeMux()
+			mux.Handle("GET /api/drives/{driveId}/route", h)
+
+			req := httptest.NewRequestWithContext(
+				context.Background(),
+				http.MethodGet,
+				"/api/drives/"+driveID+"/route",
+				nil,
+			)
+			if tt.authHeader != "" {
+				req.Header.Set("Authorization", tt.authHeader)
+			}
+
+			rec := httptest.NewRecorder()
+			mux.ServeHTTP(rec, req)
+
+			if rec.Code != tt.wantStatus {
+				t.Fatalf("status: got %d, want %d. Body: %s", rec.Code, tt.wantStatus, rec.Body.String())
+			}
+
+			if tt.wantErrCode != "" {
+				var env wserrors.ErrorEnvelope
+				if err := json.NewDecoder(rec.Body).Decode(&env); err != nil {
+					t.Fatalf("decode error envelope: %v", err)
+				}
+				if env.Error.Code != tt.wantErrCode {
+					t.Errorf("error.code: got %q, want %q", env.Error.Code, tt.wantErrCode)
+				}
+				return
+			}
+
+			var resp struct {
+				DriveID     string          `json:"driveId"`
+				RoutePoints json.RawMessage `json:"routePoints"`
+			}
+			if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+				t.Fatalf("decode response: %v", err)
+			}
+			if resp.DriveID != driveID {
+				t.Errorf("driveId: got %q, want %q", resp.DriveID, driveID)
+			}
+			if string(resp.RoutePoints) != tt.wantRoutePoints {
+				t.Errorf("routePoints: got %s, want %s", resp.RoutePoints, tt.wantRoutePoints)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## What & why

Closes the last **DV-20** gap. Drives already record an encrypted breadcrumb trail (`Drive.routePoints` / `routePointsEnc`), but there was **no read endpoint**, so clients can't render a completed drive's route on a map. This adds `GET /api/drives/{driveId}/route` per `rest-api.md §7.4`.

(Motivated by the sdk-testbench drive-detail page, whose route map currently shows a "no route recorded" fallback because this endpoint 404s.)

## How

`internal/telemetry/drive_route_handler.go` mirrors the sibling `VehicleDrivesHandler` flow exactly:
1. Validate the bearer JWT.
2. Fetch the drive (need its `vehicleId` to authorize) → **404 `not_found`** if unknown.
3. Verify the caller owns the drive's vehicle via `VehicleSnapshotReader.GetByID(...).UserID` → **403 `vehicle_not_owned`** otherwise.
4. Project through the role-based `ResourceDriveRoute` mask (`routePoints`; owner + viewer per §5.2.4, FR-5.1) + optional audit.
5. Return `{ "driveId": "...", "routePoints": [...] }`. Empty route → `[]` (never `null`).

The store's `GetByID` already resolves the `routePointsEnc` shadow, so the handler sees decrypted points and returns them over TLS. `driveRouteAdapter` bridges `store.DriveRepo` → the handler interface (the store's not-found error already wraps `sdk.ErrNotFound`). Mounted in `wiring.go` next to the drives list.

## Tests / checks

8 table-driven handler tests (missing/invalid token, drive-not-found, store error, ownership mismatch, missing-vehicle fault, happy path, empty route). `go build ./...`, `go vet`, `golangci-lint` (0 issues), and the contract tests all pass. Adversarially reviewed for IDOR / leak / mask — sound.

## Deploy

Holding for explicit go-ahead before merge (this is the production telemetry server).

🤖 Generated with [Claude Code](https://claude.com/claude-code)