### PR TITLE
MYR-188 Prevent TLS cert expiry recurrence: endpoint cert monitor + alerts + renewal runbook

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -42,6 +42,14 @@ TESLA_KEY_FILE=/certs/tesla-private-key.pem
 # PEM-encoded public key served at .well-known for Tesla app identity verification.
 # TESLA_PUBLIC_KEY=
 
+# ---- TLS certificate monitoring (MYR-188) ------------------------------------
+# Comma-separated host:port endpoints the server TLS-dials on a schedule to
+# report the SERVED cert's expiry as Prometheus gauges (alerts fire at
+# 30/14/7 days — see deployments/alerts/tls-cert.rules.yml). This catches
+# TLS terminated outside the app — notably the Fly-managed cert on the 4443
+# client port, which no on-disk file check can see. Unset = monitor disabled.
+# TLS_MONITOR_ENDPOINTS=telemetry.myrobotaxi.app:443,telemetry.myrobotaxi.app:4443
+
 # ---- Logging -----------------------------------------------------------------
 # "json" for structured production logs, omit or set to anything else for text.
 LOG_FORMAT=json

--- a/cmd/telemetry-server/main.go
+++ b/cmd/telemetry-server/main.go
@@ -223,6 +223,13 @@ func run() error { //nolint:funlen // composition root — sequential dependency
 	// refreshes on its own goroutine until the rollouts complete. See
 	// startPlaintextGauges in wiring.go.
 	startPlaintextGauges(ctx, reg, db.Pool(), accountTokenGaugeInterval, vehicleGPSGaugeInterval, routeBlobGaugeInterval, logger)
+
+	// --- TLS endpoint cert monitor (MYR-188) ---
+	// Probes the served leaf cert on each configured public endpoint so an
+	// impending expiry pages BEFORE it takes down customer traffic —
+	// including the Fly-terminated 4443 cert that no file monitor can see.
+	startCertEndpointMonitor(ctx, reg, cfg.Monitoring().CertEndpoints, logger)
+
 	// --- Audit sidecar (MYR-77) ---
 	// Best-effort S3 mirror of every AuditLog INSERT.
 	// No-op when AUDIT_SIDECAR_BUCKET is empty (local dev).
@@ -340,4 +347,3 @@ func run() error { //nolint:funlen // composition root — sequential dependency
 	logger.Info("telemetry-server stopped cleanly")
 	return nil
 }
-

--- a/cmd/telemetry-server/wiring.go
+++ b/cmd/telemetry-server/wiring.go
@@ -104,6 +104,24 @@ func startPlaintextGauges(
 	go routeBlobGauge.Run(ctx)
 }
 
+// startCertEndpointMonitor wires the endpoint TLS certificate monitor,
+// which TLS-dials each configured host:port and exposes the served leaf's
+// expiry as Prometheus gauges. Unlike the file-based monitor it sees certs
+// terminated outside this process (notably the Fly-managed cert on the
+// client WebSocket port) — the blind spot behind the MYR-188 outage. When
+// no endpoints are configured (TLS_MONITOR_ENDPOINTS unset) it is a no-op.
+func startCertEndpointMonitor(ctx context.Context, reg prometheus.Registerer, endpoints []string, logger *slog.Logger) {
+	if len(endpoints) == 0 {
+		logger.Info("tls endpoint cert monitor disabled (set TLS_MONITOR_ENDPOINTS to enable)")
+		return
+	}
+	monitor := telemetry.NewEndpointCertMonitor(telemetry.EndpointCertMonitorConfig{
+		Endpoints: endpoints,
+	}, reg, logger.With(slog.String("component", "cert-endpoint-monitor")))
+	go monitor.Run(ctx)
+	logger.Info("tls endpoint cert monitor started", slog.Any("endpoints", endpoints))
+}
+
 // startPoolStatsCollector spawns a background goroutine that polls
 // db.CollectPoolStats every interval and exits when ctx cancels.
 // CollectPoolStats reads pgxpool.Stat() and pushes the values into the

--- a/deployments/alerts/tls-cert.rules.yml
+++ b/deployments/alerts/tls-cert.rules.yml
@@ -1,0 +1,64 @@
+# TLS certificate expiry + reachability alerts (MYR-188).
+#
+# These fire on the gauges emitted by the EndpointCertMonitor
+# (internal/telemetry/cert_endpoint_monitor.go), which TLS-dials each
+# endpoint in TLS_MONITOR_ENDPOINTS and reports the SERVED leaf's expiry —
+# covering both the app-terminated mTLS cert (443) and the Fly-managed
+# client cert (4443) that no on-disk file check can see.
+#
+# Thresholds are non-overlapping so a single cert fires exactly one expiry
+# alert at a time, escalating warning → critical → page as it ages.
+groups:
+  - name: tls-certificates
+    rules:
+      - alert: TLSCertExpiryWarning
+        expr: |
+          telemetry_tls_endpoint_cert_expiry_days_remaining >= 14
+          and telemetry_tls_endpoint_cert_expiry_days_remaining < 30
+        for: 1h
+        labels:
+          severity: warning
+        annotations:
+          summary: "TLS cert on {{ $labels.endpoint }} expires in {{ $value | humanize }}d"
+          description: >-
+            The certificate served at {{ $labels.endpoint }} has under 30 days
+            of validity left. Renew it per docs/tls-certificates.md before it
+            drops into the critical window.
+
+      - alert: TLSCertExpiryCritical
+        expr: |
+          telemetry_tls_endpoint_cert_expiry_days_remaining >= 7
+          and telemetry_tls_endpoint_cert_expiry_days_remaining < 14
+        for: 10m
+        labels:
+          severity: critical
+        annotations:
+          summary: "TLS cert on {{ $labels.endpoint }} expires in {{ $value | humanize }}d"
+          description: >-
+            The certificate served at {{ $labels.endpoint }} expires in under
+            14 days. Renew now — see docs/tls-certificates.md.
+
+      - alert: TLSCertExpiryUrgent
+        expr: telemetry_tls_endpoint_cert_expiry_days_remaining < 7
+        for: 5m
+        labels:
+          severity: page
+        annotations:
+          summary: "TLS cert on {{ $labels.endpoint }} expires in {{ $value | humanize }}d (or already expired)"
+          description: >-
+            The certificate served at {{ $labels.endpoint }} expires in under 7
+            days (a negative value means it has already expired and customer
+            traffic is broken). Renew immediately — docs/tls-certificates.md.
+
+      - alert: TLSEndpointUnreachable
+        expr: telemetry_tls_endpoint_cert_reachable == 0
+        for: 15m
+        labels:
+          severity: critical
+        annotations:
+          summary: "TLS endpoint {{ $labels.endpoint }} unreachable for 15m"
+          description: >-
+            The cert monitor could not complete a TLS probe of
+            {{ $labels.endpoint }} for 15 minutes. The endpoint may be down, or
+            TLS termination there may be failing (e.g. a missing/expired cert
+            that aborts the handshake before a leaf is presented).

--- a/deployments/prometheus.yml
+++ b/deployments/prometheus.yml
@@ -2,6 +2,11 @@ global:
   scrape_interval: 15s
   evaluation_interval: 15s
 
+# Alerting/recording rules. tls-cert.rules.yml (MYR-188) pages on TLS certs
+# approaching expiry using the EndpointCertMonitor gauges.
+rule_files:
+  - "alerts/*.rules.yml"
+
 scrape_configs:
   - job_name: telemetry-server
     static_configs:

--- a/docs/tls-certificates.md
+++ b/docs/tls-certificates.md
@@ -1,0 +1,111 @@
+# TLS Certificates — Topology, Renewal & Monitoring
+
+`telemetry.myrobotaxi.app` serves **two independent TLS surfaces on one
+hostname**. They use **different certificates, issued and renewed by
+different systems.** Confusing them is what caused the 2026-07 outage
+(MYR-188), so read this before touching certs.
+
+```
+                         telemetry.myrobotaxi.app  (CNAME → *.fly.dev, DNS at Dynadot)
+                          │
+   ┌──────────────────────┴───────────────────────┐
+   │ Port 443  — Tesla mTLS                        │ Port 4443 — browser WS + REST
+   │ Fly TCP passthrough (NO tls handler)          │ Fly terminates TLS
+   │ the APP terminates TLS + reads client certs   │ app serves plain HTTP on :8080
+   │ cert: TLS_CERT_B64 / TLS_KEY_B64 Fly secrets  │ cert: Fly-managed (fly certs)
+   │ renewal: MANUAL (see §2)                       │ renewal: automatic once DNS-validated (§3)
+   └───────────────────────────────────────────────┘
+```
+
+Both certs currently expire **2026-10-03**.
+
+---
+
+## 1. Why one hostname needs two renewal paths
+
+- **Port 443 can't use Fly's managed cert.** It's a raw TCP passthrough so
+  the app can complete the mTLS handshake and read each vehicle's client
+  certificate. Fly never sees the bytes, so it can't terminate TLS there —
+  the app must present its own cert from a secret.
+- **Fly's managed cert (4443) can't validate over HTTP-01.** Fly's ACME
+  HTTP-01 challenge is served on port 443, but 443 is the passthrough — the
+  challenge can't be answered. **The Fly cert MUST use DNS validation** (§3).
+- **The two ACME challenges must not collide.** A single-name cert for
+  `telemetry.myrobotaxi.app` validates at `_acme-challenge.telemetry.myrobotaxi.app`
+  — the same name Fly's DNS delegation uses. A CNAME (Fly) and a TXT
+  (certbot) cannot coexist there. So the **app's 443 cert is a wildcard
+  `*.myrobotaxi.app`**, which validates at the apex `_acme-challenge.myrobotaxi.app`
+  — a different name that never clashes with Fly's.
+
+---
+
+## 2. Renew the port-443 mTLS cert (wildcard `*.myrobotaxi.app`)
+
+The app cert is a Let's Encrypt wildcard delivered via the `TLS_CERT_B64` /
+`TLS_KEY_B64` Fly secrets. It is **manual DNS-01** today (see the automation
+gap in §4).
+
+```bash
+# 1. Issue/renew the wildcard (DNS-01 — the ONLY challenge that works here).
+sudo certbot certonly --manual --preferred-challenges dns -d '*.myrobotaxi.app'
+
+# 2. Certbot prints a TXT value. At Dynadot, set:
+#      Subdomain: _acme-challenge   Type: TXT   Value: <printed value>
+#    NOTE: apex "_acme-challenge", NOT "_acme-challenge.telemetry"
+#    (that one is Fly's — see §3). Verify before continuing:
+dig +short TXT _acme-challenge.myrobotaxi.app @ns1.dyna-ns.net
+
+# 3. Push the new cert to Fly (files are root-only; read with sudo,
+#    run fly as your own user so it uses your login):
+fly secrets set -a my-robo-taxi-telemetry \
+  TLS_CERT_B64="$(sudo base64 -i /etc/letsencrypt/live/myrobotaxi.app/fullchain.pem)" \
+  TLS_KEY_B64="$(sudo base64 -i /etc/letsencrypt/live/myrobotaxi.app/privkey.pem)"
+# Setting secrets triggers a rolling redeploy; start.sh decodes them to
+# /tmp/certs/server.crt on boot.
+
+# 4. Verify the served cert (should be the new NotAfter, mTLS port):
+scripts/check-cert-expiry.sh --endpoint telemetry.myrobotaxi.app:443
+```
+
+Vehicles reconnect on their own as they next phone home; no fleet-config
+re-push is needed because the hostname is unchanged.
+
+---
+
+## 3. Renew / fix the port-4443 Fly-managed cert
+
+Normally automatic. If `fly certs show telemetry.myrobotaxi.app` is stuck on
+`Issuing…` or expired, it's because HTTP-01 can't traverse the 443
+passthrough. Move it to **DNS validation** (one-time; auto-renews after):
+
+```bash
+fly certs setup telemetry.myrobotaxi.app -a my-robo-taxi-telemetry
+# Add the CNAME it prints at Dynadot:
+#   _acme-challenge.telemetry.myrobotaxi.app  CNAME  telemetry.myrobotaxi.app.<hash>.flydns.net
+# (Delete any stale _acme-challenge.telemetry TXT first — a CNAME can't
+#  coexist with a TXT.)
+fly certs check telemetry.myrobotaxi.app -a my-robo-taxi-telemetry   # nudges validation
+scripts/check-cert-expiry.sh --endpoint telemetry.myrobotaxi.app:4443
+```
+
+---
+
+## 4. Monitoring & alerting
+
+- **EndpointCertMonitor** (`internal/telemetry/cert_endpoint_monitor.go`)
+  TLS-dials every endpoint in `TLS_MONITOR_ENDPOINTS` and emits
+  `telemetry_tls_endpoint_cert_expiry_days_remaining{endpoint}` +
+  `telemetry_tls_endpoint_cert_reachable{endpoint}`. It reads the **served**
+  leaf, so it sees the Fly 4443 cert that the older file-based monitor
+  structurally cannot. Enable it in prod:
+  `TLS_MONITOR_ENDPOINTS=telemetry.myrobotaxi.app:443,telemetry.myrobotaxi.app:4443`.
+- **Alerts**: `deployments/alerts/tls-cert.rules.yml` pages at 30 / 14 / 7
+  days remaining and on 15m of unreachability.
+- **Ad-hoc / CI check**: `scripts/check-cert-expiry.sh --endpoint HOST:PORT`.
+
+### Known gap — 443 cert auto-renewal (tracked, MYR-188)
+
+The wildcard is `certbot --manual`, so it does **not** auto-renew. Until an
+auth-hook / DNS-plugin flow (Dynadot API or acme.sh) that re-sets the Fly
+secrets is wired, renewal is a **manual calendar task before 2026-10-03**.
+The alert rules above are the safety net.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -18,8 +18,20 @@ type Config struct {
 	auth           AuthConfig
 	proxy          ProxyConfig
 	teslaOAuth     TeslaOAuthConfig
+	monitoring     MonitoringConfig
 	mapboxToken    string
 	teslaPublicKey string
+}
+
+// MonitoringConfig holds observability probe settings.
+type MonitoringConfig struct {
+	// CertEndpoints is the list of host:port addresses the endpoint TLS
+	// certificate monitor probes on a schedule (see EndpointCertMonitor).
+	// It covers certs terminated outside the app process — notably the
+	// Fly-managed cert on the client WebSocket port, which the file-based
+	// monitor cannot see. Empty disables the monitor. Populated from the
+	// TLS_MONITOR_ENDPOINTS env var (comma-separated).
+	CertEndpoints []string
 }
 
 // ServerConfig holds port bindings for the three HTTP listeners.
@@ -139,6 +151,10 @@ func (c *Config) Proxy() ProxyConfig { return c.proxy }
 // TeslaOAuth returns the Tesla OAuth2 application credentials. When
 // ClientID is empty, automatic token refresh is disabled.
 func (c *Config) TeslaOAuth() TeslaOAuthConfig { return c.teslaOAuth }
+
+// Monitoring returns the observability probe configuration. When
+// CertEndpoints is empty, the endpoint TLS cert monitor is disabled.
+func (c *Config) Monitoring() MonitoringConfig { return c.monitoring }
 
 // MapboxToken returns the Mapbox API token. Empty string means geocoding
 // is disabled.

--- a/internal/config/load.go
+++ b/internal/config/load.go
@@ -20,13 +20,14 @@ type fileConfig struct {
 	Proxy     fileProxyConfig     `json:"proxy"`
 
 	// Populated from environment, not JSON.
-	databaseURL      string
-	authSecret       string
-	mapboxToken      string
-	teslaPublicKey   string
-	fleetTelemetryCA string
-	teslaClientID    string
-	teslaClientSec   string
+	databaseURL          string
+	authSecret           string
+	mapboxToken          string
+	teslaPublicKey       string
+	fleetTelemetryCA     string
+	teslaClientID        string
+	teslaClientSec       string
+	certMonitorEndpoints []string
 }
 
 type fileServerConfig struct {
@@ -123,7 +124,7 @@ func applyEnvOverrides(fc *fileConfig) error {
 		missing = append(missing, "AUTH_SECRET")
 	}
 
-	fc.mapboxToken = os.Getenv("MAPBOX_TOKEN")             // optional
+	fc.mapboxToken = os.Getenv("MAPBOX_TOKEN")            // optional
 	fc.teslaPublicKey = os.Getenv("TESLA_PUBLIC_KEY")     // optional
 	fc.fleetTelemetryCA = os.Getenv("FLEET_TELEMETRY_CA") // optional: PEM CA cert
 	fc.teslaClientID = os.Getenv("AUTH_TESLA_ID")         // optional: enables token refresh
@@ -159,6 +160,14 @@ func applyEnvOverrides(fc *fileConfig) error {
 	// signal "explicitly empty" (fail-closed). Per NFR-3.22 and MYR-17.
 	if v, ok := os.LookupEnv("WEBSOCKET_ALLOWED_ORIGINS"); ok {
 		fc.WebSocket.AllowedOrigins = parseOriginList(v)
+	}
+
+	// TLS_MONITOR_ENDPOINTS is a comma-separated list of host:port
+	// addresses the endpoint cert monitor probes (e.g.
+	// "telemetry.myrobotaxi.app:443,telemetry.myrobotaxi.app:4443").
+	// Unset/empty disables the monitor.
+	if v, ok := os.LookupEnv("TLS_MONITOR_ENDPOINTS"); ok {
+		fc.certMonitorEndpoints = parseOriginList(v)
 	}
 
 	if len(missing) > 0 {
@@ -235,6 +244,9 @@ func buildConfig(fc *fileConfig) *Config {
 		teslaOAuth: TeslaOAuthConfig{
 			ClientID:     fc.teslaClientID,
 			ClientSecret: fc.teslaClientSec,
+		},
+		monitoring: MonitoringConfig{
+			CertEndpoints: fc.certMonitorEndpoints,
 		},
 		mapboxToken:    fc.mapboxToken,
 		teslaPublicKey: fc.teslaPublicKey,

--- a/internal/telemetry/cert_endpoint_monitor.go
+++ b/internal/telemetry/cert_endpoint_monitor.go
@@ -193,8 +193,13 @@ func (m *EndpointCertMonitor) probeExpiry(ctx context.Context, endpoint string) 
 	dialer := &tls.Dialer{
 		NetDialer: &net.Dialer{Timeout: m.dialTimeout},
 		Config: &tls.Config{
-			ServerName:         host, // SNI — Fly serves the right cert per hostname
-			InsecureSkipVerify: true, //nolint:gosec // G402: we read the served cert's expiry; an expired/invalid cert must be inspected, not rejected
+			ServerName: host, // SNI — Fly serves the right cert per hostname
+			// #nosec G402 -- this is a monitoring probe: we read the served
+			// cert's expiry, so an expired/invalid/mismatched cert MUST be
+			// inspected, not rejected. A validating dial would fail the
+			// handshake and defeat the entire purpose. (//nolint covers the
+			// golangci-lint gosec pass; #nosec covers the standalone gosec CI job.)
+			InsecureSkipVerify: true, //nolint:gosec // G402: intentional — see #nosec note above
 			MinVersion:         tls.VersionTLS12,
 			VerifyConnection:   capture,
 		},

--- a/internal/telemetry/cert_endpoint_monitor.go
+++ b/internal/telemetry/cert_endpoint_monitor.go
@@ -1,0 +1,223 @@
+package telemetry
+
+import (
+	"context"
+	"crypto/tls"
+	"fmt"
+	"log/slog"
+	"net"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+// Default cadence and per-probe timeout for the endpoint cert monitor.
+const (
+	defaultEndpointCheckInterval = 6 * time.Hour
+	defaultEndpointDialTimeout   = 10 * time.Second
+
+	// Day thresholds at which a served cert's remaining validity escalates
+	// healthy → warn → critical in the logs. The Prometheus alert rules in
+	// deployments/alerts/tls-cert.rules.yml mirror these numbers.
+	certWarnDays     = 30
+	certCriticalDays = 14
+)
+
+// EndpointCertMonitor periodically TLS-dials a set of live endpoints and
+// exposes the *served* leaf certificate's expiry as Prometheus gauges.
+//
+// Unlike the file-based CertMonitor, this reads the certificate the server
+// actually presents on the wire, so it covers TLS terminated OUTSIDE the
+// app process — e.g. the Fly-managed cert on the client WebSocket port
+// (4443), which no on-disk file monitor can ever see. That blind spot is
+// exactly what let the 4443 cert lapse unnoticed in the 2026-07 outage
+// (MYR-188).
+type EndpointCertMonitor struct {
+	expiryGauge    *prometheus.GaugeVec
+	daysGauge      *prometheus.GaugeVec
+	reachableGauge *prometheus.GaugeVec
+	endpoints      []string
+	dialTimeout    time.Duration
+	checkInterval  time.Duration
+	logger         *slog.Logger
+}
+
+// EndpointCertMonitorConfig configures an EndpointCertMonitor.
+type EndpointCertMonitorConfig struct {
+	// Endpoints is the list of host:port addresses to TLS-dial. Example:
+	// {"telemetry.myrobotaxi.app:443", "telemetry.myrobotaxi.app:4443"}.
+	Endpoints []string
+
+	// CheckInterval is how often to re-probe every endpoint. Default: 6h.
+	CheckInterval time.Duration
+
+	// DialTimeout bounds each individual TLS handshake. Default: 10s.
+	DialTimeout time.Duration
+}
+
+// NewEndpointCertMonitor creates an EndpointCertMonitor and registers its
+// Prometheus metrics on reg.
+func NewEndpointCertMonitor(cfg EndpointCertMonitorConfig, reg prometheus.Registerer, logger *slog.Logger) *EndpointCertMonitor {
+	if cfg.CheckInterval == 0 {
+		cfg.CheckInterval = defaultEndpointCheckInterval
+	}
+	if cfg.DialTimeout == 0 {
+		cfg.DialTimeout = defaultEndpointDialTimeout
+	}
+
+	m := &EndpointCertMonitor{
+		expiryGauge: prometheus.NewGaugeVec(prometheus.GaugeOpts{
+			Namespace: "telemetry",
+			Subsystem: "tls",
+			Name:      "endpoint_cert_expiry_timestamp_seconds",
+			Help:      "Unix timestamp when the certificate served at the endpoint expires.",
+		}, []string{"endpoint"}),
+		daysGauge: prometheus.NewGaugeVec(prometheus.GaugeOpts{
+			Namespace: "telemetry",
+			Subsystem: "tls",
+			Name:      "endpoint_cert_expiry_days_remaining",
+			Help:      "Days until the certificate served at the endpoint expires.",
+		}, []string{"endpoint"}),
+		reachableGauge: prometheus.NewGaugeVec(prometheus.GaugeOpts{
+			Namespace: "telemetry",
+			Subsystem: "tls",
+			Name:      "endpoint_cert_reachable",
+			Help:      "1 if the endpoint's certificate was read on the last probe, else 0.",
+		}, []string{"endpoint"}),
+		endpoints:     cfg.Endpoints,
+		dialTimeout:   cfg.DialTimeout,
+		checkInterval: cfg.CheckInterval,
+		logger:        logger,
+	}
+
+	reg.MustRegister(m.expiryGauge, m.daysGauge, m.reachableGauge)
+	return m
+}
+
+// Run starts the periodic probe loop. It blocks until ctx is cancelled;
+// call it in a goroutine.
+func (m *EndpointCertMonitor) Run(ctx context.Context) {
+	m.checkAll(ctx)
+
+	ticker := time.NewTicker(m.checkInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			m.checkAll(ctx)
+		}
+	}
+}
+
+// checkAll probes every configured endpoint once and updates metrics.
+func (m *EndpointCertMonitor) checkAll(ctx context.Context) {
+	for _, ep := range m.endpoints {
+		m.checkOne(ctx, ep)
+	}
+}
+
+// checkOne TLS-dials a single endpoint, records the served leaf's expiry,
+// and logs an escalating message as the remaining validity shrinks.
+func (m *EndpointCertMonitor) checkOne(ctx context.Context, endpoint string) {
+	expiry, err := m.probeExpiry(ctx, endpoint)
+	if err != nil {
+		m.logger.Error("tls endpoint cert probe failed",
+			slog.String("endpoint", endpoint),
+			slog.String("error", err.Error()),
+		)
+		m.reachableGauge.WithLabelValues(endpoint).Set(0)
+		// Deliberately leave the expiry/days gauges at their last known
+		// value rather than zeroing them: a transient dial failure must
+		// not read as "expires at epoch 0" and page on its own. The
+		// reachable gauge going to 0 is the signal for an unreachable
+		// endpoint; a separate alert rule watches it.
+		return
+	}
+
+	m.reachableGauge.WithLabelValues(endpoint).Set(1)
+	m.expiryGauge.WithLabelValues(endpoint).Set(float64(expiry.Unix()))
+
+	days := time.Until(expiry).Hours() / 24
+	m.daysGauge.WithLabelValues(endpoint).Set(days)
+
+	switch {
+	case days < certCriticalDays:
+		m.logger.Error("tls endpoint cert expiring imminently",
+			slog.String("endpoint", endpoint),
+			slog.Float64("days_remaining", days),
+			slog.Time("expires", expiry),
+		)
+	case days < certWarnDays:
+		m.logger.Warn("tls endpoint cert expiring soon",
+			slog.String("endpoint", endpoint),
+			slog.Float64("days_remaining", days),
+			slog.Time("expires", expiry),
+		)
+	default:
+		m.logger.Debug("tls endpoint cert checked",
+			slog.String("endpoint", endpoint),
+			slog.Float64("days_remaining", days),
+			slog.Time("expires", expiry),
+		)
+	}
+}
+
+// probeExpiry TLS-dials endpoint and returns the served leaf certificate's
+// NotAfter.
+//
+// Certificate verification is intentionally disabled: the entire point is
+// to read the expiry of whatever cert is served, including an expired or
+// hostname-mismatched one — a validating dial would fail the handshake and
+// tell us nothing. The served leaf is captured via a VerifyConnection hook
+// (which runs regardless of InsecureSkipVerify, and on resumed sessions) so
+// that even the Tesla mTLS port (443), which aborts the handshake because
+// we present no client certificate, still yields the server cert it sent
+// before aborting.
+func (m *EndpointCertMonitor) probeExpiry(ctx context.Context, endpoint string) (time.Time, error) {
+	host, _, err := net.SplitHostPort(endpoint)
+	if err != nil {
+		return time.Time{}, fmt.Errorf("parsing endpoint %q: %w", endpoint, err)
+	}
+
+	var leafExpiry time.Time
+	capture := func(cs tls.ConnectionState) error {
+		if len(cs.PeerCertificates) > 0 {
+			leafExpiry = cs.PeerCertificates[0].NotAfter
+		}
+		return nil
+	}
+
+	dialer := &tls.Dialer{
+		NetDialer: &net.Dialer{Timeout: m.dialTimeout},
+		Config: &tls.Config{
+			ServerName:         host, // SNI — Fly serves the right cert per hostname
+			InsecureSkipVerify: true, //nolint:gosec // G402: we read the served cert's expiry; an expired/invalid cert must be inspected, not rejected
+			MinVersion:         tls.VersionTLS12,
+			VerifyConnection:   capture,
+		},
+	}
+
+	dialCtx, cancel := context.WithTimeout(ctx, m.dialTimeout)
+	defer cancel()
+
+	conn, dialErr := dialer.DialContext(dialCtx, "tcp", endpoint)
+	if conn != nil {
+		_ = conn.Close()
+	}
+
+	// The mTLS listener (443) requires a client cert we don't present, so
+	// DialContext returns an error AFTER the server has already sent its
+	// certificate — which the capture hook recorded. Prefer the captured
+	// expiry; only surface the dial error when we captured nothing.
+	switch {
+	case !leafExpiry.IsZero():
+		return leafExpiry, nil
+	case dialErr != nil:
+		return time.Time{}, fmt.Errorf("tls dial %s: %w", endpoint, dialErr)
+	default:
+		return time.Time{}, fmt.Errorf("endpoint %s presented no certificate", endpoint)
+	}
+}

--- a/internal/telemetry/cert_endpoint_monitor_test.go
+++ b/internal/telemetry/cert_endpoint_monitor_test.go
@@ -1,0 +1,209 @@
+package telemetry
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"io"
+	"log/slog"
+	"math/big"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+// startTestTLSServer starts a TLS listener on 127.0.0.1 serving a
+// self-signed cert with the given validity and client-auth policy, and
+// returns its host:port. The listener is closed on test cleanup.
+func startTestTLSServer(t *testing.T, validity time.Duration, clientAuth tls.ClientAuthType) string {
+	t.Helper()
+
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("generating key: %v", err)
+	}
+	tmpl := &x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject:      pkix.Name{CommonName: "localhost"},
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     time.Now().Add(validity),
+		DNSNames:     []string{"localhost"},
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &key.PublicKey, key)
+	if err != nil {
+		t.Fatalf("creating cert: %v", err)
+	}
+
+	cfg := &tls.Config{
+		Certificates: []tls.Certificate{{Certificate: [][]byte{der}, PrivateKey: key}},
+		MinVersion:   tls.VersionTLS12,
+		ClientAuth:   clientAuth,
+	}
+	if clientAuth == tls.RequireAndVerifyClientCert {
+		// A CA pool the (absent) client cert can never satisfy, forcing the
+		// server to abort the handshake AFTER it has already sent its own
+		// certificate — mirrors the Tesla mTLS (443) path the monitor must
+		// still be able to read.
+		pool := x509.NewCertPool()
+		leaf, err := x509.ParseCertificate(der)
+		if err != nil {
+			t.Fatalf("parsing test cert: %v", err)
+		}
+		pool.AddCert(leaf)
+		cfg.ClientCAs = pool
+	}
+
+	ln, err := tls.Listen("tcp", "127.0.0.1:0", cfg)
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	t.Cleanup(func() { _ = ln.Close() })
+
+	go func() {
+		for {
+			conn, err := ln.Accept()
+			if err != nil {
+				return
+			}
+			go func(c net.Conn) {
+				if tc, ok := c.(*tls.Conn); ok {
+					_ = tc.HandshakeContext(context.Background())
+				}
+				_ = c.Close()
+			}(conn)
+		}
+	}()
+
+	return ln.Addr().String()
+}
+
+func newTestEndpointMonitor(t *testing.T, endpoints []string, reg *prometheus.Registry) *EndpointCertMonitor {
+	t.Helper()
+	logger := slog.New(slog.NewTextHandler(io.Discard, &slog.HandlerOptions{Level: slog.LevelError}))
+	return NewEndpointCertMonitor(EndpointCertMonitorConfig{
+		Endpoints:   endpoints,
+		DialTimeout: 3 * time.Second,
+	}, reg, logger)
+}
+
+func TestEndpointCertMonitorProbeExpiry(t *testing.T) {
+	valid := startTestTLSServer(t, 90*24*time.Hour, tls.NoClientCert)
+	mtls := startTestTLSServer(t, 45*24*time.Hour, tls.RequireAndVerifyClientCert)
+
+	tests := []struct {
+		name     string
+		endpoint string
+		wantErr  bool
+		wantDays float64
+	}{
+		{name: "valid server", endpoint: valid, wantDays: 90},
+		// The server requires a client cert we never present, so the
+		// handshake aborts — but the served leaf must still be read.
+		{name: "mtls server still readable", endpoint: mtls, wantDays: 45},
+		{name: "connection refused", endpoint: "127.0.0.1:1", wantErr: true},
+		{name: "missing port", endpoint: "no-port", wantErr: true},
+	}
+
+	m := newTestEndpointMonitor(t, nil, prometheus.NewRegistry())
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := m.probeExpiry(context.Background(), tt.endpoint)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got expiry %v", got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			days := time.Until(got).Hours() / 24
+			if days < tt.wantDays-2 || days > tt.wantDays+2 {
+				t.Errorf("days remaining = %v, want ~%v", days, tt.wantDays)
+			}
+		})
+	}
+}
+
+func TestEndpointCertMonitorCheckAll(t *testing.T) {
+	valid := startTestTLSServer(t, 90*24*time.Hour, tls.NoClientCert)
+	const unreachable = "127.0.0.1:1"
+
+	reg := prometheus.NewRegistry()
+	m := newTestEndpointMonitor(t, []string{valid, unreachable}, reg)
+
+	m.checkAll(context.Background())
+
+	gauges := gatherEndpointGauges(t, reg)
+
+	if got := gauges["telemetry_tls_endpoint_cert_reachable"][valid]; got != 1 {
+		t.Errorf("valid endpoint reachable = %v, want 1", got)
+	}
+	if got := gauges["telemetry_tls_endpoint_cert_reachable"][unreachable]; got != 0 {
+		t.Errorf("unreachable endpoint reachable = %v, want 0", got)
+	}
+	days := gauges["telemetry_tls_endpoint_cert_expiry_days_remaining"][valid]
+	if days < 85 || days > 95 {
+		t.Errorf("valid endpoint days remaining = %v, want ~90", days)
+	}
+	if ts := gauges["telemetry_tls_endpoint_cert_expiry_timestamp_seconds"][valid]; ts == 0 {
+		t.Error("valid endpoint expiry timestamp should be non-zero")
+	}
+}
+
+func TestEndpointCertMonitorRunCancellation(t *testing.T) {
+	valid := startTestTLSServer(t, 30*24*time.Hour, tls.NoClientCert)
+
+	reg := prometheus.NewRegistry()
+	logger := slog.New(slog.NewTextHandler(io.Discard, &slog.HandlerOptions{Level: slog.LevelError}))
+	m := NewEndpointCertMonitor(EndpointCertMonitorConfig{
+		Endpoints:     []string{valid},
+		CheckInterval: 50 * time.Millisecond,
+		DialTimeout:   3 * time.Second,
+	}, reg, logger)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() {
+		m.Run(ctx)
+		close(done)
+	}()
+
+	time.Sleep(150 * time.Millisecond)
+	cancel()
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("Run did not return after context cancellation")
+	}
+}
+
+// gatherEndpointGauges returns metric_name → endpoint_label → value for
+// every gauge in reg that carries an "endpoint" label.
+func gatherEndpointGauges(t *testing.T, reg *prometheus.Registry) map[string]map[string]float64 {
+	t.Helper()
+	families, err := reg.Gather()
+	if err != nil {
+		t.Fatalf("gathering metrics: %v", err)
+	}
+	out := make(map[string]map[string]float64)
+	for _, f := range families {
+		vals := make(map[string]float64)
+		for _, metric := range f.GetMetric() {
+			for _, label := range metric.GetLabel() {
+				if label.GetName() == "endpoint" {
+					vals[label.GetValue()] = metric.GetGauge().GetValue()
+				}
+			}
+		}
+		out[f.GetName()] = vals
+	}
+	return out
+}

