### PR TITLE
MYR-189 feat(fleet): GET /api/fleet-config/{vin} config status endpoint (synced + expiry)

### DIFF
--- a/cmd/telemetry-server/wiring.go
+++ b/cmd/telemetry-server/wiring.go
@@ -384,7 +384,8 @@ func setupFleetConfigEndpoint(
 	)
 
 	srv.HandleFunc("POST /api/fleet-config/{vin}", fleetHandler.ServeHTTP)
-	logger.Info("fleet config push endpoint enabled",
+	srv.HandleFunc("GET /api/fleet-config/{vin}", fleetHandler.ServeHTTP)
+	logger.Info("fleet config endpoints enabled (GET status + POST re-push)",
 		slog.String("proxy_url", cfg.Proxy().URL),
 	)
 }

--- a/docs/contracts/rest-api.md
+++ b/docs/contracts/rest-api.md
@@ -232,7 +232,7 @@ Per-site audit (REST surface in `internal/telemetry/`, WS surface in `internal/w
 | [`vehicle_status_handler.go`](../../internal/telemetry/vehicle_status_handler.go) — vehicle ownership mismatch | 403 | `ErrCodeVehicleNotOwned` | Caller's `userID` ≠ vehicle's `ownerID` |
 | [`vehicle_status_handler.go`](../../internal/telemetry/vehicle_status_handler.go) — DB lookup error | 500 | `ErrCodeInternalError` | `GetVehicleOwner` returns non-`ErrNotFound` |
 | [`vehicle_status_mask.go`](../../internal/telemetry/vehicle_status_mask.go) — role resolution error | 500 | `ErrCodeInternalError` | `ResolveRole` returns error |
-| [`fleet_config_handler.go`](../../internal/telemetry/fleet_config_handler.go) — wrong method | 405 | `ErrCodeInvalidRequest` | `r.Method != POST` |
+| [`fleet_config_handler.go`](../../internal/telemetry/fleet_config_handler.go) — wrong method | 405 | `ErrCodeInvalidRequest` | Method is neither `GET` (config status) nor `POST` (re-push) |
 | [`fleet_config_handler.go`](../../internal/telemetry/fleet_config_handler.go) — invalid VIN | 400 | `ErrCodeInvalidRequest` | Malformed `{vin}` path param |
 | [`fleet_config_handler.go`](../../internal/telemetry/fleet_config_handler.go) — missing/invalid Authorization | 401 | `ErrCodeAuthFailed` | Header omitted or `ValidateToken` fails |
 | [`fleet_config_handler.go`](../../internal/telemetry/fleet_config_handler.go) — vehicle ownership mismatch | 403 | `ErrCodeVehicleNotOwned` | Caller's `userID` ≠ vehicle's `ownerID` |

--- a/internal/telemetry/fleet_api.go
+++ b/internal/telemetry/fleet_api.go
@@ -8,7 +8,6 @@ import (
 	"io"
 	"log/slog"
 	"net/http"
-	neturl "net/url"
 	"time"
 )
 
@@ -129,78 +128,6 @@ func (c *FleetAPIClient) PushTelemetryConfig(
 	return &result, nil
 }
 
-// GetTelemetryErrors retrieves recent telemetry connection errors for a
-// vehicle from the Fleet API. Useful for diagnosing why a vehicle is
-// not sending telemetry.
-func (c *FleetAPIClient) GetTelemetryErrors(
-	ctx context.Context,
-	token string,
-	vin string,
-) (*FleetErrorsResponse, error) {
-	if token == "" {
-		return nil, fmt.Errorf("GetTelemetryErrors: auth token is required")
-	}
-	if len(vin) != 17 {
-		return nil, fmt.Errorf("GetTelemetryErrors: invalid VIN %q (must be 17 characters)", redactVIN(vin))
-	}
-
-	url := c.baseURL + "/api/1/vehicles/" + neturl.PathEscape(vin) + "/fleet_telemetry_errors"
-
-	c.logger.Debug("fetching telemetry errors",
-		slog.String("vin", redactVIN(vin)),
-	)
-
-	respBody, err := c.doWithRetry(ctx, http.MethodGet, url, token, nil)
-	if err != nil {
-		return nil, fmt.Errorf("GetTelemetryErrors(%s): %w", redactVIN(vin), err)
-	}
-
-	var result FleetErrorsResponse
-	if err := json.Unmarshal(respBody, &result); err != nil {
-		return nil, fmt.Errorf("GetTelemetryErrors(%s): decode response: %w", redactVIN(vin), err)
-	}
-
-	c.logger.Debug("telemetry errors retrieved",
-		slog.String("vin", redactVIN(vin)),
-		slog.Int("count", len(result.Response.Errors)),
-	)
-
-	return &result, nil
-}
-
-// GetTelemetryConfig retrieves a vehicle's current fleet telemetry config
-// state from the Fleet API — chiefly the "synced" flag (whether the vehicle
-// has received and applied a config). The token must be a valid OAuth2
-// Bearer token for the fleet owner.
-func (c *FleetAPIClient) GetTelemetryConfig(
-	ctx context.Context,
-	token string,
-	vin string,
-) (*FleetConfigStatusResponse, error) {
-	if token == "" {
-		return nil, fmt.Errorf("GetTelemetryConfig: auth token is required")
-	}
-	if len(vin) != vinLength {
-		return nil, fmt.Errorf("GetTelemetryConfig: invalid VIN %q (must be 17 characters)", redactVIN(vin))
-	}
-
-	url := c.baseURL + "/api/1/vehicles/" + neturl.PathEscape(vin) + "/fleet_telemetry_config"
-
-	c.logger.Debug("fetching telemetry config status", slog.String("vin", redactVIN(vin)))
-
-	respBody, err := c.doWithRetry(ctx, http.MethodGet, url, token, nil)
-	if err != nil {
-		return nil, fmt.Errorf("GetTelemetryConfig(%s): %w", redactVIN(vin), err)
-	}
-
-	var result FleetConfigStatusResponse
-	if err := json.Unmarshal(respBody, &result); err != nil {
-		return nil, fmt.Errorf("GetTelemetryConfig(%s): decode response: %w", redactVIN(vin), err)
-	}
-
-	return &result, nil
-}
-
 // doWithRetry executes an HTTP request with retry logic for rate
 // limiting (429) and server errors (5xx).
 func (c *FleetAPIClient) doWithRetry(
@@ -220,11 +147,12 @@ func (c *FleetAPIClient) doWithRetry(
 			)
 		}
 
-		// #nosec G704 -- SSRF taint: url's scheme+host is always the fixed
-		// Fleet API base (config, not user input); callers only interpolate
-		// validated, PathEscape'd VINs as path segments, so the request
-		// target host is never attacker-controlled.
-		req, err := http.NewRequestWithContext(ctx, method, url, newBodyReader(body)) //nolint:gosec // G704: host is fixed config — see #nosec note above
+		// #nosec G107 G704 -- SSRF taint (reported as G704 by the pinned
+		// gosec; G107 is the classic URL-taint id): url's scheme+host is
+		// always the fixed Fleet API base (config, not user input); callers
+		// only interpolate validated, PathEscape'd VINs as path segments, so
+		// the request target host is never attacker-controlled.
+		req, err := http.NewRequestWithContext(ctx, method, url, newBodyReader(body)) //nolint:gosec // host is fixed config — see #nosec note above
 		if err != nil {
 			return nil, fmt.Errorf("create request: %w", err)
 		}
@@ -234,9 +162,9 @@ func (c *FleetAPIClient) doWithRetry(
 			req.Header.Set("Content-Type", "application/json")
 		}
 
-		// #nosec G704 -- request target host is the fixed Fleet API base
-		// (see note above); no attacker control of scheme/host.
-		resp, err := c.httpClient.Do(req) //nolint:gosec // G704: host is fixed config
+		// #nosec G107 G704 -- request target host is the fixed Fleet API
+		// base (see note above); no attacker control of scheme/host.
+		resp, err := c.httpClient.Do(req) //nolint:gosec // host is fixed config
 		if err != nil {
 			lastErr = fmt.Errorf("http request: %w", err)
 			// Network errors are not retried — they are likely transient

--- a/internal/telemetry/fleet_api.go
+++ b/internal/telemetry/fleet_api.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"log/slog"
 	"net/http"
+	neturl "net/url"
 	"time"
 )
 
@@ -143,7 +144,7 @@ func (c *FleetAPIClient) GetTelemetryErrors(
 		return nil, fmt.Errorf("GetTelemetryErrors: invalid VIN %q (must be 17 characters)", redactVIN(vin))
 	}
 
-	url := c.baseURL + "/api/1/vehicles/" + vin + "/fleet_telemetry_errors"
+	url := c.baseURL + "/api/1/vehicles/" + neturl.PathEscape(vin) + "/fleet_telemetry_errors"
 
 	c.logger.Debug("fetching telemetry errors",
 		slog.String("vin", redactVIN(vin)),
@@ -167,6 +168,39 @@ func (c *FleetAPIClient) GetTelemetryErrors(
 	return &result, nil
 }
 
+// GetTelemetryConfig retrieves a vehicle's current fleet telemetry config
+// state from the Fleet API — chiefly the "synced" flag (whether the vehicle
+// has received and applied a config). The token must be a valid OAuth2
+// Bearer token for the fleet owner.
+func (c *FleetAPIClient) GetTelemetryConfig(
+	ctx context.Context,
+	token string,
+	vin string,
+) (*FleetConfigStatusResponse, error) {
+	if token == "" {
+		return nil, fmt.Errorf("GetTelemetryConfig: auth token is required")
+	}
+	if len(vin) != vinLength {
+		return nil, fmt.Errorf("GetTelemetryConfig: invalid VIN %q (must be 17 characters)", redactVIN(vin))
+	}
+
+	url := c.baseURL + "/api/1/vehicles/" + neturl.PathEscape(vin) + "/fleet_telemetry_config"
+
+	c.logger.Debug("fetching telemetry config status", slog.String("vin", redactVIN(vin)))
+
+	respBody, err := c.doWithRetry(ctx, http.MethodGet, url, token, nil)
+	if err != nil {
+		return nil, fmt.Errorf("GetTelemetryConfig(%s): %w", redactVIN(vin), err)
+	}
+
+	var result FleetConfigStatusResponse
+	if err := json.Unmarshal(respBody, &result); err != nil {
+		return nil, fmt.Errorf("GetTelemetryConfig(%s): decode response: %w", redactVIN(vin), err)
+	}
+
+	return &result, nil
+}
+
 // doWithRetry executes an HTTP request with retry logic for rate
 // limiting (429) and server errors (5xx).
 func (c *FleetAPIClient) doWithRetry(
@@ -186,7 +220,11 @@ func (c *FleetAPIClient) doWithRetry(
 			)
 		}
 
-		req, err := http.NewRequestWithContext(ctx, method, url, newBodyReader(body))
+		// #nosec G704 -- SSRF taint: url's scheme+host is always the fixed
+		// Fleet API base (config, not user input); callers only interpolate
+		// validated, PathEscape'd VINs as path segments, so the request
+		// target host is never attacker-controlled.
+		req, err := http.NewRequestWithContext(ctx, method, url, newBodyReader(body)) //nolint:gosec // G704: host is fixed config — see #nosec note above
 		if err != nil {
 			return nil, fmt.Errorf("create request: %w", err)
 		}
@@ -196,7 +234,9 @@ func (c *FleetAPIClient) doWithRetry(
 			req.Header.Set("Content-Type", "application/json")
 		}
 
-		resp, err := c.httpClient.Do(req)
+		// #nosec G704 -- request target host is the fixed Fleet API base
+		// (see note above); no attacker control of scheme/host.
+		resp, err := c.httpClient.Do(req) //nolint:gosec // G704: host is fixed config
 		if err != nil {
 			lastErr = fmt.Errorf("http request: %w", err)
 			// Network errors are not retried — they are likely transient

--- a/internal/telemetry/fleet_api_types.go
+++ b/internal/telemetry/fleet_api_types.go
@@ -49,6 +49,28 @@ type FleetConfigResult struct {
 	SkippedVehicles map[string]string `json:"skipped_vehicles"`
 }
 
+// FleetConfigStatusResponse wraps the payload of GET
+// /api/1/vehicles/{vin}/fleet_telemetry_config.
+type FleetConfigStatusResponse struct {
+	Response FleetConfigStatus `json:"response"`
+}
+
+// FleetConfigStatus is the vehicle's current telemetry-config state as
+// reported by Tesla. Synced is always present; Config is echoed back with
+// the applied settings. Exp is best-effort — Tesla documents Synced but not
+// that it echoes exp, so callers must treat a nil Exp as "unknown".
+type FleetConfigStatus struct {
+	Synced bool                    `json:"synced"`
+	Config *FleetConfigStatusInner `json:"config"`
+}
+
+// FleetConfigStatusInner is the subset of the echoed config we surface.
+type FleetConfigStatusInner struct {
+	Hostname string `json:"hostname"`
+	Port     int    `json:"port"`
+	Exp      *int64 `json:"exp"`
+}
+
 // FleetErrorsResponse wraps the list of telemetry errors returned
 // by GET /api/1/vehicles/{vin}/fleet_telemetry_errors.
 type FleetErrorsResponse struct {

--- a/internal/telemetry/fleet_api_vehicle_get.go
+++ b/internal/telemetry/fleet_api_vehicle_get.go
@@ -1,0 +1,82 @@
+package telemetry
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"net/http"
+	neturl "net/url"
+)
+
+// GetTelemetryConfig retrieves a vehicle's current fleet telemetry config
+// state from the Fleet API — chiefly the "synced" flag (whether the vehicle
+// has received and applied a config). The token must be a valid OAuth2
+// Bearer token for the fleet owner.
+func (c *FleetAPIClient) GetTelemetryConfig(
+	ctx context.Context,
+	token string,
+	vin string,
+) (*FleetConfigStatusResponse, error) {
+	if token == "" {
+		return nil, fmt.Errorf("GetTelemetryConfig: auth token is required")
+	}
+	if len(vin) != vinLength {
+		return nil, fmt.Errorf("GetTelemetryConfig: invalid VIN %q (must be 17 characters)", redactVIN(vin))
+	}
+
+	url := c.baseURL + "/api/1/vehicles/" + neturl.PathEscape(vin) + "/fleet_telemetry_config"
+
+	c.logger.Debug("fetching telemetry config status", slog.String("vin", redactVIN(vin)))
+
+	respBody, err := c.doWithRetry(ctx, http.MethodGet, url, token, nil)
+	if err != nil {
+		return nil, fmt.Errorf("GetTelemetryConfig(%s): %w", redactVIN(vin), err)
+	}
+
+	var result FleetConfigStatusResponse
+	if err := json.Unmarshal(respBody, &result); err != nil {
+		return nil, fmt.Errorf("GetTelemetryConfig(%s): decode response: %w", redactVIN(vin), err)
+	}
+
+	return &result, nil
+}
+
+// GetTelemetryErrors retrieves recent telemetry connection errors for a
+// vehicle from the Fleet API. Useful for diagnosing why a vehicle is
+// not sending telemetry.
+func (c *FleetAPIClient) GetTelemetryErrors(
+	ctx context.Context,
+	token string,
+	vin string,
+) (*FleetErrorsResponse, error) {
+	if token == "" {
+		return nil, fmt.Errorf("GetTelemetryErrors: auth token is required")
+	}
+	if len(vin) != vinLength {
+		return nil, fmt.Errorf("GetTelemetryErrors: invalid VIN %q (must be 17 characters)", redactVIN(vin))
+	}
+
+	url := c.baseURL + "/api/1/vehicles/" + neturl.PathEscape(vin) + "/fleet_telemetry_errors"
+
+	c.logger.Debug("fetching telemetry errors",
+		slog.String("vin", redactVIN(vin)),
+	)
+
+	respBody, err := c.doWithRetry(ctx, http.MethodGet, url, token, nil)
+	if err != nil {
+		return nil, fmt.Errorf("GetTelemetryErrors(%s): %w", redactVIN(vin), err)
+	}
+
+	var result FleetErrorsResponse
+	if err := json.Unmarshal(respBody, &result); err != nil {
+		return nil, fmt.Errorf("GetTelemetryErrors(%s): decode response: %w", redactVIN(vin), err)
+	}
+
+	c.logger.Debug("telemetry errors retrieved",
+		slog.String("vin", redactVIN(vin)),
+		slog.Int("count", len(result.Response.Errors)),
+	)
+
+	return &result, nil
+}

--- a/internal/telemetry/fleet_config_handler.go
+++ b/internal/telemetry/fleet_config_handler.go
@@ -162,57 +162,6 @@ func (h *FleetConfigHandler) handlePush(w http.ResponseWriter, r *http.Request) 
 	})
 }
 
-// fleetConfigStatusResponse is the GET /api/fleet-config/{vin} body. Synced
-// comes straight from Tesla. The expiry fields are populated only when Tesla
-// echoes the config's `exp` (undocumented but often present); when it does
-// not, ExpiresAt is empty and DaysRemaining is nil, and the UI falls back to
-// the Synced flag to convey "streaming vs not".
-type fleetConfigStatusResponse struct {
-	VIN           string `json:"vin"`
-	Synced        bool   `json:"synced"`
-	Hostname      string `json:"hostname,omitempty"`
-	Port          int    `json:"port,omitempty"`
-	ExpiresAt     string `json:"expiresAt,omitempty"` // RFC3339; empty if exp unknown
-	Expired       bool   `json:"expired"`
-	DaysRemaining *int   `json:"daysRemaining,omitempty"` // nil if exp unknown
-}
-
-// handleStatus handles GET /api/fleet-config/{vin} — reports the vehicle's
-// current telemetry-config state (Tesla's synced flag plus best-effort
-// expiry) so the UI can show whether a re-push is needed.
-func (h *FleetConfigHandler) handleStatus(w http.ResponseWriter, r *http.Request) {
-	vin, teslaTok, ok := h.authorize(w, r)
-	if !ok {
-		return
-	}
-	ctx := r.Context()
-
-	status, err := h.fleet.GetTelemetryConfig(ctx, teslaTok.AccessToken, vin)
-	if err != nil {
-		h.handleFleetAPIError(w, vin, err)
-		return
-	}
-
-	resp := fleetConfigStatusResponse{
-		VIN:    redactVIN(vin),
-		Synced: status.Response.Synced,
-	}
-	if cfg := status.Response.Config; cfg != nil {
-		resp.Hostname = cfg.Hostname
-		resp.Port = cfg.Port
-		if cfg.Exp != nil {
-			expiresAt := time.Unix(*cfg.Exp, 0).UTC()
-			remaining := time.Until(expiresAt)
-			days := int(remaining.Hours() / 24)
-			resp.ExpiresAt = expiresAt.Format(time.RFC3339)
-			resp.Expired = remaining <= 0
-			resp.DaysRemaining = &days
-		}
-	}
-
-	h.writeJSON(w, http.StatusOK, resp)
-}
-
 // verifyOwnership checks that userID owns the vehicle identified by vin.
 // Returns true if the ownership check passes. On failure it writes an HTTP
 // error response and returns false.

--- a/internal/telemetry/fleet_config_handler.go
+++ b/internal/telemetry/fleet_config_handler.go
@@ -56,23 +56,34 @@ func NewFleetConfigHandler(
 	return h
 }
 
-// ServeHTTP handles the fleet config push request.
+// ServeHTTP routes GET (status) and POST (re-push) for
+// /api/fleet-config/{vin}.
 func (h *FleetConfigHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	if r.Method != http.MethodPost {
+	switch r.Method {
+	case http.MethodPost:
+		h.handlePush(w, r)
+	case http.MethodGet:
+		h.handleStatus(w, r)
+	default:
 		h.writeError(w, http.StatusMethodNotAllowed, wserrors.ErrCodeInvalidRequest, "method not allowed")
-		return
 	}
+}
 
+// authorize validates the VIN and caller JWT, checks vehicle ownership, and
+// resolves the caller's (auto-refreshed) Tesla token — the common front
+// half of both the push and status paths. On any failure it writes the
+// error response and returns ok=false.
+func (h *FleetConfigHandler) authorize(w http.ResponseWriter, r *http.Request) (string, TeslaToken, bool) {
 	vin := r.PathValue("vin")
 	if len(vin) != vinLength {
 		h.writeError(w, http.StatusBadRequest, wserrors.ErrCodeInvalidRequest, "invalid VIN: must be 17 characters")
-		return
+		return "", TeslaToken{}, false
 	}
 
 	token := extractBearerToken(r)
 	if token == "" {
 		h.writeError(w, http.StatusUnauthorized, wserrors.ErrCodeAuthFailed, "missing Authorization header")
-		return
+		return "", TeslaToken{}, false
 	}
 
 	ctx := r.Context()
@@ -84,17 +95,29 @@ func (h *FleetConfigHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			slog.String("error", err.Error()),
 		)
 		h.writeError(w, http.StatusUnauthorized, wserrors.ErrCodeAuthFailed, "invalid or expired token")
-		return
+		return "", TeslaToken{}, false
 	}
 
 	if !h.verifyOwnership(ctx, w, vin, userID) {
-		return
+		return "", TeslaToken{}, false
 	}
 
 	teslaTok, ok := h.resolveTeslaToken(ctx, w, userID)
 	if !ok {
+		return "", TeslaToken{}, false
+	}
+
+	return vin, teslaTok, true
+}
+
+// handlePush handles POST /api/fleet-config/{vin} — (re)pushes the telemetry
+// config to the vehicle via the Fleet API proxy.
+func (h *FleetConfigHandler) handlePush(w http.ResponseWriter, r *http.Request) {
+	vin, teslaTok, ok := h.authorize(w, r)
+	if !ok {
 		return
 	}
+	ctx := r.Context()
 
 	var ca *string
 	if h.endpoint.CA != "" {
@@ -137,6 +160,57 @@ func (h *FleetConfigHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		Status: "configured",
 		VIN:    redactVIN(vin),
 	})
+}
+
+// fleetConfigStatusResponse is the GET /api/fleet-config/{vin} body. Synced
+// comes straight from Tesla. The expiry fields are populated only when Tesla
+// echoes the config's `exp` (undocumented but often present); when it does
+// not, ExpiresAt is empty and DaysRemaining is nil, and the UI falls back to
+// the Synced flag to convey "streaming vs not".
+type fleetConfigStatusResponse struct {
+	VIN           string `json:"vin"`
+	Synced        bool   `json:"synced"`
+	Hostname      string `json:"hostname,omitempty"`
+	Port          int    `json:"port,omitempty"`
+	ExpiresAt     string `json:"expiresAt,omitempty"` // RFC3339; empty if exp unknown
+	Expired       bool   `json:"expired"`
+	DaysRemaining *int   `json:"daysRemaining,omitempty"` // nil if exp unknown
+}
+
+// handleStatus handles GET /api/fleet-config/{vin} — reports the vehicle's
+// current telemetry-config state (Tesla's synced flag plus best-effort
+// expiry) so the UI can show whether a re-push is needed.
+func (h *FleetConfigHandler) handleStatus(w http.ResponseWriter, r *http.Request) {
+	vin, teslaTok, ok := h.authorize(w, r)
+	if !ok {
+		return
+	}
+	ctx := r.Context()
+
+	status, err := h.fleet.GetTelemetryConfig(ctx, teslaTok.AccessToken, vin)
+	if err != nil {
+		h.handleFleetAPIError(w, vin, err)
+		return
+	}
+
+	resp := fleetConfigStatusResponse{
+		VIN:    redactVIN(vin),
+		Synced: status.Response.Synced,
+	}
+	if cfg := status.Response.Config; cfg != nil {
+		resp.Hostname = cfg.Hostname
+		resp.Port = cfg.Port
+		if cfg.Exp != nil {
+			expiresAt := time.Unix(*cfg.Exp, 0).UTC()
+			remaining := time.Until(expiresAt)
+			days := int(remaining.Hours() / 24)
+			resp.ExpiresAt = expiresAt.Format(time.RFC3339)
+			resp.Expired = remaining <= 0
+			resp.DaysRemaining = &days
+		}
+	}
+
+	h.writeJSON(w, http.StatusOK, resp)
 }
 
 // verifyOwnership checks that userID owns the vehicle identified by vin.

--- a/internal/telemetry/fleet_config_handler_test.go
+++ b/internal/telemetry/fleet_config_handler_test.go
@@ -58,13 +58,18 @@ func validTeslaToken() *stubTeslaTokenProvider {
 
 // stubFleetServer starts an httptest.Server that returns predefined responses.
 // This lets us test the handler end-to-end through the real FleetAPIClient.
+// The server is closed on test cleanup, so callers must NOT Close it again
+// (double Close panics) — including the inline `stubFleetServer(t, ...).URL`
+// callers that would otherwise leak.
 func stubFleetServer(t *testing.T, statusCode int, body string) *httptest.Server {
 	t.Helper()
-	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(statusCode)
 		fmt.Fprint(w, body)
 	}))
+	t.Cleanup(srv.Close)
+	return srv
 }
 
 func discardLogger() *slog.Logger {
@@ -283,7 +288,6 @@ func TestFleetConfigHandler_ServeHTTP(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			// Start a stub Fleet API server for each test case.
 			fleetSrv := stubFleetServer(t, tt.fleetStatus, tt.fleetBody)
-			t.Cleanup(fleetSrv.Close)
 
 			fleetClient := newTestFleetClient(fleetSrv.URL)
 
@@ -505,7 +509,6 @@ func TestFleetConfigHandler_Status(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			fleetSrv := stubFleetServer(t, tt.fleetStatus, tt.fleetBody)
-			t.Cleanup(fleetSrv.Close)
 
 			handler := NewFleetConfigHandler(
 				&stubTokenValidator{userID: userID},
@@ -553,8 +556,13 @@ func TestFleetConfigHandler_Status(t *testing.T) {
 			if hasExpiry := resp.ExpiresAt != ""; hasExpiry != tt.wantHasExpiry {
 				t.Errorf("has expiry: got %v, want %v (expiresAt=%q)", hasExpiry, tt.wantHasExpiry, resp.ExpiresAt)
 			}
-			if tt.wantHasExpiry && resp.DaysRemaining == nil {
-				t.Error("expected daysRemaining to be set when expiry is present")
+			// daysRemaining is set only when expiry is known AND not expired
+			// (nil once expired so the UI branches on `expired`).
+			switch {
+			case tt.wantHasExpiry && !tt.wantExpired && resp.DaysRemaining == nil:
+				t.Error("expected daysRemaining to be set when expiry is present and not expired")
+			case tt.wantExpired && resp.DaysRemaining != nil:
+				t.Errorf("expected daysRemaining nil when expired, got %d", *resp.DaysRemaining)
 			}
 		})
 	}
@@ -581,6 +589,31 @@ func TestFleetConfigHandler_MethodNotAllowed(t *testing.T) {
 
 	if rec.Code != http.StatusMethodNotAllowed {
 		t.Errorf("status: got %d, want %d", rec.Code, http.StatusMethodNotAllowed)
+	}
+}
+
+func TestFleetConfigHandler_StatusEnforcesOwnership(t *testing.T) {
+	// GET shares authorize() with POST; guard that a non-owner is rejected
+	// on the GET path so a future refactor can't regress it.
+	handler := NewFleetConfigHandler(
+		&stubTokenValidator{userID: "user-123"},
+		&stubVehicleOwner{ownerID: "someone-else"},
+		validTeslaToken(),
+		newTestFleetClient(stubFleetServer(t, http.StatusOK, `{"response":{"synced":true}}`).URL),
+		EndpointConfig{Hostname: "telemetry.example.com", Port: 443},
+		discardLogger(),
+	)
+
+	mux := http.NewServeMux()
+	mux.Handle("GET /api/fleet-config/{vin}", handler)
+
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/api/fleet-config/5YJ3E1EA1PF000001", nil)
+	req.Header.Set("Authorization", "Bearer valid-token")
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusForbidden {
+		t.Errorf("GET status: got %d, want %d (ownership must be enforced)", rec.Code, http.StatusForbidden)
 	}
 }
 

--- a/internal/telemetry/fleet_config_handler_test.go
+++ b/internal/telemetry/fleet_config_handler_test.go
@@ -351,10 +351,10 @@ func TestFleetConfigHandler_ServeHTTP(t *testing.T) {
 
 func TestFleetConfigHandler_TeslaTokenPassedToFleetAPI(t *testing.T) {
 	const (
-		validVIN       = "5YJ3E1EA1PF000001"
-		userID         = "user-123"
-		teslaToken     = "tesla-oauth-real-token" //nolint:gosec // test fixture, not a real credential
-		successBody    = `{"response":{"updated_vehicles":1,"skipped_vehicles":{}}}`
+		validVIN    = "5YJ3E1EA1PF000001"
+		userID      = "user-123"
+		teslaToken  = "tesla-oauth-real-token" //nolint:gosec // test fixture, not a real credential
+		successBody = `{"response":{"updated_vehicles":1,"skipped_vehicles":{}}}`
 	)
 
 	// Capture the Authorization header sent to the Fleet API.
@@ -440,6 +440,147 @@ func TestFleetConfigHandler_TeslaTokenNoExpiry(t *testing.T) {
 
 	if rec.Code != http.StatusOK {
 		t.Errorf("status code: got %d, want %d (token with no expiry should succeed)", rec.Code, http.StatusOK)
+	}
+}
+
+func TestFleetConfigHandler_Status(t *testing.T) {
+	const (
+		validVIN  = "5YJ3E1EA1PF000001"
+		userID    = "user-123"
+		authToken = "valid-token"
+	)
+
+	futureExp := time.Now().Add(300 * 24 * time.Hour).Unix()
+	pastExp := time.Now().Add(-24 * time.Hour).Unix()
+
+	syncedFuture := fmt.Sprintf(`{"response":{"synced":true,"config":{"hostname":"telemetry.example.com","port":443,"exp":%d}}}`, futureExp)
+	syncedExpired := fmt.Sprintf(`{"response":{"synced":true,"config":{"hostname":"h","port":443,"exp":%d}}}`, pastExp)
+	notSynced := `{"response":{"synced":false,"config":null}}`
+	syncedNoExp := `{"response":{"synced":true,"config":{"hostname":"h","port":443}}}`
+
+	tests := []struct {
+		name          string
+		vin           string
+		authHeader    string
+		fleetStatus   int
+		fleetBody     string
+		wantStatus    int
+		wantError     string
+		wantSynced    bool
+		wantExpired   bool
+		wantHasExpiry bool
+	}{
+		{
+			name: "synced with future expiry", vin: validVIN, authHeader: "Bearer " + authToken,
+			fleetStatus: http.StatusOK, fleetBody: syncedFuture,
+			wantStatus: http.StatusOK, wantSynced: true, wantHasExpiry: true,
+		},
+		{
+			name: "synced but expired config", vin: validVIN, authHeader: "Bearer " + authToken,
+			fleetStatus: http.StatusOK, fleetBody: syncedExpired,
+			wantStatus: http.StatusOK, wantSynced: true, wantExpired: true, wantHasExpiry: true,
+		},
+		{
+			name: "not synced, no config", vin: validVIN, authHeader: "Bearer " + authToken,
+			fleetStatus: http.StatusOK, fleetBody: notSynced,
+			wantStatus: http.StatusOK, wantSynced: false, wantHasExpiry: false,
+		},
+		{
+			name: "synced but Tesla omitted exp", vin: validVIN, authHeader: "Bearer " + authToken,
+			fleetStatus: http.StatusOK, fleetBody: syncedNoExp,
+			wantStatus: http.StatusOK, wantSynced: true, wantHasExpiry: false,
+		},
+		{
+			name: "invalid VIN", vin: "SHORT", authHeader: "Bearer " + authToken,
+			fleetStatus: http.StatusOK, fleetBody: notSynced,
+			wantStatus: http.StatusBadRequest, wantError: "invalid VIN",
+		},
+		{
+			name: "fleet API error", vin: validVIN, authHeader: "Bearer " + authToken,
+			fleetStatus: http.StatusInternalServerError, fleetBody: `{"error":"boom"}`,
+			wantStatus: http.StatusBadGateway, wantError: "fleet API error",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fleetSrv := stubFleetServer(t, tt.fleetStatus, tt.fleetBody)
+			t.Cleanup(fleetSrv.Close)
+
+			handler := NewFleetConfigHandler(
+				&stubTokenValidator{userID: userID},
+				&stubVehicleOwner{ownerID: userID},
+				validTeslaToken(),
+				newTestFleetClient(fleetSrv.URL),
+				EndpointConfig{Hostname: "telemetry.example.com", Port: 443},
+				discardLogger(),
+			)
+
+			mux := http.NewServeMux()
+			mux.Handle("GET /api/fleet-config/{vin}", handler)
+
+			req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/api/fleet-config/"+tt.vin, nil)
+			if tt.authHeader != "" {
+				req.Header.Set("Authorization", tt.authHeader)
+			}
+			rec := httptest.NewRecorder()
+			mux.ServeHTTP(rec, req)
+
+			if rec.Code != tt.wantStatus {
+				t.Fatalf("status: got %d, want %d", rec.Code, tt.wantStatus)
+			}
+			if tt.wantError != "" {
+				var errResp wserrors.ErrorEnvelope
+				if err := json.NewDecoder(rec.Body).Decode(&errResp); err != nil {
+					t.Fatalf("decode error response: %v", err)
+				}
+				if !strings.Contains(errResp.Error.Message, tt.wantError) {
+					t.Errorf("error message: got %q, want substring %q", errResp.Error.Message, tt.wantError)
+				}
+				return
+			}
+
+			var resp fleetConfigStatusResponse
+			if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+				t.Fatalf("decode status response: %v", err)
+			}
+			if resp.Synced != tt.wantSynced {
+				t.Errorf("synced: got %v, want %v", resp.Synced, tt.wantSynced)
+			}
+			if resp.Expired != tt.wantExpired {
+				t.Errorf("expired: got %v, want %v", resp.Expired, tt.wantExpired)
+			}
+			if hasExpiry := resp.ExpiresAt != ""; hasExpiry != tt.wantHasExpiry {
+				t.Errorf("has expiry: got %v, want %v (expiresAt=%q)", hasExpiry, tt.wantHasExpiry, resp.ExpiresAt)
+			}
+			if tt.wantHasExpiry && resp.DaysRemaining == nil {
+				t.Error("expected daysRemaining to be set when expiry is present")
+			}
+		})
+	}
+}
+
+func TestFleetConfigHandler_MethodNotAllowed(t *testing.T) {
+	handler := NewFleetConfigHandler(
+		&stubTokenValidator{userID: "user-123"},
+		&stubVehicleOwner{ownerID: "user-123"},
+		validTeslaToken(),
+		newTestFleetClient(stubFleetServer(t, http.StatusOK, `{"response":{"synced":true}}`).URL),
+		EndpointConfig{Hostname: "telemetry.example.com", Port: 443},
+		discardLogger(),
+	)
+
+	// Register without a method so ServeHTTP's own dispatch handles the verb.
+	mux := http.NewServeMux()
+	mux.Handle("/api/fleet-config/{vin}", handler)
+
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodPut, "/api/fleet-config/5YJ3E1EA1PF000001", nil)
+	req.Header.Set("Authorization", "Bearer valid-token")
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusMethodNotAllowed {
+		t.Errorf("status: got %d, want %d", rec.Code, http.StatusMethodNotAllowed)
 	}
 }
 

--- a/internal/telemetry/fleet_config_status_handler.go
+++ b/internal/telemetry/fleet_config_status_handler.go
@@ -1,0 +1,64 @@
+package telemetry
+
+import (
+	"net/http"
+	"time"
+)
+
+// fleetConfigStatusResponse is the GET /api/fleet-config/{vin} body. Synced
+// comes straight from Tesla. The expiry fields are populated only when Tesla
+// echoes the config's `exp` (undocumented but often present); when it does
+// not, ExpiresAt is empty and DaysRemaining is nil, and the UI falls back to
+// the Synced flag to convey "streaming vs not".
+type fleetConfigStatusResponse struct {
+	VIN           string `json:"vin"`
+	Synced        bool   `json:"synced"`
+	Hostname      string `json:"hostname,omitempty"`
+	Port          int    `json:"port,omitempty"`
+	ExpiresAt     string `json:"expiresAt,omitempty"` // RFC3339; empty if exp unknown
+	Expired       bool   `json:"expired"`
+	DaysRemaining *int   `json:"daysRemaining,omitempty"` // nil if expired or exp unknown
+}
+
+// handleStatus handles GET /api/fleet-config/{vin} — reports the vehicle's
+// current telemetry-config state (Tesla's synced flag plus best-effort
+// expiry) so the UI can show whether a re-push is needed.
+func (h *FleetConfigHandler) handleStatus(w http.ResponseWriter, r *http.Request) {
+	vin, teslaTok, ok := h.authorize(w, r)
+	if !ok {
+		return
+	}
+	ctx := r.Context()
+
+	status, err := h.fleet.GetTelemetryConfig(ctx, teslaTok.AccessToken, vin)
+	if err != nil {
+		h.handleFleetAPIError(w, vin, err)
+		return
+	}
+
+	resp := fleetConfigStatusResponse{
+		VIN:    redactVIN(vin),
+		Synced: status.Response.Synced,
+	}
+	if cfg := status.Response.Config; cfg != nil {
+		resp.Hostname = cfg.Hostname
+		resp.Port = cfg.Port
+		if cfg.Exp != nil {
+			expiresAt := time.Unix(*cfg.Exp, 0).UTC()
+			remaining := time.Until(expiresAt)
+			resp.ExpiresAt = expiresAt.Format(time.RFC3339)
+			resp.Expired = remaining <= 0
+			// DaysRemaining is only meaningful while the config is still
+			// valid; leave it nil once expired so the UI branches on
+			// `expired` instead of rendering a negative countdown. The
+			// int() truncates toward zero (30.7d → 30), which reads as
+			// "days fully remaining".
+			if !resp.Expired {
+				days := int(remaining.Hours() / 24)
+				resp.DaysRemaining = &days
+			}
+		}
+	}
+
+	h.writeJSON(w, http.StatusOK, resp)
+}


### PR DESCRIPTION
Part 1 of MYR-189 (backend). Enables the bench to show a vehicle's fleet-telemetry config state and drive the existing re-push. Frontend UI is a follow-up PR in `sdk-testbench`.

## Context
After the 2026-07 cert outage, cars still weren't streaming because their fleet telemetry configs had **expired** (configs carry a 30–350d `exp`, and there's no auto re-push). Fixing it meant running `push-fleet-config.sh` by hand, with zero visibility into expiry. This makes config state visible so a UI can show "expired → re-push".

## What
- `FleetAPIClient.GetTelemetryConfig(ctx, token, vin)` — Tesla `GET .../fleet_telemetry_config`, returns `synced` (always) and echoes the config incl. `exp` **when present** (Tesla documents `synced` but not `exp`, so it's treated as best-effort).
- `GET /api/fleet-config/{vin}` — owner-gated (reuses the POST path's JWT + ownership + Tesla-token-refresh via a factored-out `authorize()`), returns:
  `{vin, synced, hostname, port, expiresAt?, expired, daysRemaining?}`.
  The existing `POST` (re-push) is unchanged; `ServeHTTP` now routes GET/POST.
- VIN path segments are `url.PathEscape`'d; the shared retry helper's SSRF taint is annotated (host is the fixed Fleet API base).

## Notes
- `/api/fleet-config/{vin}` is an **operational** endpoint (not in the §6 catalog / openapi paths), so no formal SDK schema change — only the rest-api.md error-table method row updated for accuracy.
- **Expiry is best-effort from Tesla.** If Tesla omits `exp`, the UI falls back to the `synced` flag (streaming vs not). If that proves insufficient in practice, a server-side `exp` record on push is the fast-follow.
- Must be **deployed** before the frontend PR is useful.

## Testing
`go build`, `go vet`, `golangci-lint` (0), `gosec` (0), `go test ./internal/telemetry/ ./cmd/telemetry-server/` — all pass. New table-driven GET tests: synced+future, expired, not-synced, Tesla-omits-exp, invalid VIN, Fleet API error, + 405 dispatch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)