### PR TITLE
MYR-206: populate startLocation/endLocation + locationName from geocoder place names

### DIFF
--- a/internal/store/drive_mapper.go
+++ b/internal/store/drive_mapper.go
@@ -1,7 +1,6 @@
 package store
 
 import (
-	"fmt"
 	"time"
 
 	"github.com/myrobotaxi/telemetry/internal/events"
@@ -10,6 +9,17 @@ import (
 // mapDriveStarted converts a DriveStartedEvent into a DriveRecord suitable
 // for insertion. End-time fields are set to placeholder values that will be
 // overwritten when the drive completes.
+//
+// StartLocation/StartAddress default to "" — the same "not geocoded yet"
+// sentinel documented for the four Drive location columns in
+// rest-api.md §7.2 ("zero-GPS at drive start, or reverse-geocode lookup
+// failed" => the wire handler omits the key rather than emitting a
+// placeholder). writer_drives.go's handleDriveStarted overwrites
+// StartLocation/StartAddress from the geocoder's Result.PlaceName /
+// Result.Address only on a successful lookup; leaving both fields empty
+// here (rather than a formatted "lat,lng" string) is required so a
+// disabled geocoder or a lookup miss doesn't leak raw coordinates into
+// what is documented as a human-readable place-name field.
 func mapDriveStarted(evt events.DriveStartedEvent, vehicleID string) DriveRecord {
 	return DriveRecord{
 		ID:            evt.DriveID,
@@ -17,7 +27,7 @@ func mapDriveStarted(evt events.DriveStartedEvent, vehicleID string) DriveRecord
 		Date:          evt.StartedAt.Format(time.DateOnly),
 		StartTime:     evt.StartedAt.Format(time.RFC3339),
 		EndTime:       "",
-		StartLocation: formatLocation(evt.Location),
+		StartLocation: "",
 		StartAddress:  "",
 		EndLocation:   "",
 		EndAddress:    "",
@@ -27,10 +37,13 @@ func mapDriveStarted(evt events.DriveStartedEvent, vehicleID string) DriveRecord
 
 // mapDriveCompletion converts a DriveEndedEvent into a DriveCompletion
 // with the final stats from the drive detector.
+//
+// EndLocation/EndAddress default to "" for the same reason StartLocation
+// does in mapDriveStarted — see that comment.
 func mapDriveCompletion(evt events.DriveEndedEvent) DriveCompletion {
 	return DriveCompletion{
 		EndTime:         evt.EndedAt.Format(time.RFC3339),
-		EndLocation:     formatLocation(evt.Stats.EndLocation),
+		EndLocation:     "",
 		EndAddress:      "",
 		DistanceMiles:   evt.Stats.Distance,
 		DurationMinutes: int(evt.Stats.Duration.Minutes()),
@@ -73,14 +86,4 @@ func mapRoutePoints(pts []events.RoutePoint) []RoutePointRecord {
 		}
 	}
 	return records
-}
-
-// formatLocation formats a Location as a "lat,lng" string for the Prisma
-// schema's string-typed location columns. Returns empty string if both
-// coordinates are zero (protobuf default for "not set").
-func formatLocation(loc events.Location) string {
-	if loc.Latitude == 0 && loc.Longitude == 0 {
-		return ""
-	}
-	return fmt.Sprintf("%.6f,%.6f", loc.Latitude, loc.Longitude)
 }

--- a/internal/store/drive_mapper_test.go
+++ b/internal/store/drive_mapper_test.go
@@ -33,8 +33,15 @@ func TestMapDriveStarted(t *testing.T) {
 	if record.StartTime != "2026-03-17T14:30:00Z" {
 		t.Errorf("StartTime = %q, want %q", record.StartTime, "2026-03-17T14:30:00Z")
 	}
-	if record.StartLocation != "33.097500,-96.821400" {
-		t.Errorf("StartLocation = %q, want %q", record.StartLocation, "33.097500,-96.821400")
+	// StartLocation is intentionally left empty by mapDriveStarted even
+	// though the event carries non-zero GPS: it is populated later by
+	// writer_drives.go's handleDriveStarted from the geocoder's
+	// Result.PlaceName, and must default to "" (not a raw "lat,lng"
+	// string) so a disabled/failed geocode leaves the wire-contract
+	// "not geocoded yet" sentinel intact. See TestWriter_DriveStarted_*
+	// in writer_drives_test.go for the geocoder-wired behavior.
+	if record.StartLocation != "" {
+		t.Errorf("StartLocation = %q, want empty (geocoder not yet consulted in mapDriveStarted)", record.StartLocation)
 	}
 	if record.EndTime != "" {
 		t.Errorf("EndTime = %q, want empty", record.EndTime)
@@ -68,8 +75,10 @@ func TestMapDriveCompletion(t *testing.T) {
 	if completion.EndTime != "2026-03-17T15:15:00Z" {
 		t.Errorf("EndTime = %q, want %q", completion.EndTime, "2026-03-17T15:15:00Z")
 	}
-	if completion.EndLocation != "33.110000,-96.830000" {
-		t.Errorf("EndLocation = %q, want %q", completion.EndLocation, "33.110000,-96.830000")
+	// EndLocation is intentionally left empty by mapDriveCompletion for
+	// the same reason StartLocation is in TestMapDriveStarted above.
+	if completion.EndLocation != "" {
+		t.Errorf("EndLocation = %q, want empty (geocoder not yet consulted in mapDriveCompletion)", completion.EndLocation)
 	}
 	if completion.DistanceMiles != 12.5 {
 		t.Errorf("DistanceMiles = %f, want 12.5", completion.DistanceMiles)
@@ -183,49 +192,6 @@ func TestMapRoutePoints(t *testing.T) {
 			}
 			if r.Timestamp != "2026-03-17T14:31:00Z" {
 				t.Errorf("Timestamp = %q, want %q", r.Timestamp, "2026-03-17T14:31:00Z")
-			}
-		})
-	}
-}
-
-func TestFormatLocation(t *testing.T) {
-	tests := []struct {
-		name string
-		loc  events.Location
-		want string
-	}{
-		{
-			name: "valid coordinates",
-			loc:  events.Location{Latitude: 33.097500, Longitude: -96.821400},
-			want: "33.097500,-96.821400",
-		},
-		{
-			name: "zero lat and lng treated as unset",
-			loc:  events.Location{Latitude: 0, Longitude: 0},
-			want: "",
-		},
-		{
-			name: "zero lat with nonzero lng is valid",
-			loc:  events.Location{Latitude: 0, Longitude: -96.821400},
-			want: "0.000000,-96.821400",
-		},
-		{
-			name: "nonzero lat with zero lng is valid",
-			loc:  events.Location{Latitude: 33.097500, Longitude: 0},
-			want: "33.097500,0.000000",
-		},
-		{
-			name: "negative coordinates",
-			loc:  events.Location{Latitude: -33.8688, Longitude: 151.2093},
-			want: "-33.868800,151.209300",
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got := formatLocation(tt.loc)
-			if got != tt.want {
-				t.Errorf("formatLocation(%+v) = %q, want %q", tt.loc, got, tt.want)
 			}
 		})
 	}

--- a/internal/store/writer_drives_geocode_test.go
+++ b/internal/store/writer_drives_geocode_test.go
@@ -1,0 +1,326 @@
+package store
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"testing"
+	"time"
+
+	"github.com/myrobotaxi/telemetry/internal/events"
+	"github.com/myrobotaxi/telemetry/internal/geocode"
+)
+
+// MYR-206 — unit tests for reverse-geocode Result.PlaceName wiring into
+// the Drive record's StartLocation/EndLocation columns. These
+// complement TestWriter_DriveStarted / TestWriter_DriveEnded in
+// writer_test.go (which both use geocode.NoopGeocoder{} and never
+// assert on the location/address fields) by exercising
+// handleDriveStarted/handleDriveEnded in writer_drives.go with a
+// geocoder that actually returns results.
+
+// newDriveGeocodeTestWriter wires a Writer with the supplied geocoder
+// so handleDriveStarted/handleDriveEnded's reverse-geocode calls can be
+// asserted on.
+func newDriveGeocodeTestWriter(t *testing.T, bus events.Bus, drives drivePersister, lookup vinIDLookup, geo geocode.Geocoder) *Writer {
+	t.Helper()
+	vehicles := &mockVehicleUpdater{}
+	return NewWriter(vehicles, drives, lookup, bus, geo, slog.Default(), WriterConfig{
+		FlushInterval: 50 * time.Millisecond,
+		BatchSize:     1000,
+	})
+}
+
+// TestWriter_DriveStarted_GeocoderPlaceName verifies that a successful
+// reverse-geocode with a POI match (Result.PlaceName non-empty) is
+// wired onto DriveRecord.StartLocation, and the accompanying street
+// address onto StartAddress.
+func TestWriter_DriveStarted_GeocoderPlaceName(t *testing.T) {
+	bus := newTestBus(t)
+	drives := &mockDrivePersister{}
+	lookup := &stubIDLookup{
+		pairs: map[string]struct{ id, userID string }{
+			"5YJ3E1EA1NF000001": {id: "veh_001", userID: "user_001"},
+		},
+	}
+	geo := &stubGeocoder{
+		results: []geocode.Result{{PlaceName: "Whole Foods Market", Address: "399 4th Street, San Francisco, CA"}},
+	}
+
+	w := newDriveGeocodeTestWriter(t, bus, drives, lookup, geo)
+	if err := w.Start(context.Background()); err != nil {
+		t.Fatalf("start: %v", err)
+	}
+	defer func() { _ = w.Stop() }()
+
+	evt := events.NewEvent(events.DriveStartedEvent{
+		VIN:     "5YJ3E1EA1NF000001",
+		DriveID: "drive_001",
+		Location: events.Location{
+			Latitude:  33.0975,
+			Longitude: -96.8214,
+		},
+		StartedAt: time.Now(),
+	})
+	if err := bus.Publish(context.Background(), evt); err != nil {
+		t.Fatalf("publish: %v", err)
+	}
+
+	waitForCondition(t, 2*time.Second, func() bool {
+		return len(drives.getCreates()) > 0
+	})
+
+	record := drives.getCreates()[0].Record
+	if record.StartLocation != "Whole Foods Market" {
+		t.Errorf("StartLocation = %q, want %q", record.StartLocation, "Whole Foods Market")
+	}
+	if record.StartAddress != "399 4th Street, San Francisco, CA" {
+		t.Errorf("StartAddress = %q, want %q", record.StartAddress, "399 4th Street, San Francisco, CA")
+	}
+	if got := geo.callCount(); got != 1 {
+		t.Errorf("geocoder calls = %d, want 1", got)
+	}
+}
+
+// TestWriter_DriveStarted_GeocoderAddressOnly verifies the residential
+// case: Mapbox returns a match but no POI within the geocoder's
+// distance threshold, so Result.PlaceName is empty while Result.Address
+// is populated. StartLocation must stay empty (omitted on the wire per
+// rest-api.md §7.2) while StartAddress is still set from the address.
+func TestWriter_DriveStarted_GeocoderAddressOnly(t *testing.T) {
+	bus := newTestBus(t)
+	drives := &mockDrivePersister{}
+	lookup := &stubIDLookup{
+		pairs: map[string]struct{ id, userID string }{
+			"5YJ3E1EA1NF000001": {id: "veh_001", userID: "user_001"},
+		},
+	}
+	geo := &stubGeocoder{
+		results: []geocode.Result{{PlaceName: "", Address: "4220 Tributary Wy, Frisco, TX"}},
+	}
+
+	w := newDriveGeocodeTestWriter(t, bus, drives, lookup, geo)
+	if err := w.Start(context.Background()); err != nil {
+		t.Fatalf("start: %v", err)
+	}
+	defer func() { _ = w.Stop() }()
+
+	evt := events.NewEvent(events.DriveStartedEvent{
+		VIN:     "5YJ3E1EA1NF000001",
+		DriveID: "drive_002",
+		Location: events.Location{
+			Latitude:  33.0975,
+			Longitude: -96.8214,
+		},
+		StartedAt: time.Now(),
+	})
+	if err := bus.Publish(context.Background(), evt); err != nil {
+		t.Fatalf("publish: %v", err)
+	}
+
+	waitForCondition(t, 2*time.Second, func() bool {
+		return len(drives.getCreates()) > 0
+	})
+
+	record := drives.getCreates()[0].Record
+	if record.StartLocation != "" {
+		t.Errorf("StartLocation = %q, want empty (no POI within threshold)", record.StartLocation)
+	}
+	if record.StartAddress != "4220 Tributary Wy, Frisco, TX" {
+		t.Errorf("StartAddress = %q, want %q", record.StartAddress, "4220 Tributary Wy, Frisco, TX")
+	}
+}
+
+// TestWriter_DriveStarted_GeocoderNoResult is the regression guard for
+// the raw-coordinate leak this ticket fixes: when the geocoder returns
+// ErrNoResult (disabled geocoder, or Mapbox genuinely had no match),
+// both StartLocation and StartAddress must stay empty — never a
+// formatted "lat,lng" string. Before the MYR-206 fix, mapDriveStarted
+// seeded StartLocation with formatLocation(evt.Location), which only
+// got overwritten on a *successful* geocode, so a failed/disabled
+// lookup left the raw coordinate string in place.
+func TestWriter_DriveStarted_GeocoderNoResult(t *testing.T) {
+	bus := newTestBus(t)
+	drives := &mockDrivePersister{}
+	lookup := &stubIDLookup{
+		pairs: map[string]struct{ id, userID string }{
+			"5YJ3E1EA1NF000001": {id: "veh_001", userID: "user_001"},
+		},
+	}
+	geo := &stubGeocoder{} // empty results → ErrNoResult on every call
+
+	w := newDriveGeocodeTestWriter(t, bus, drives, lookup, geo)
+	if err := w.Start(context.Background()); err != nil {
+		t.Fatalf("start: %v", err)
+	}
+	defer func() { _ = w.Stop() }()
+
+	evt := events.NewEvent(events.DriveStartedEvent{
+		VIN:     "5YJ3E1EA1NF000001",
+		DriveID: "drive_003",
+		Location: events.Location{
+			Latitude:  33.0975,
+			Longitude: -96.8214,
+		},
+		StartedAt: time.Now(),
+	})
+	if err := bus.Publish(context.Background(), evt); err != nil {
+		t.Fatalf("publish: %v", err)
+	}
+
+	waitForCondition(t, 2*time.Second, func() bool {
+		return len(drives.getCreates()) > 0
+	})
+
+	record := drives.getCreates()[0].Record
+	if record.StartLocation != "" {
+		t.Errorf("StartLocation = %q, want empty (geocoder returned no result)", record.StartLocation)
+	}
+	if record.StartAddress != "" {
+		t.Errorf("StartAddress = %q, want empty (geocoder returned no result)", record.StartAddress)
+	}
+}
+
+// TestWriter_DriveEnded_GeocoderPlaceName mirrors
+// TestWriter_DriveStarted_GeocoderPlaceName for the drive-completion
+// path: a successful reverse-geocode with a POI match wires
+// Result.PlaceName onto DriveCompletion.EndLocation.
+func TestWriter_DriveEnded_GeocoderPlaceName(t *testing.T) {
+	bus := newTestBus(t)
+	drives := &mockDrivePersister{}
+	lookup := &stubIDLookup{pairs: map[string]struct{ id, userID string }{}}
+	geo := &stubGeocoder{
+		results: []geocode.Result{{PlaceName: "Home", Address: "742 Evergreen Terrace, San Francisco, CA"}},
+	}
+
+	w := newDriveGeocodeTestWriter(t, bus, drives, lookup, geo)
+	if err := w.Start(context.Background()); err != nil {
+		t.Fatalf("start: %v", err)
+	}
+	defer func() { _ = w.Stop() }()
+
+	evt := events.NewEvent(events.DriveEndedEvent{
+		VIN:     "5YJ3E1EA1NF000001",
+		DriveID: "drive_004",
+		EndedAt: time.Now(),
+		Stats: events.DriveStats{
+			Distance: 12.5,
+			Duration: 45 * time.Minute,
+			EndLocation: events.Location{
+				Latitude:  33.1100,
+				Longitude: -96.8300,
+			},
+			EndChargeLevel: 82,
+		},
+	})
+	if err := bus.Publish(context.Background(), evt); err != nil {
+		t.Fatalf("publish: %v", err)
+	}
+
+	waitForCondition(t, 2*time.Second, func() bool {
+		return len(drives.getCompletes()) > 0
+	})
+
+	stats := drives.getCompletes()[0].Stats
+	if stats.EndLocation != "Home" {
+		t.Errorf("EndLocation = %q, want %q", stats.EndLocation, "Home")
+	}
+	if stats.EndAddress != "742 Evergreen Terrace, San Francisco, CA" {
+		t.Errorf("EndAddress = %q, want %q", stats.EndAddress, "742 Evergreen Terrace, San Francisco, CA")
+	}
+}
+
+// TestWriter_DriveEnded_GeocoderNoResult is the drive-completion
+// counterpart to TestWriter_DriveStarted_GeocoderNoResult: a failed /
+// absent geocode must leave EndLocation and EndAddress both empty,
+// never a raw "lat,lng" string.
+func TestWriter_DriveEnded_GeocoderNoResult(t *testing.T) {
+	bus := newTestBus(t)
+	drives := &mockDrivePersister{}
+	lookup := &stubIDLookup{pairs: map[string]struct{ id, userID string }{}}
+	geo := &stubGeocoder{} // empty results → ErrNoResult on every call
+
+	w := newDriveGeocodeTestWriter(t, bus, drives, lookup, geo)
+	if err := w.Start(context.Background()); err != nil {
+		t.Fatalf("start: %v", err)
+	}
+	defer func() { _ = w.Stop() }()
+
+	evt := events.NewEvent(events.DriveEndedEvent{
+		VIN:     "5YJ3E1EA1NF000001",
+		DriveID: "drive_005",
+		EndedAt: time.Now(),
+		Stats: events.DriveStats{
+			Distance: 12.5,
+			Duration: 45 * time.Minute,
+			EndLocation: events.Location{
+				Latitude:  33.1100,
+				Longitude: -96.8300,
+			},
+			EndChargeLevel: 82,
+		},
+	})
+	if err := bus.Publish(context.Background(), evt); err != nil {
+		t.Fatalf("publish: %v", err)
+	}
+
+	waitForCondition(t, 2*time.Second, func() bool {
+		return len(drives.getCompletes()) > 0
+	})
+
+	stats := drives.getCompletes()[0].Stats
+	if stats.EndLocation != "" {
+		t.Errorf("EndLocation = %q, want empty (geocoder returned no result)", stats.EndLocation)
+	}
+	if stats.EndAddress != "" {
+		t.Errorf("EndAddress = %q, want empty (geocoder returned no result)", stats.EndAddress)
+	}
+}
+
+// TestWriter_DriveEnded_GeocoderTransportError verifies that a
+// non-ErrNoResult geocoder failure (e.g. Mapbox transport/HTTP error)
+// is logged but does not crash the write path, and — like the
+// ErrNoResult case — leaves EndLocation/EndAddress empty rather than
+// falling back to raw coordinates.
+func TestWriter_DriveEnded_GeocoderTransportError(t *testing.T) {
+	bus := newTestBus(t)
+	drives := &mockDrivePersister{}
+	lookup := &stubIDLookup{pairs: map[string]struct{ id, userID string }{}}
+	geo := &stubGeocoder{err: errors.New("mapbox unreachable")}
+
+	w := newDriveGeocodeTestWriter(t, bus, drives, lookup, geo)
+	if err := w.Start(context.Background()); err != nil {
+		t.Fatalf("start: %v", err)
+	}
+	defer func() { _ = w.Stop() }()
+
+	evt := events.NewEvent(events.DriveEndedEvent{
+		VIN:     "5YJ3E1EA1NF000001",
+		DriveID: "drive_006",
+		EndedAt: time.Now(),
+		Stats: events.DriveStats{
+			Distance: 12.5,
+			Duration: 45 * time.Minute,
+			EndLocation: events.Location{
+				Latitude:  33.1100,
+				Longitude: -96.8300,
+			},
+			EndChargeLevel: 82,
+		},
+	})
+	if err := bus.Publish(context.Background(), evt); err != nil {
+		t.Fatalf("publish: %v", err)
+	}
+
+	waitForCondition(t, 2*time.Second, func() bool {
+		return len(drives.getCompletes()) > 0
+	})
+
+	stats := drives.getCompletes()[0].Stats
+	if stats.EndLocation != "" {
+		t.Errorf("EndLocation = %q, want empty (geocoder transport error)", stats.EndLocation)
+	}
+	if stats.EndAddress != "" {
+		t.Errorf("EndAddress = %q, want empty (geocoder transport error)", stats.EndAddress)
+	}
+}

--- a/internal/store/writer_location_address_test.go
+++ b/internal/store/writer_location_address_test.go
@@ -109,6 +109,43 @@ func TestScheduleLocationGeocode_FirstFlushFires(t *testing.T) {
 	}
 }
 
+// TestScheduleLocationGeocode_EmptyPlaceName verifies MYR-206's Result
+// carrying an empty PlaceName (address-only match — no POI within the
+// geocoder's distance threshold) still produces a Vehicle row write:
+// LocationName is set to the empty string (the documented
+// vehicle-state.schema.json sentinel for "no geocode available", NOT
+// omitted from the update) while LocationAddr carries the resolved
+// street address.
+func TestScheduleLocationGeocode_EmptyPlaceName(t *testing.T) {
+	vehicles := &mockVehicleUpdater{}
+	geo := &stubGeocoder{
+		results: []geocode.Result{{PlaceName: "", Address: "4220 Tributary Wy"}},
+	}
+	w := newLocAddrTestWriter(t, vehicles, geo)
+
+	update := &VehicleUpdate{
+		Latitude:    floatPtr(33.086131),
+		Longitude:   floatPtr(-96.852202),
+		LastUpdated: time.Now(),
+	}
+	w.scheduleLocationGeocode(testVIN, update)
+
+	awaitGeocodeCalls(t, geo, 1)
+	awaitVehicleWrites(t, vehicles, 1)
+	w.geocodeWG.Wait()
+
+	writes := vehicles.getTelemetryWrites()
+	if len(writes) != 1 {
+		t.Fatalf("vehicle writes = %d, want 1", len(writes))
+	}
+	if writes[0].Update.LocationName == nil || *writes[0].Update.LocationName != "" {
+		t.Errorf("LocationName = %v, want empty string (no POI within threshold)", ptrVal(writes[0].Update.LocationName))
+	}
+	if writes[0].Update.LocationAddr == nil || *writes[0].Update.LocationAddr != "4220 Tributary Wy" {
+		t.Errorf("LocationAddr = %v, want %q", ptrVal(writes[0].Update.LocationAddr), "4220 Tributary Wy")
+	}
+}
+
 // TestScheduleLocationGeocode_DebouncedFlushes drives each branch of the
 // debounce decision via a single table: the cache is pre-seeded with an
 // anchor entry, the scheduler is invoked once, and the test asserts


### PR DESCRIPTION
## Summary

Investigated the reported bug ("drive rows / live-map vehicle sheet show raw addresses because `startLocation`/`endLocation`/`locationName` are never populated from `geocode.Result.PlaceName`") and found that **the wiring already exists on `main`** (shipped incrementally in MYR-144/MYR-145/MYR-148), but had one real gap: a bug that leaked raw GPS coordinates into `startLocation`/`endLocation` whenever geocoding failed or was disabled, plus missing test coverage for the whole PlaceName path. This PR fixes that bug and adds the missing tests.

## Consumption-path trace

- **Drives** — `internal/store/writer_drives.go`
  - `handleDriveStarted()` (lines 18-65): creates the `DriveRecord` via `mapDriveStarted`, then reverse-geocodes `evt.Location` and on success sets `record.StartLocation = geo.PlaceName` (line 47) / `record.StartAddress = geo.Address` (line 48).
  - `handleDriveEnded()` (lines 129-186): builds `DriveCompletion` via `mapDriveCompletion`, reverse-geocodes `evt.Stats.EndLocation`, and on success sets `completion.EndLocation = geo.PlaceName` (line 150) / `completion.EndAddress = geo.Address` (line 151).
  - Persisted via `internal/store/drive_repo.go:90` (`Create`) and `internal/store/drive_repo.go:220` (`Complete`) into the existing `"startLocation"`/`"startAddress"`/`"endLocation"`/`"endAddress"` columns (`internal/store/queries.go:85`, `:118`, `:135`).
  - Wire contract already documents the omit-when-empty rule: `internal/telemetry/vehicle_drives_types.go` `driveSummary.toMaskMap()` (lines 156-186) omits each of the four keys when the store value is `""`; `docs/contracts/rest-api.md` §5.2.2/§7.2 states reverse-geocode failure is one of the cases that must produce an *omitted* key.
- **Vehicle current location** — `internal/store/writer_location_address.go`
  - `runLocationGeocode()` (lines 158-184) and `geocodeParkedLocation()` (lines 240-263) both call `w.geocoder.ReverseGeocode` once and pass `res.PlaceName, res.Address` into `persistLocationAddress()` (line 193), which sets `VehicleUpdate{LocationName: &nameCopy, LocationAddr: &addrCopy}` (lines 196-199) and writes it via `w.vehicles.UpdateTelemetry`.
  - Read path: `internal/store/vehicle_repo_scan.go:56` scans `"locationName"`/`"locationAddress"` into `Vehicle.LocationName`/`Vehicle.LocationAddress`; `internal/telemetry/vehicle_snapshot_types.go:82/123` surfaces it on the snapshot response, always present (non-nullable, `""` = "no geocode yet" per `docs/contracts/schemas/vehicle-state.schema.json:102-106`).

### The actual gap (fixed in this PR)

- `internal/store/drive_mapper.go`: `mapDriveStarted`/`mapDriveCompletion` previously seeded `StartLocation`/`EndLocation` with `formatLocation(evt.Location)` — a `"lat,lng"` string. The success-only overwrite in `writer_drives.go` meant a **disabled geocoder or a genuine `ErrNoResult`/transport error left the raw coordinate string in the DB column permanently**, contradicting the documented "omit when reverse-geocode failed" wire contract and leaking a non-name value into what's meant to be a human-readable place-name field. Fixed by defaulting both fields to `""` (matching the existing `StartAddress`/`EndAddress` pattern), removing the now-unused `formatLocation` helper.
- No gap found in the vehicle-location path — it was already fully wired, including the per-VIN cache (`locAddrCache` in `writer_location_address.go`) already carrying the `name` field since MYR-144, so this PR adds no new Mapbox calls.

## Files changed

- `internal/store/drive_mapper.go` — `StartLocation`/`EndLocation` default to `""` instead of a formatted `"lat,lng"` string; removed the now-unused `formatLocation` helper.
- `internal/store/drive_mapper_test.go` — updated `TestMapDriveStarted`/`TestMapDriveCompletion` assertions for the new empty default; removed `TestFormatLocation` (function deleted).
- `internal/store/writer_drives_geocode_test.go` (new) — end-to-end coverage of `handleDriveStarted`/`handleDriveEnded` with a stub geocoder.
- `internal/store/writer_location_address_test.go` — added one test covering the empty-`PlaceName` case for the vehicle current-location write path.

## Neighborhood/locality fallback — SKIPPED

`internal/geocode/geocode.go`'s Mapbox request is hardcoded to `types=poi,address` (line 146, asserted by `TestMapboxGeocoder_RequestFormat` in `geocode_test.go`), so Mapbox never returns neighborhood/locality features in the response at all — there's nothing to parse. Supporting a `Neighborhood` fallback cleanly would require broadening the requested `types`, which changes the shape/size of the `limit=5` candidate set `buildResult` ranks over and would need re-deriving the POI/address selection logic against a three-type mix rather than the current two-type (poi vs. not-poi, address vs. not-address) scan. That's a restructuring of the request + ranking logic, not an additive parse change, so per the task instructions I skipped it rather than force a narrow fit.

## Test coverage added

- `internal/store/writer_drives_geocode_test.go`:
  - `TestWriter_DriveStarted_GeocoderPlaceName` — POI match wires `StartLocation`/`StartAddress`.
  - `TestWriter_DriveStarted_GeocoderAddressOnly` — address-only match (no POI in range) leaves `StartLocation` empty, `StartAddress` set.
  - `TestWriter_DriveStarted_GeocoderNoResult` — regression guard: `ErrNoResult` leaves both fields empty (not a raw coordinate string).
  - `TestWriter_DriveEnded_GeocoderPlaceName` — POI match wires `EndLocation`/`EndAddress`.
  - `TestWriter_DriveEnded_GeocoderNoResult` — regression guard for the end-of-drive path.
  - `TestWriter_DriveEnded_GeocoderTransportError` — non-`ErrNoResult` geocoder failure also leaves both fields empty.
- `internal/store/writer_location_address_test.go`:
  - `TestScheduleLocationGeocode_EmptyPlaceName` — empty `PlaceName` still produces a Vehicle-row write, with `LocationName` set to `""` (documented sentinel) and `LocationAddr` set from the address.
- `internal/store/drive_mapper_test.go`: `TestMapDriveStarted`/`TestMapDriveCompletion` updated to assert the new empty-string default.

### Pass/fail summary

- `go build ./...` — clean.
- `go vet ./...` — clean.
- `golangci-lint run ./...` — `0 issues`.
- `go test ./...` — all packages report `ok`. **Caveat:** `internal/store`'s `TestMain` (`internal/store/db_test.go`) unconditionally `os.Exit(0)`s when Docker isn't reachable, which gates *every* test in that package (not just the testcontainers-backed integration tests) — this sandbox has no Docker daemon, so `internal/store`'s "ok" reflects a clean early-exit, not actual execution of the new/changed tests. Verified instead via `go build ./...`, `go vet ./...`, and `go test -c -o ... ./internal/store/` (compiles the full test binary with zero errors) plus a manual trace against the existing `stubGeocoder`/`mockDrivePersister`/`mockVehicleUpdater` test doubles already exercised elsewhere in the same package. All other packages (`internal/geocode`, `internal/drives`, `internal/telemetry`, `internal/ws`, `tests/contract`, etc.) ran for real and passed.

## Risks

- **Stale existing DB rows**: any `Drive` row written before this fix, where geocoding failed/was disabled at drive-start, has `startLocation`/`endLocation` permanently set to the old `"lat,lng"` string rather than empty. This fix only changes behavior going forward; no backfill/migration is included per the ticket's "do not add a migration" constraint. Worth a follow-up backfill if those rows are user-visible.
- **No new Mapbox calls / no cache-shape risk**: verified no caching layer needed extending — the drive-start/end geocode calls are one-shot per event (no cache), and the vehicle current-location per-VIN cache (`locAddrCache`) already stores `name` alongside `address` since MYR-144, so there's no stale "address-only" cache shape to worry about.
- **Scope note**: `DestinationName`/destination reverse-geocoding (`writer_destination_address.go`) is untouched — it's out of this ticket's scope (`startLocation`/`endLocation`/`locationName` only) and its cache intentionally only stores `address`, not a POI name, because `DestinationName` comes from Tesla telemetry directly rather than the geocoder.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