--- a/scripts/check-cert-expiry.sh
+++ b/scripts/check-cert-expiry.sh
@@ -14,18 +14,26 @@ set -euo pipefail
 #   --certs-dir DIR     Certificate directory (default: ./certs)
 #   --warn-days N       Warning threshold in days (default: 30)
 #   --cert FILE         Check a specific certificate file instead of the directory
+#   --endpoint HOST:PORT  Check the cert SERVED at a live TLS endpoint (repeatable).
+#                         Reads the leaf the server actually presents — covers
+#                         TLS terminated outside the app (e.g. the Fly-managed
+#                         4443 cert) that no file check can see. Works against
+#                         the mTLS 443 port too (the server sends its cert
+#                         before aborting the client-cert-less handshake).
 #   --json              Output results as JSON (for monitoring integration)
 #   --help              Show this help message
 #
 # Exit codes:
 #   0 — All certificates are valid and not expiring soon
-#   1 — Error (missing files, invalid certs, etc.)
+#   1 — Error (missing files, invalid certs, unreachable endpoint, etc.)
 #   2 — One or more certificates expire within the warning threshold
 #
 # Examples:
 #   ./scripts/check-cert-expiry.sh
 #   ./scripts/check-cert-expiry.sh --warn-days 14 --json
 #   ./scripts/check-cert-expiry.sh --cert /etc/ssl/server.crt
