### PR TITLE
MYR-157: drive distance from odometer delta + clamp FSD% ≤100%

### DIFF
--- a/internal/drives/detector.go
+++ b/internal/drives/detector.go
@@ -298,6 +298,14 @@ func (d *Detector) handleTelemetry(te events.VehicleTelemetryEvent) {
 		state.fsdMilesKnown = true
 	}
 
+	// Cache odometer the same way (MYR-157) so startDrive can seed an
+	// accurate distance baseline — odometer streams on the same slow
+	// cadence as FSD and is usually absent from the gear-change frame.
+	if odo, ok := extractFloatField(te.Fields, telemetry.FieldOdometer); ok {
+		state.lastOdometer = odo
+		state.odometerKnown = true
+	}
+
 	switch state.status {
 	case StatusIdle:
 		d.handleIdle(state, vin, te)

--- a/internal/drives/detector_test.go
+++ b/internal/drives/detector_test.go
@@ -1400,3 +1400,105 @@ func TestCalculateStats_ZeroSpeedCount(t *testing.T) {
 		t.Errorf("AvgSpeed: got %f, want 0 (no speed samples)", stats.AvgSpeed)
 	}
 }
+
+// MYR-157: drive distance is derived from the odometer delta (an accurate
+// cumulative counter), not the GPS haversine of sparse route points. The
+// route points here span a large GPS distance to prove the odometer wins.
+func TestCalculateStats_DistanceFromOdometer(t *testing.T) {
+	drive := &activeDrive{
+		startedAt:           time.Now(),
+		lastTimestamp:       time.Now().Add(5 * time.Minute),
+		startOdometer:       1000.0,
+		lastOdometer:        1002.0, // odometer delta = 2.0 mi
+		odometerBaselineSet: true,
+		routePoints: []events.RoutePoint{
+			{Latitude: 33.0, Longitude: -96.0},
+			{Latitude: 33.5, Longitude: -96.5}, // ~45 mi of GPS — must be ignored
+		},
+	}
+	stats := calculateStats(drive)
+	if stats.Distance != 2.0 {
+		t.Errorf("Distance: got %f, want 2.0 (odometer delta, not GPS)", stats.Distance)
+	}
+}
+
+// MYR-157: with no odometer baseline observed, distance falls back to the
+// GPS haversine sum (legacy behavior).
+func TestCalculateStats_DistanceFallsBackToGPS(t *testing.T) {
+	drive := &activeDrive{
+		startedAt:     time.Now(),
+		lastTimestamp: time.Now().Add(5 * time.Minute),
+		// odometerBaselineSet defaults false → GPS fallback.
+		routePoints: []events.RoutePoint{
+			{Latitude: 33.0, Longitude: -96.0},
+			{Latitude: 33.01, Longitude: -96.0},
+		},
+	}
+	gps := totalDistance(drive.routePoints)
+	stats := calculateStats(drive)
+	if gps <= 0 || stats.Distance != gps {
+		t.Errorf("Distance: got %f, want GPS fallback %f (>0)", stats.Distance, gps)
+	}
+}
+
+// MYR-157: a mid-drive odometer reset (delta ≤ 0) falls back to GPS rather
+// than reporting a negative/zero distance.
+func TestCalculateStats_DistanceFallsBackOnOdometerReset(t *testing.T) {
+	drive := &activeDrive{
+		startedAt:           time.Now(),
+		lastTimestamp:       time.Now().Add(5 * time.Minute),
+		startOdometer:       2000.0,
+		lastOdometer:        1.0, // reset mid-drive → non-positive delta
+		odometerBaselineSet: true,
+		routePoints: []events.RoutePoint{
+			{Latitude: 33.0, Longitude: -96.0},
+			{Latitude: 33.01, Longitude: -96.0},
+		},
+	}
+	gps := totalDistance(drive.routePoints)
+	stats := calculateStats(drive)
+	if stats.Distance != gps {
+		t.Errorf("Distance: got %f, want GPS fallback %f on odometer reset", stats.Distance, gps)
+	}
+}
+
+// MYR-157: FSD% is clamped to ≤100% — guards the >100% (e.g. 176%) that
+// previously surfaced when FSD miles were divided by an undercounting
+// distance.
+func TestCalculateStats_FSDPercentageClampedTo100(t *testing.T) {
+	drive := &activeDrive{
+		startedAt:           time.Now(),
+		lastTimestamp:       time.Now().Add(5 * time.Minute),
+		startFSDMiles:       100.0,
+		lastFSDMiles:        102.0, // FSD delta = 2.0
+		fsdBaselineSet:      true,
+		startOdometer:       500.0,
+		lastOdometer:        501.0, // distance = 1.0 → 200% pre-clamp
+		odometerBaselineSet: true,
+	}
+	stats := calculateStats(drive)
+	if stats.FSDPercentage != 100.0 {
+		t.Errorf("FSDPercentage: got %f, want 100 (clamped)", stats.FSDPercentage)
+	}
+}
+
+// MYR-157: a normal FSD share computed against the odometer distance.
+func TestCalculateStats_FSDPercentageFromOdometer(t *testing.T) {
+	drive := &activeDrive{
+		startedAt:           time.Now(),
+		lastTimestamp:       time.Now().Add(5 * time.Minute),
+		startFSDMiles:       100.0,
+		lastFSDMiles:        101.0, // FSD = 1.0
+		fsdBaselineSet:      true,
+		startOdometer:       500.0,
+		lastOdometer:        502.0, // distance = 2.0
+		odometerBaselineSet: true,
+	}
+	stats := calculateStats(drive)
+	if stats.Distance != 2.0 {
+		t.Errorf("Distance: got %f, want 2.0", stats.Distance)
+	}
+	if stats.FSDPercentage != 50.0 {
+		t.Errorf("FSDPercentage: got %f, want 50", stats.FSDPercentage)
+	}
+}

