### PR TITLE
MYR-207: seed startChargeLevel from last-known charge at drive start

### DIFF
--- a/internal/drives/detector.go
+++ b/internal/drives/detector.go
@@ -305,6 +305,17 @@ func (d *Detector) handleTelemetry(te events.VehicleTelemetryEvent) {
 		state.odometerKnown = true
 	}
 
+	// Cache SOC the same way (MYR-207) so startDrive can seed
+	// startChargeLevel from the last-known charge — the gear-change frame
+	// that starts a drive frequently lacks the charge atomic group, which
+	// otherwise persisted startChargeLevel=0. Only cache non-zero values:
+	// a literal 0 is exactly the zero-value default we are guarding
+	// against, never a plausible parked charge.
+	if soc, ok := extractFloatField(te.Fields, telemetry.FieldSOC); ok && soc > 0 {
+		state.lastSOC = soc
+		state.socKnown = true
+	}
+
 	switch state.status {
 	case StatusIdle:
 		d.handleIdle(state, vin, te)

--- a/internal/drives/detector_test.go
+++ b/internal/drives/detector_test.go
@@ -717,6 +717,225 @@ func TestDetector_FSDMilesAcrossCadenceMismatch(t *testing.T) {
 	}
 }
 
+// TestDetector_StartChargeAcrossCadenceMismatch is the MYR-207 regression
+// test. The charge atomic group streams on a slower cadence than gear, so the
+// gear-change frame that starts a drive frequently carries no SOC. The
+// detector must seed startChargeLevel from the last-known charge cached while
+// idle rather than persisting 0 (which produced the nonsense "0% -> 75%,
+// -75% used" drive summaries on production). endChargeLevel behaviour must be
+// unchanged. Two scenarios: charge arrives late in the drive, and charge never
+// arrives during the drive at all.
+func TestDetector_StartChargeAcrossCadenceMismatch(t *testing.T) {
+	t.Run("charge arrives late in drive", func(t *testing.T) {
+		bus := testBus()
+		defer bus.Close(context.Background())
+
+		cfg := testConfig()
+		cfg.EndDebounce = 20 * time.Millisecond
+		cfg.MinDuration = 0
+		cfg.MinDistanceMiles = 0
+
+		d := NewDetector(bus, cfg, testLogger(), NoopDetectorMetrics{}, nil)
+		if err := d.Start(context.Background()); err != nil {
+			t.Fatalf("Start: %v", err)
+		}
+		defer func() { _ = d.Stop() }()
+
+		startedCh := subscribeTopic(t, bus, events.TopicDriveStarted)
+		endedCh := subscribeTopic(t, bus, events.TopicDriveEnded)
+
+		now := time.Now()
+
+		// Idle charge tick: the vehicle reports SOC=75 while parked. This is
+		// the last-known charge the next drive should seed its start from.
+		idleFields := map[string]events.TelemetryValue{
+			string(telemetry.FieldGear): {StringVal: ptr("P")},
+			string(telemetry.FieldSOC):  {FloatVal: ptr(75.0)},
+		}
+		publishTelemetry(t, bus, telemetryEvent("VIN_SOC", now, idleFields))
+
+		// Drive starts on a gear-change frame that carries NO SOC field — the
+		// realistic case given the gear/charge cadence mismatch.
+		startFields := map[string]events.TelemetryValue{
+			string(telemetry.FieldGear):     {StringVal: ptr("D")},
+			string(telemetry.FieldSpeed):    {FloatVal: ptr(0.0)},
+			string(telemetry.FieldLocation): {LocationVal: &events.Location{Latitude: 33.0, Longitude: -96.0}},
+		}
+		publishTelemetry(t, bus, telemetryEvent("VIN_SOC", now.Add(1*time.Second), startFields))
+		if _, ok := waitForEvent(startedCh); !ok {
+			t.Fatal("timed out waiting for DriveStartedEvent")
+		}
+
+		// A later in-drive frame finally carries an updated SOC value.
+		midFields := map[string]events.TelemetryValue{
+			string(telemetry.FieldGear):     {StringVal: ptr("D")},
+			string(telemetry.FieldSpeed):    {FloatVal: ptr(60.0)},
+			string(telemetry.FieldLocation): {LocationVal: &events.Location{Latitude: 33.2, Longitude: -96.2}},
+			string(telemetry.FieldSOC):      {FloatVal: ptr(70.0)},
+		}
+		publishTelemetry(t, bus, telemetryEvent("VIN_SOC", now.Add(61*time.Second), midFields))
+
+		stopFields := map[string]events.TelemetryValue{
+			string(telemetry.FieldGear):     {StringVal: ptr("P")},
+			string(telemetry.FieldSpeed):    {FloatVal: ptr(0.0)},
+			string(telemetry.FieldLocation): {LocationVal: &events.Location{Latitude: 33.3, Longitude: -96.3}},
+			string(telemetry.FieldSOC):      {FloatVal: ptr(70.0)},
+		}
+		publishTelemetry(t, bus, telemetryEvent("VIN_SOC", now.Add(120*time.Second), stopFields))
+
+		evt, ok := waitForEvent(endedCh)
+		if !ok {
+			t.Fatal("timed out waiting for DriveEndedEvent")
+		}
+		stats := evt.Payload.(events.DriveEndedEvent).Stats
+
+		// Start charge is the pre-drive last-known value (75), NOT the late
+		// in-drive sample (70) and NOT a zero-value default. Before the fix
+		// this was 0 because the gear-change start frame carried no SOC.
+		if stats.StartChargeLevel != 75 {
+			t.Errorf("StartChargeLevel: got %d, want 75", stats.StartChargeLevel)
+		}
+		// End charge behaviour is unchanged: the most recent in-drive SOC.
+		if stats.EndChargeLevel != 70 {
+			t.Errorf("EndChargeLevel: got %d, want 70", stats.EndChargeLevel)
+		}
+	})
+
+	t.Run("charge never arrives during drive", func(t *testing.T) {
+		bus := testBus()
+		defer bus.Close(context.Background())
+
+		cfg := testConfig()
+		cfg.EndDebounce = 20 * time.Millisecond
+		cfg.MinDuration = 0
+		cfg.MinDistanceMiles = 0
+
+		d := NewDetector(bus, cfg, testLogger(), NoopDetectorMetrics{}, nil)
+		if err := d.Start(context.Background()); err != nil {
+			t.Fatalf("Start: %v", err)
+		}
+		defer func() { _ = d.Stop() }()
+
+		startedCh := subscribeTopic(t, bus, events.TopicDriveStarted)
+		endedCh := subscribeTopic(t, bus, events.TopicDriveEnded)
+
+		now := time.Now()
+
+		// Idle charge tick establishes the last-known charge (62).
+		idleFields := map[string]events.TelemetryValue{
+			string(telemetry.FieldGear): {StringVal: ptr("P")},
+			string(telemetry.FieldSOC):  {FloatVal: ptr(62.0)},
+		}
+		publishTelemetry(t, bus, telemetryEvent("VIN_SOC2", now, idleFields))
+
+		// Entire drive carries no SOC field at all.
+		startFields := map[string]events.TelemetryValue{
+			string(telemetry.FieldGear):     {StringVal: ptr("D")},
+			string(telemetry.FieldSpeed):    {FloatVal: ptr(0.0)},
+			string(telemetry.FieldLocation): {LocationVal: &events.Location{Latitude: 33.0, Longitude: -96.0}},
+		}
+		publishTelemetry(t, bus, telemetryEvent("VIN_SOC2", now.Add(1*time.Second), startFields))
+		if _, ok := waitForEvent(startedCh); !ok {
+			t.Fatal("timed out waiting for DriveStartedEvent")
+		}
+
+		midFields := map[string]events.TelemetryValue{
+			string(telemetry.FieldGear):     {StringVal: ptr("D")},
+			string(telemetry.FieldSpeed):    {FloatVal: ptr(55.0)},
+			string(telemetry.FieldLocation): {LocationVal: &events.Location{Latitude: 33.2, Longitude: -96.2}},
+		}
+		publishTelemetry(t, bus, telemetryEvent("VIN_SOC2", now.Add(61*time.Second), midFields))
+
+		stopFields := map[string]events.TelemetryValue{
+			string(telemetry.FieldGear):     {StringVal: ptr("P")},
+			string(telemetry.FieldSpeed):    {FloatVal: ptr(0.0)},
+			string(telemetry.FieldLocation): {LocationVal: &events.Location{Latitude: 33.3, Longitude: -96.3}},
+		}
+		publishTelemetry(t, bus, telemetryEvent("VIN_SOC2", now.Add(120*time.Second), stopFields))
+
+		evt, ok := waitForEvent(endedCh)
+		if !ok {
+			t.Fatal("timed out waiting for DriveEndedEvent")
+		}
+		stats := evt.Payload.(events.DriveEndedEvent).Stats
+
+		// With no in-drive SOC ever, both start and end fall back to the
+		// pre-drive last-known charge (62) — a plausible, non-zero summary
+		// rather than the "0% -> 0%" the bug produced.
+		if stats.StartChargeLevel != 62 {
+			t.Errorf("StartChargeLevel: got %d, want 62", stats.StartChargeLevel)
+		}
+		if stats.EndChargeLevel != 62 {
+			t.Errorf("EndChargeLevel: got %d, want 62", stats.EndChargeLevel)
+		}
+	})
+
+	t.Run("cold start seeds from first in-drive sample", func(t *testing.T) {
+		bus := testBus()
+		defer bus.Close(context.Background())
+
+		cfg := testConfig()
+		cfg.EndDebounce = 20 * time.Millisecond
+		cfg.MinDuration = 0
+		cfg.MinDistanceMiles = 0
+
+		d := NewDetector(bus, cfg, testLogger(), NoopDetectorMetrics{}, nil)
+		if err := d.Start(context.Background()); err != nil {
+			t.Fatalf("Start: %v", err)
+		}
+		defer func() { _ = d.Stop() }()
+
+		startedCh := subscribeTopic(t, bus, events.TopicDriveStarted)
+		endedCh := subscribeTopic(t, bus, events.TopicDriveEnded)
+
+		now := time.Now()
+
+		// No idle charge tick: the detector has never seen SOC for this
+		// vehicle (e.g. first drive after a restart). The start frame also
+		// carries no SOC.
+		startFields := map[string]events.TelemetryValue{
+			string(telemetry.FieldGear):     {StringVal: ptr("D")},
+			string(telemetry.FieldSpeed):    {FloatVal: ptr(0.0)},
+			string(telemetry.FieldLocation): {LocationVal: &events.Location{Latitude: 33.0, Longitude: -96.0}},
+		}
+		publishTelemetry(t, bus, telemetryEvent("VIN_SOC3", now, startFields))
+		if _, ok := waitForEvent(startedCh); !ok {
+			t.Fatal("timed out waiting for DriveStartedEvent")
+		}
+
+		// First in-drive SOC sample seeds the start charge lazily.
+		midFields := map[string]events.TelemetryValue{
+			string(telemetry.FieldGear):     {StringVal: ptr("D")},
+			string(telemetry.FieldSpeed):    {FloatVal: ptr(55.0)},
+			string(telemetry.FieldLocation): {LocationVal: &events.Location{Latitude: 33.2, Longitude: -96.2}},
+			string(telemetry.FieldSOC):      {FloatVal: ptr(58.0)},
+		}
+		publishTelemetry(t, bus, telemetryEvent("VIN_SOC3", now.Add(61*time.Second), midFields))
+
+		stopFields := map[string]events.TelemetryValue{
+			string(telemetry.FieldGear):     {StringVal: ptr("P")},
+			string(telemetry.FieldSpeed):    {FloatVal: ptr(0.0)},
+			string(telemetry.FieldLocation): {LocationVal: &events.Location{Latitude: 33.3, Longitude: -96.3}},
+			string(telemetry.FieldSOC):      {FloatVal: ptr(54.0)},
+		}
+		publishTelemetry(t, bus, telemetryEvent("VIN_SOC3", now.Add(120*time.Second), stopFields))
+
+		evt, ok := waitForEvent(endedCh)
+		if !ok {
+			t.Fatal("timed out waiting for DriveEndedEvent")
+		}
+		stats := evt.Payload.(events.DriveEndedEvent).Stats
+
+		// Start charge is the first in-drive sample (58), not 0.
+		if stats.StartChargeLevel != 58 {
+			t.Errorf("StartChargeLevel: got %d, want 58", stats.StartChargeLevel)
+		}
+		if stats.EndChargeLevel != 54 {
+			t.Errorf("EndChargeLevel: got %d, want 54", stats.EndChargeLevel)
+		}
+	})
+}
+
 func TestDetector_DisconnectEndsDrive(t *testing.T) {
 	bus := testBus()
 	defer bus.Close(context.Background())

--- a/internal/drives/state.go
+++ b/internal/drives/state.go
@@ -75,6 +75,20 @@ type vehicleState struct {
 	lastOdometer  float64
 	odometerKnown bool
 
+	// lastSOC caches the most recent state-of-charge value seen for this
+	// vehicle, including while idle (mirrors lastFSDMiles/lastOdometer).
+	// socKnown reports whether a plausible (non-zero) value has been
+	// observed. The charge atomic group streams on a slower cadence than
+	// gear, so the gear-change frame that starts a drive frequently lacks
+	// SOC; without a cache startDrive recorded startChargeLevel=0 while
+	// endChargeLevel captured correctly, producing a nonsense "0% -> 75%,
+	// -75% used" summary (MYR-207). SOC does not change while parked, so
+	// the last idle sample is the correct drive-start charge. Only
+	// non-zero values are cached: a literal 0 is the protobuf/zero-value
+	// default we are guarding against, never a plausible parked charge.
+	lastSOC  float64
+	socKnown bool
+
 	// lastTelemetryAt records the wall-clock time of the most recently
 	// received telemetry event for this vehicle (any field, gear-bearing
 	// or not). The end-condition watchdog uses this to detect drives
@@ -93,6 +107,7 @@ type activeDrive struct {
 	speedSum       float64 // running sum for average calculation
 	speedCount     int     // number of speed samples
 	startCharge    float64 // SOC at drive start (percent)
+	startChargeSet bool    // true once startCharge holds a real observed value (MYR-207)
 	startOdometer  float64 // odometer at drive start (miles)
 	startEnergy    float64 // energyRemaining at drive start (kWh)
 	startFSDMiles  float64 // fsdMilesSinceReset baseline for this drive

--- a/internal/drives/transitions.go
+++ b/internal/drives/transitions.go
@@ -114,6 +114,14 @@ func accumulateDriveCounters(drive *activeDrive, te events.VehicleTelemetryEvent
 	}
 
 	if soc, ok := extractFloatField(te.Fields, telemetry.FieldSOC); ok {
+		// Lazily seed the start charge from the first in-drive SOC sample
+		// when it was cold at drive start (no cached idle value) — better
+		// than persisting 0. Mirrors the FSD/odometer baseline (MYR-157,
+		// MYR-207).
+		if !drive.startChargeSet && soc > 0 {
+			drive.startCharge = soc
+			drive.startChargeSet = true
+		}
 		drive.lastSOC = soc
 	}
 
@@ -138,10 +146,21 @@ func (d *Detector) startDrive(state *vehicleState, vin string, te events.Vehicle
 		startLoc = *state.lastLocation
 	}
 
-	// Snapshot initial values from the event.
-	var startCharge float64
-	if soc, ok := extractFloatField(te.Fields, telemetry.FieldSOC); ok {
+	// Seed the start charge (SOC %) from the last-known value cached for
+	// this vehicle (including while idle), preferring a fresh non-zero SOC
+	// on the triggering frame. The gear-change frame that starts a drive
+	// often lacks the charge atomic group; without this seed
+	// startChargeLevel persisted as 0 while endChargeLevel captured
+	// correctly, yielding a nonsense "0% -> 75%" summary (MYR-207). SOC
+	// does not change while parked, so the last idle sample is the correct
+	// drive-start charge. If neither source has a value, the baseline stays
+	// unset and accumulateDriveCounters lazily captures it from the first
+	// in-drive SOC sample (mirrors the FSD/odometer baseline, MYR-157).
+	startCharge := state.lastSOC
+	startChargeSet := state.socKnown
+	if soc, ok := extractFloatField(te.Fields, telemetry.FieldSOC); ok && soc > 0 {
 		startCharge = soc
+		startChargeSet = true
 	}
 
 	var startEnergy float64
@@ -165,6 +184,7 @@ func (d *Detector) startDrive(state *vehicleState, vin string, te events.Vehicle
 		startLocation:       startLoc,
 		maxSpeed:            0,
 		startCharge:         startCharge,
+		startChargeSet:      startChargeSet,
 		startOdometer:       state.lastOdometer,
 		lastOdometer:        state.lastOdometer,
 		odometerBaselineSet: state.odometerKnown,


### PR DESCRIPTION
## Root cause

Real drives were persisted with `startChargeLevel = 0` while `endChargeLevel` was correct (e.g. 75), yielding a nonsense "0% → 75%, -75% used" drive summary.

The drive-detection state machine snapshots the drive-start charge **only from the SOC field on the gear-change frame that triggers the drive**:

- `internal/drives/transitions.go:142-145` (pre-fix) — `startDrive` did `var startCharge float64; if soc, ok := extractFloatField(te.Fields, telemetry.FieldSOC); ok { startCharge = soc }`. When that frame lacks the charge atomic group (`FieldSOC`), `startCharge` stays at the zero value `0`.
- This value flows to persistence via `activeDrive.startCharge` → `calculateStats` at `internal/drives/stats.go:120`: `StartChargeLevel: int(drive.startCharge)`.

SOC (the charge atomic group) streams on a **slower cadence than gear**, so the 1s gear-change frame that starts a drive almost never carries SOC — exactly the same cadence-mismatch that MYR-157 fixed for FSD miles and odometer. Those two fields are seeded from an idle cache on `vehicleState`; **SOC had no such cache**, so it fell through to `0`.

`endChargeLevel` was unaffected because `accumulateDriveCounters` (`internal/drives/transitions.go`) updates `drive.lastSOC` on every in-drive SOC frame, and `calculateStats` reads `EndChargeLevel: int(drive.lastSOC)` (`stats.go:121`) — SOC frames reliably arrive during/by the end of a drive.

## Fix

Mirror the existing MYR-157 FSD/odometer baseline-seeding pattern for SOC:

1. `internal/drives/state.go` — add `lastSOC float64` + `socKnown bool` to `vehicleState` (last-known charge cache) and `startChargeSet bool` to `activeDrive` (lazy-seed flag).
2. `internal/drives/detector.go` — `handleTelemetry` caches the most recent **non-zero** SOC for the vehicle (including while idle), alongside the existing FSD/odometer caching. Only non-zero values are cached: a literal `0` is precisely the zero-value default being guarded against, never a plausible parked charge.
3. `internal/drives/transitions.go`:
   - `startDrive` seeds `startCharge` from the cached `state.lastSOC`, preferring a fresh non-zero SOC on the triggering frame. A plausible non-zero start therefore always wins over a literal `0`.
   - `accumulateDriveCounters` lazily captures `startCharge` from the first in-drive SOC sample when it was cold at drive start (no cached idle value) — better than persisting `0`.

`endChargeLevel` behaviour is untouched.

## Test coverage

`TestDetector_StartChargeAcrossCadenceMismatch` (`internal/drives/detector_test.go`), three subtests:
- **charge arrives late in drive** — idle SOC=75, start frame carries no SOC, a late in-drive frame carries SOC=70. Asserts `StartChargeLevel == 75` (pre-drive last-known, not the late 70, not 0) and `EndChargeLevel == 70` (unchanged behaviour).
- **charge never arrives during drive** — idle SOC=62, no in-drive SOC at all. Asserts start and end both fall back to 62 (plausible summary, not "0% → 0%").
- **cold start seeds from first in-drive sample** — no idle SOC ever seen (e.g. first drive after restart), start frame no SOC, first in-drive SOC=58. Asserts `StartChargeLevel == 58` (lazy seed, not 0).

`go test ./...`: all packages pass. `go vet ./...`: clean. `golangci-lint run ./internal/drives/...`: 0 issues.

## Backfill note

This PR does **not** backfill existing bad rows — that is a separate, orchestrator-owned operation. A safe backfill would target `drives` rows where `startChargeLevel = 0` (the corrupted marker). A plausible replacement value is the **previous drive's `endChargeLevel` for the same vehicle** (ordered by start time), since charge does not change while parked between drives — the same invariant this fix relies on. Where no prior drive exists, fall back to that drive's own `endChargeLevel` (yields a conservative 0% delta rather than a negative one). The backfill must be idempotent (only touch `startChargeLevel = 0`) and should exclude any drive whose `endChargeLevel` is also 0 (no trustworthy source), leaving those for manual review.

## Risk

- **MYR-160 drive segmentation** — no interaction: this change only affects how `startCharge` is seeded, not when drives start/end; segmentation logic (watchdog stall/duration caps) is untouched.
- **Charging during a drive** — SOC seeded at start is the pre-drive charge; if the vehicle charges mid-drive, `endChargeLevel` could exceed `startChargeLevel` (positive delta). That is correct behaviour and orthogonal to this fix.
- **Literal SOC=0 frames** — deliberately not cached and not used to override, to avoid re-poisoning the baseline; an empty-battery drive is implausible and, if real, would still lazy-seed from the first non-zero in-drive sample.

🤖 Generated with [Claude Code](https://claude.com/claude-code)