+#   ./scripts/check-cert-expiry.sh --endpoint telemetry.myrobotaxi.app:443 \
+#                                  --endpoint telemetry.myrobotaxi.app:4443
 
 readonly SCRIPT_NAME="$(basename "$0")"
 
@@ -34,6 +42,7 @@ CERTS_DIR="./certs"
 WARN_DAYS=30
 SPECIFIC_CERT=""
 JSON_OUTPUT=false
+declare -a ENDPOINTS=()
 
 # Tracking for exit code.
 EXIT_CODE=0
@@ -128,6 +137,35 @@ check_cert() {
     fi
 }
 
+# Check the certificate a live TLS endpoint actually serves. Fetches the
+# leaf via `openssl s_client` (which prints the server cert even when an
+# mTLS server later aborts the handshake for want of a client cert) and
+# reuses check_cert for the expiry math and thresholds.
+check_endpoint() {
+    local endpoint="$1"
+    local host="${endpoint%%:*}"
+
+    if [[ "$endpoint" != *:* || -z "$host" || "$endpoint" == "${host}:" ]]; then
+        error "Invalid endpoint (want HOST:PORT): $endpoint"
+        EXIT_CODE=1
+        return
+    fi
+
+    local tmp
+    tmp="$(mktemp)"
+
+    if ! echo | openssl s_client -connect "$endpoint" -servername "$host" 2>/dev/null \
+        | openssl x509 -outform pem >"$tmp" 2>/dev/null || [[ ! -s "$tmp" ]]; then
+        error "Failed to fetch certificate from $endpoint (TLS handshake failed or no cert served)"
+        EXIT_CODE=1
+        rm -f "$tmp"
+        return
+    fi
+
+    check_cert "$tmp" "$endpoint"
+    rm -f "$tmp"
+}
+
 # ─── Argument parsing ─────────────────────────────────────────────────
 
 parse_args() {
@@ -146,6 +184,10 @@ parse_args() {
                 ;;
             --cert)
                 SPECIFIC_CERT="${2:?--cert requires a value}"
+                shift 2
+                ;;
+            --endpoint)
+                ENDPOINTS+=("${2:?--endpoint requires a HOST:PORT value}")
                 shift 2
                 ;;
             --json)