--- a/internal/drives/state.go
+++ b/internal/drives/state.go
@@ -64,6 +64,17 @@ type vehicleState struct {
 	lastFSDMiles  float64
 	fsdMilesKnown bool
 
+	// lastOdometer caches the most recent odometer value seen for this
+	// vehicle, including while idle (mirrors lastFSDMiles). odometerKnown
+	// reports whether a value has been observed. Odometer streams on a slow
+	// cadence (60s), so the gear-change event that starts a drive usually
+	// lacks it; caching lets startDrive seed an accurate baseline (the car
+	// has not moved since the last parked sample). calculateStats derives
+	// drive distance from the odometer delta (MYR-157), which is far more
+	// accurate than the GPS-haversine of sparse route points.
+	lastOdometer  float64
+	odometerKnown bool
+
 	// lastTelemetryAt records the wall-clock time of the most recently
 	// received telemetry event for this vehicle (any field, gear-bearing
 	// or not). The end-condition watchdog uses this to detect drives
@@ -87,7 +98,11 @@ type activeDrive struct {
 	startFSDMiles  float64 // fsdMilesSinceReset baseline for this drive
 	lastFSDMiles   float64 // most recent fsdMilesSinceReset seen
 	fsdBaselineSet bool    // true once startFSDMiles holds a real observed value
-	lastLocation   events.Location
+	// Odometer distance (MYR-157): distance = lastOdometer - startOdometer
+	// when odometerBaselineSet, else fall back to GPS totalDistance.
+	lastOdometer        float64 // most recent odometer reading (miles)
+	odometerBaselineSet bool    // true once startOdometer holds a real observed value
+	lastLocation        events.Location
 	lastTimestamp  time.Time
 	lastSOC        float64 // most recent SOC for EndChargeLevel
 	lastEnergy     float64 // most recent energyRemaining for EnergyDelta

--- a/internal/drives/stats.go
+++ b/internal/drives/stats.go
@@ -53,7 +53,19 @@ func totalDistance(points []events.RoutePoint) float64 {
 // The endSOC and endEnergy values come from the most recent telemetry event.
 func calculateStats(drive *activeDrive) events.DriveStats {
 	duration := drive.lastTimestamp.Sub(drive.startedAt)
+
+	// Distance prefers the odometer delta (MYR-157): odometer is an
+	// accurate cumulative counter, whereas totalDistance() sums GPS
+	// haversine chords between sparse route points and undercounts real
+	// road distance. Fall back to GPS when no odometer baseline was
+	// observed, or when the delta is non-positive (e.g. an odometer reset,
+	// or a drive with no in-motion odometer sample yet).
 	distance := totalDistance(drive.routePoints)
+	if drive.odometerBaselineSet {
+		if odoDist := drive.lastOdometer - drive.startOdometer; odoDist > 0 {
+			distance = odoDist
+		}
+	}
 
 	var avgSpeed float64
 	if drive.speedCount > 0 {
@@ -76,9 +88,16 @@ func calculateStats(drive *activeDrive) events.DriveStats {
 		}
 	}
 
+	// FSD share, clamped to [0,100]. FSD miles ⊆ total odometer miles, so a
+	// correct measurement is always ≤100%; the clamp guards against residual
+	// counter/sampling skew that previously produced >100% (e.g. 176%) when
+	// FSD (odometer-accurate) was divided by the undercounting GPS distance.
 	var fsdPercentage float64
 	if distance > 0 && fsdMiles > 0 {
 		fsdPercentage = (fsdMiles / distance) * 100.0
+		if fsdPercentage > 100.0 {
+			fsdPercentage = 100.0
+		}
 	}
 
 	endLocation := drive.lastLocation

--- a/internal/drives/transitions.go
+++ b/internal/drives/transitions.go
@@ -62,6 +62,16 @@ func (d *Detector) handleDriving(state *vehicleState, vin string, te events.Vehi
 		drive.lastFSDMiles = fsd
 	}
 
+	// Update odometer tracking the same way (MYR-157) — lazily seed the
+	// baseline from the first in-drive sample when it was cold at start.
+	if odo, ok := extractFloatField(te.Fields, telemetry.FieldOdometer); ok {
+		if !drive.odometerBaselineSet {
+			drive.startOdometer = odo
+			drive.odometerBaselineSet = true
+		}
+		drive.lastOdometer = odo
+	}
+
 	// Update SOC tracking.
 	if soc, ok := extractFloatField(te.Fields, telemetry.FieldSOC); ok {
 		drive.lastSOC = soc
@@ -122,37 +132,35 @@ func (d *Detector) startDrive(state *vehicleState, vin string, te events.Vehicle
 		startCharge = soc
 	}
 
-	var startOdometer float64
-	if odo, ok := extractFloatField(te.Fields, telemetry.FieldOdometer); ok {
-		startOdometer = odo
-	}
-
 	var startEnergy float64
 	if energy, ok := extractFloatField(te.Fields, telemetry.FieldEnergyRemaining); ok {
 		startEnergy = energy
 	}
 
-	// Seed the FSD baseline from the most recent value seen for this vehicle
-	// (cached in handleTelemetry, including while idle). FSD miles is a
-	// cumulative "miles since reset" counter that does not advance while
-	// parked, so the last value before the drive is the correct baseline.
-	// If no value has ever been observed, leave the baseline unset —
-	// handleDriving lazily captures it from the first in-drive FSD sample.
+	// Seed the FSD + odometer baselines from the most recent values seen for
+	// this vehicle (cached in handleTelemetry, including while idle). Both
+	// are cumulative counters that don't advance while parked, so the last
+	// value before the drive is the correct baseline; the gear-change frame
+	// that starts the drive usually lacks them (slow cadence). If none has
+	// been observed, the baseline stays unset and handleDriving lazily
+	// captures it from the first in-drive sample (MYR-157).
 	drive := &activeDrive{
-		id:             driveID,
-		startedAt:      te.CreatedAt,
-		startLocation:  startLoc,
-		maxSpeed:       0,
-		startCharge:    startCharge,
-		startOdometer:  startOdometer,
-		startEnergy:    startEnergy,
-		startFSDMiles:  state.lastFSDMiles,
-		lastFSDMiles:   state.lastFSDMiles,
-		fsdBaselineSet: state.fsdMilesKnown,
-		lastLocation:   startLoc,
-		lastTimestamp:  te.CreatedAt,
-		lastSOC:        startCharge,
-		lastEnergy:     startEnergy,
+		id:                  driveID,
+		startedAt:           te.CreatedAt,
+		startLocation:       startLoc,
+		maxSpeed:            0,
+		startCharge:         startCharge,
+		startOdometer:       state.lastOdometer,
+		lastOdometer:        state.lastOdometer,
+		odometerBaselineSet: state.odometerKnown,
+		startEnergy:         startEnergy,
+		startFSDMiles:       state.lastFSDMiles,
+		lastFSDMiles:        state.lastFSDMiles,
+		fsdBaselineSet:      state.fsdMilesKnown,
+		lastLocation:        startLoc,
+		lastTimestamp:       te.CreatedAt,
+		lastSOC:             startCharge,
+		lastEnergy:          startEnergy,
 	}
 
 	state.status = StatusDriving


### PR DESCRIPTION
Closes MYR-157.

## Problem
Per-drive **FSD% > 100%** (live: 176%, 107%) and **distances undercount** (a ~2-mi drive showed 1.1 mi). `distance` was the **GPS haversine** of sparse route points (undercounts), while `fsdMiles` is the delta of Tesla's **odometer-accurate** `SelfDrivingMilesSinceReset` (proto 259). Dividing the two → >100%.

## Proto-validated
Reviewed `teslamotors/fleet-telemetry/protos/vehicle_data.proto`: **no per-frame FSD/Autopilot "engaged" field exists** → the cumulative-counter delta is the only way to measure FSD miles. `Odometer` (proto 5) is the correct distance basis and was already captured at drive start but unused.

## Change
- Cache odometer per-vehicle (incl. idle) and seed the drive's start baseline from it — mirrors the existing FSD-baseline machinery (`state.go`, `detector.go`, `transitions.go`); lazily captured from the first in-drive sample if cold.
- `stats.go`: `distance = lastOdometer − startOdometer` when a baseline exists, else fall back to GPS `totalDistance()` (and on a non-positive delta — e.g. odometer reset). `fsdPercentage = ΔFSD/ΔOdometer`, **clamped [0,100]**.
- Uses the **detector's float** odometer, not the stored int `OdometerMiles` (truncates — MYR-159).

## Tests
5 new `calculateStats` unit tests: odometer distance beats GPS; GPS fallback (no odometer / on reset); FSD% clamp; normal FSD% from odometer. Full `internal/drives` suite + contract + handler tests + golangci-lint all green. Backward-compatible (drives with no odometer field keep GPS distance).

## Scope / caveats
- Only **new** drives improve (stats finalize at drive-end; historical can't recompute).
- Boundary sampling granularity → **MYR-158**. Drive over-segmentation/stuck-active → **MYR-160**. Odometer stored-precision (int→float) → **MYR-159**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)