@@ -174,9 +216,15 @@ main() {
         die "openssl is not installed."
     fi
 
-    if [[ -n "$SPECIFIC_CERT" ]]; then
-        # Check a single cert.
-        check_cert "$SPECIFIC_CERT" "$(basename "$SPECIFIC_CERT")"
+    if [[ ${#ENDPOINTS[@]} -gt 0 || -n "$SPECIFIC_CERT" ]]; then
+        # Explicit targets: live endpoints and/or a single cert file. When
+        # either is given we do NOT also scan the certs dir.
+        for endpoint in "${ENDPOINTS[@]}"; do
+            check_endpoint "$endpoint"
+        done
+        if [[ -n "$SPECIFIC_CERT" ]]; then
+            check_cert "$SPECIFIC_CERT" "$(basename "$SPECIFIC_CERT")"
+        fi
     else
         # Check all certs in the directory.
         if [[ ! -d "$CERTS_DIR" ]]; then


### PR DESCRIPTION
Closes MYR-188. Follow-up to the 2026-07-05 TLS-expiry outage.

## Problem

The outage cert — the **Fly-managed cert on the 4443 client port** — was never monitored and couldn't be: `internal/telemetry/cert_monitor.go` reads cert **files** off disk, and that cert never exists as a file on the app (Fly terminates it). Worse, `NewCertMonitor` was **never even wired in**, so nothing was monitoring *any* cert. Both the app's 443 mTLS cert and the Fly 4443 cert lapsed with zero warning.

## What this adds

- **`EndpointCertMonitor`** (`internal/telemetry/cert_endpoint_monitor.go`) — TLS-dials each endpoint in `TLS_MONITOR_ENDPOINTS` and exposes the **served** leaf's expiry as gauges (`telemetry_tls_endpoint_cert_expiry_days_remaining` / `_timestamp_seconds` / `_reachable`, labelled by `endpoint`). Reads the cert regardless of who terminates TLS, so it sees the Fly 4443 cert the file monitor can't.
  - Verification is disabled on purpose (must read expired/mismatched certs, not reject them); the leaf is captured via `VerifyConnection`, so the **mTLS 443 port still reports** even though it aborts the handshake for want of a client cert. Table-driven tests cover valid / mTLS-abort / unreachable / malformed-endpoint.
  - **Actually wired into `main`** (`startCertEndpointMonitor`) — the first cert monitor that runs.
- **Prometheus alerts** (`deployments/alerts/tls-cert.rules.yml`) — escalating warning (<30d) → critical (<14d) → page (<7d/expired), plus a critical on 15m unreachability. Wired via `rule_files`.
- **`scripts/check-cert-expiry.sh --endpoint HOST:PORT`** — checks the live prod certs (both 443 and 4443), not just the dev `./certs` dir. Verified against production (both read `→ Oct 3`).
- **Runbook** (`docs/tls-certificates.md`) — split-TLS topology, per-cert renewal, the two ACME gotchas, and `.env.example` docs.

## Scope note — 443 auto-renewal deferred (documented)

The wildcard `*.myrobotaxi.app` cert is `certbot --manual`, so it does **not** auto-renew. Automating it (Dynadot API / acme.sh auth-hook that re-sets the Fly secrets) is a bigger, separate change; per the AC it's documented as a tracked manual task before **2026-10-03**, with these alerts as the safety net. Happy to split that into its own issue.

## Testing

- `go build ./...`, `go vet`, `golangci-lint run` → 0 issues
- `go test ./internal/telemetry/ ./internal/config/ ./cmd/telemetry-server/` → pass
- Alert YAML validated; `check-cert-expiry.sh --endpoint` run against live prod.

🤖 Generated with [Claude Code](https://claude.com/claude-code)