### PR TITLE
MYR-206: neighborhood fallback for geocoded place names

### DIFF
--- a/internal/geocode/geocode.go
+++ b/internal/geocode/geocode.go
@@ -55,7 +55,16 @@ const poiDistanceThreshold = 50.0
 
 // Result holds the output of a reverse geocode lookup.
 type Result struct {
-	// PlaceName is the short place name (e.g. "Thompson Hotel").
+	// PlaceName is the short place name. A POI within
+	// poiDistanceThreshold wins (e.g. "Thompson Hotel"); otherwise the
+	// containing neighborhood's name is used (e.g. "Preston Highlands")
+	// so residential drive endpoints still get a human-readable label.
+	// Empty when neither is available — consumers fall back to Address.
+	//
+	// PlaceName is NEVER a bare city/locality name: an intra-city drive
+	// would render "Dallas → Dallas", which client QA explicitly
+	// rejected (MYR-206). Neighborhood is the floor of the fallback
+	// chain.
 	PlaceName string
 	// Address is the full street address
 	// (e.g. "506 San Jacinto Blvd, Austin, TX 78701").
@@ -142,8 +151,17 @@ func (g *MapboxGeocoder) ReverseGeocode(ctx context.Context, lat, lng float64) (
 	// limit=5 gives us a small candidate set so we can prefer a nearby
 	// POI over the closest address-only feature when one is in walking
 	// range; see the post-decode ranking below.
+	//
+	// types includes "neighborhood" (MYR-206) so buildResult can fall
+	// back to the containing neighborhood's name when no POI is within
+	// walking range — the common residential-endpoint case. "locality"
+	// (and coarser city-level types) are deliberately NOT requested:
+	// buildResult would only ever discard them (a bare city name in
+	// PlaceName renders "Dallas → Dallas" on intra-city drives, rejected
+	// by client QA), so requesting them wastes candidate slots in the
+	// limit=5 window.
 	url := fmt.Sprintf(
-		"https://api.mapbox.com/geocoding/v5/mapbox.places/%f,%f.json?access_token=%s&limit=5&types=poi,address",
+		"https://api.mapbox.com/geocoding/v5/mapbox.places/%f,%f.json?access_token=%s&limit=5&types=poi,address,neighborhood",
 		lng, lat, g.token,
 	)
 
@@ -173,67 +191,6 @@ func (g *MapboxGeocoder) ReverseGeocode(ctx context.Context, lat, lng float64) (
 	}
 
 	return buildResult(lat, lng, data.Features), nil
-}
-
-// buildResult selects the best PlaceName and Address from a Mapbox
-// response.
-//
-// PlaceName: returns the FIRST POI feature (in Mapbox's relevance order)
-// whose center is within poiDistanceThreshold of the queried coord. If
-// no POI qualifies, PlaceName is empty so downstream consumers fall
-// back to the street address — Mapbox's "address" features carry only
-// the street name in Text (e.g. "Tributary Way"), which makes a poor
-// label for a residential drive.
-//
-// Address: prefers the first address feature's full place_name; if none
-// is present, falls back to features[0].place_name so we never return
-// an empty address when the API gave us something.
-func buildResult(lat, lng float64, features []mapboxFeature) *Result {
-	var (
-		placeName   string
-		addressLine string
-		haveAddress bool
-	)
-
-	for _, f := range features {
-		if placeName == "" && isPOI(f.PlaceType) {
-			featLng, featLat := f.Center[0], f.Center[1]
-			if haversineMeters(lat, lng, featLat, featLng) <= poiDistanceThreshold {
-				placeName = f.Text
-			}
-		}
-		if !haveAddress && containsType(f.PlaceType, "address") {
-			addressLine = f.PlaceName
-			haveAddress = true
-		}
-	}
-
-	if !haveAddress {
-		addressLine = features[0].PlaceName
-	}
-
-	return &Result{
-		PlaceName: placeName,
-		Address:   addressLine,
-	}
-}
-
-// isPOI reports whether a Mapbox feature's place_type list includes the
-// "poi" tag.
-func isPOI(types []string) bool {
-	return containsType(types, "poi")
-}
-
-// containsType reports whether want appears in the given place_type
-// list. Mapbox features routinely carry multiple types
-// (e.g. ["poi", "landmark"]), so we cannot rely on the first element.
-func containsType(types []string, want string) bool {
-	for _, t := range types {
-		if t == want {
-			return true
-		}
-	}
-	return false
 }
 
 // NoopGeocoder always returns ErrNoResult, effectively disabling

--- a/internal/geocode/geocode_test.go
+++ b/internal/geocode/geocode_test.go
@@ -144,6 +144,236 @@ func TestMapboxGeocoder_ReverseGeocode(t *testing.T) {
 			},
 		},
 		{
+			// MYR-206: POI within threshold beats a neighborhood feature
+			// — the POI tier is strictly above the neighborhood tier.
+			name:       "POI within threshold beats neighborhood",
+			statusCode: http.StatusOK,
+			body: `{
+				"features": [
+					{
+						"text": "Whole Foods Market",
+						"place_name": "Whole Foods Market, 525 N Lamar Blvd, Austin, TX 78703",
+						"place_type": ["poi"],
+						"center": [-97.7430, 30.2672]
+					},
+					{
+						"text": "525 N Lamar Blvd",
+						"place_name": "525 N Lamar Blvd, Austin, TX 78703",
+						"place_type": ["address"],
+						"center": [-97.7431, 30.2672]
+					},
+					{
+						"text": "Old West Austin",
+						"place_name": "Old West Austin, Austin, Texas",
+						"place_type": ["neighborhood"],
+						"center": [-97.7550, 30.2800]
+					}
+				]
+			}`,
+			wantResult: &Result{
+				PlaceName: "Whole Foods Market",
+				Address:   "525 N Lamar Blvd, Austin, TX 78703",
+			},
+		},
+		{
+			// MYR-206: order-independence — the neighborhood feature is
+			// listed FIRST in the response array, before a qualifying
+			// POI. The tier ranking must still pick the POI: candidates
+			// are collected per tier and resolved afterwards, so array
+			// order between tiers is irrelevant.
+			name:       "neighborhood listed before qualifying POI, POI still wins",
+			statusCode: http.StatusOK,
+			body: `{
+				"features": [
+					{
+						"text": "Old West Austin",
+						"place_name": "Old West Austin, Austin, Texas",
+						"place_type": ["neighborhood"],
+						"center": [-97.7550, 30.2800]
+					},
+					{
+						"text": "525 N Lamar Blvd",
+						"place_name": "525 N Lamar Blvd, Austin, TX 78703",
+						"place_type": ["address"],
+						"center": [-97.7431, 30.2672]
+					},
+					{
+						"text": "Whole Foods Market",
+						"place_name": "Whole Foods Market, 525 N Lamar Blvd, Austin, TX 78703",
+						"place_type": ["poi"],
+						"center": [-97.7430, 30.2672]
+					}
+				]
+			}`,
+			wantResult: &Result{
+				PlaceName: "Whole Foods Market",
+				Address:   "525 N Lamar Blvd, Austin, TX 78703",
+			},
+		},
+		{
+			// MYR-206: the residential case this fallback exists for —
+			// no POI within walking range, but Mapbox returns the
+			// containing neighborhood. PlaceName uses the neighborhood's
+			// text; the neighborhood's centroid distance is irrelevant
+			// (containment, not proximity).
+			name:       "no POI in range, neighborhood fallback used",
+			statusCode: http.StatusOK,
+			body: `{
+				"features": [
+					{
+						"text": "Far Away Cafe",
+						"place_name": "Far Away Cafe, 999 Elsewhere St, Austin, TX",
+						"place_type": ["poi"],
+						"center": [-97.7431, 30.2690]
+					},
+					{
+						"text": "100 Tributary Way",
+						"place_name": "100 Tributary Way, Austin, TX 78703",
+						"place_type": ["address"],
+						"center": [-97.7431, 30.2672]
+					},
+					{
+						"text": "Preston Highlands",
+						"place_name": "Preston Highlands, Dallas, Texas",
+						"place_type": ["neighborhood"],
+						"center": [-97.7600, 30.2900]
+					}
+				]
+			}`,
+			wantResult: &Result{
+				PlaceName: "Preston Highlands",
+				Address:   "100 Tributary Way, Austin, TX 78703",
+			},
+		},
+		{
+			// MYR-206: no POI and no neighborhood — PlaceName stays
+			// empty (clients fall back to the address). Locality-level
+			// features must NOT be promoted into PlaceName: a bare city
+			// name renders "Dallas → Dallas" on intra-city drives.
+			name:       "no POI, no neighborhood, locality never used",
+			statusCode: http.StatusOK,
+			body: `{
+				"features": [
+					{
+						"text": "100 Tributary Way",
+						"place_name": "100 Tributary Way, Austin, TX 78703",
+						"place_type": ["address"],
+						"center": [-97.7431, 30.2672]
+					},
+					{
+						"text": "Dallas",
+						"place_name": "Dallas, Texas, United States",
+						"place_type": ["locality"],
+						"center": [-96.7970, 32.7767]
+					},
+					{
+						"text": "Dallas",
+						"place_name": "Dallas, Texas, United States",
+						"place_type": ["place"],
+						"center": [-96.7970, 32.7767]
+					}
+				]
+			}`,
+			wantResult: &Result{
+				PlaceName: "",
+				Address:   "100 Tributary Way, Austin, TX 78703",
+			},
+		},
+		{
+			// MYR-206: locality present alongside a neighborhood — the
+			// neighborhood is used and the locality text is ignored,
+			// regardless of array order (locality listed first here).
+			name:       "locality listed before neighborhood, neighborhood used",
+			statusCode: http.StatusOK,
+			body: `{
+				"features": [
+					{
+						"text": "Dallas",
+						"place_name": "Dallas, Texas, United States",
+						"place_type": ["locality"],
+						"center": [-96.7970, 32.7767]
+					},
+					{
+						"text": "Highland Park",
+						"place_name": "Highland Park, Dallas, Texas",
+						"place_type": ["neighborhood"],
+						"center": [-96.8000, 32.8300]
+					},
+					{
+						"text": "100 Tributary Way",
+						"place_name": "100 Tributary Way, Austin, TX 78703",
+						"place_type": ["address"],
+						"center": [-97.7431, 30.2672]
+					}
+				]
+			}`,
+			wantResult: &Result{
+				PlaceName: "Highland Park",
+				Address:   "100 Tributary Way, Austin, TX 78703",
+			},
+		},
+		{
+			// MYR-206: a feature dual-tagged ["neighborhood","locality"]
+			// is excluded from the neighborhood tier — locality text
+			// must never leak into PlaceName under ANY input, so an
+			// ambiguous dual-tagged feature loses to the empty floor.
+			name:       "dual-tagged neighborhood+locality excluded from PlaceName",
+			statusCode: http.StatusOK,
+			body: `{
+				"features": [
+					{
+						"text": "Dallas",
+						"place_name": "Dallas, Texas, United States",
+						"place_type": ["neighborhood", "locality"],
+						"center": [-96.7970, 32.7767]
+					},
+					{
+						"text": "100 Tributary Way",
+						"place_name": "100 Tributary Way, Austin, TX 78703",
+						"place_type": ["address"],
+						"center": [-97.7431, 30.2672]
+					}
+				]
+			}`,
+			wantResult: &Result{
+				PlaceName: "",
+				Address:   "100 Tributary Way, Austin, TX 78703",
+			},
+		},
+		{
+			// MYR-206: multiple neighborhood features — the first one in
+			// Mapbox's relevance order wins within the tier, mirroring
+			// the "multiple POIs, first qualifying wins" rule above.
+			name:       "multiple neighborhoods, first wins",
+			statusCode: http.StatusOK,
+			body: `{
+				"features": [
+					{
+						"text": "Preston Highlands",
+						"place_name": "Preston Highlands, Dallas, Texas",
+						"place_type": ["neighborhood"],
+						"center": [-96.8000, 33.0000]
+					},
+					{
+						"text": "Preston Trail",
+						"place_name": "Preston Trail, Dallas, Texas",
+						"place_type": ["neighborhood"],
+						"center": [-96.8100, 33.0100]
+					},
+					{
+						"text": "100 Tributary Way",
+						"place_name": "100 Tributary Way, Austin, TX 78703",
+						"place_type": ["address"],
+						"center": [-97.7431, 30.2672]
+					}
+				]
+			}`,
+			wantResult: &Result{
+				PlaceName: "Preston Highlands",
+				Address:   "100 Tributary Way, Austin, TX 78703",
+			},
+		},
+		{
 			// API returns zero features — preserved ErrNoResult
 			// behavior so callers (writer_drives, writer_location_address)
 			// can treat it as a soft-fail and skip persistence.
@@ -300,8 +530,14 @@ func TestMapboxGeocoder_RequestFormat(t *testing.T) {
 	if !strings.Contains(capturedPath, "limit=5") {
 		t.Errorf("expected limit=5 in URL, got: %s", capturedPath)
 	}
-	if !strings.Contains(capturedPath, "types=poi,address") {
-		t.Errorf("expected types=poi,address in URL, got: %s", capturedPath)
+	if !strings.Contains(capturedPath, "types=poi,address,neighborhood") {
+		t.Errorf("expected types=poi,address,neighborhood in URL, got: %s", capturedPath)
+	}
+	// Locality/place (city-level) types must never be requested — their
+	// text is banned from PlaceName (see buildResult), so requesting
+	// them only wastes candidate slots in the limit=5 window.
+	if strings.Contains(capturedPath, "locality") || strings.Contains(capturedPath, "place,") {
+		t.Errorf("city-level types must not be requested, got: %s", capturedPath)
 	}
 	t.Logf("captured path: %s", capturedPath)
 }

--- a/internal/geocode/ranking.go
+++ b/internal/geocode/ranking.go
@@ -1,0 +1,101 @@
+package geocode
+
+// Feature ranking for reverse-geocode results. Split out of geocode.go
+// (which holds the HTTP client and Geocoder plumbing) when the MYR-206
+// neighborhood fallback pushed that file past the 300-line limit.
+
+// buildResult selects the best PlaceName and Address from a Mapbox
+// response.
+//
+// PlaceName is ranked in tiers, and the tier ranking is INDEPENDENT of
+// feature order in the response array — candidates for every tier are
+// collected in a single pass and the tiers are resolved afterwards, so
+// a neighborhood feature listed before a qualifying POI can never
+// shadow the POI:
+//
+//  1. POI: the first POI feature (in Mapbox's relevance order) whose
+//     center is within poiDistanceThreshold of the queried coord.
+//     Within the tier we trust Mapbox's ranking, not raw distance.
+//  2. Neighborhood: the first feature tagged "neighborhood" (MYR-206).
+//     No distance gate — reverse geocoding returns the neighborhood
+//     CONTAINING the point, and a polygon's centroid is routinely
+//     hundreds of meters from a coordinate inside it, so the POI
+//     threshold would reject nearly every legitimate match.
+//  3. Empty: downstream consumers fall back to the street address.
+//
+// PlaceName never carries a bare city name: features tagged "locality"
+// or "place" (Mapbox's city-level types) are excluded from the
+// neighborhood tier even when dual-tagged, because a city-level label
+// renders "Dallas → Dallas" on intra-city drives (rejected by client
+// QA). Neighborhood is the floor of the fallback chain.
+//
+// Address: prefers the first address feature's full place_name; if none
+// is present, falls back to features[0].place_name so we never return
+// an empty address when the API gave us something.
+func buildResult(lat, lng float64, features []mapboxFeature) *Result {
+	var (
+		poiName          string
+		neighborhoodName string
+		addressLine      string
+		haveAddress      bool
+	)
+
+	for _, f := range features {
+		if poiName == "" && isPOI(f.PlaceType) {
+			featLng, featLat := f.Center[0], f.Center[1]
+			if haversineMeters(lat, lng, featLat, featLng) <= poiDistanceThreshold {
+				poiName = f.Text
+			}
+		}
+		if neighborhoodName == "" && isNeighborhood(f.PlaceType) {
+			neighborhoodName = f.Text
+		}
+		if !haveAddress && containsType(f.PlaceType, "address") {
+			addressLine = f.PlaceName
+			haveAddress = true
+		}
+	}
+
+	if !haveAddress {
+		addressLine = features[0].PlaceName
+	}
+
+	placeName := poiName
+	if placeName == "" {
+		placeName = neighborhoodName
+	}
+
+	return &Result{
+		PlaceName: placeName,
+		Address:   addressLine,
+	}
+}
+
+// isPOI reports whether a Mapbox feature's place_type list includes the
+// "poi" tag.
+func isPOI(types []string) bool {
+	return containsType(types, "poi")
+}
+
+// isNeighborhood reports whether a Mapbox feature qualifies for the
+// neighborhood tier of the PlaceName fallback. A feature must carry the
+// "neighborhood" tag AND must not carry a city-level tag ("locality" or
+// "place") — dual-tagged features are excluded so locality text can
+// never leak into PlaceName (see buildResult's ranking comment).
+func isNeighborhood(types []string) bool {
+	return containsType(types, "neighborhood") &&
+		!containsType(types, "locality") &&
+		!containsType(types, "place")
+}
+
+// containsType reports whether want appears in the given place_type
+// list. Mapbox features routinely carry multiple types
+// (e.g. ["poi", "landmark"]), so we cannot rely on the first element.
+func containsType(types []string, want string) bool {
+	for _, t := range types {
+		if t == want {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
## Summary

Round 2 of MYR-206: implements the neighborhood fallback scoped out (and deliberately skipped) in #286. Residential drive endpoints — the most common case — rarely have a POI within the geocoder's 50m threshold, so `Result.PlaceName` stayed empty and drive rows fell back to street addresses. This PR gives them a human-readable neighborhood label ("Preston Highlands", "Highland Park") without adding any Mapbox calls.

Based on `origin/main` (278c877). Note: #286 had not merged at branch time; the two changes are independent (this PR touches only `internal/geocode`, #286 touches only `internal/store`), so there is no conflict either merge order.

## Ranking design

`Result.PlaceName` is selected in tiers (implemented in `internal/geocode/ranking.go` `buildResult`):

1. **POI** — first POI feature in Mapbox's relevance order whose center is within the existing 50m `poiDistanceThreshold`. Unchanged from before.
2. **Neighborhood** — first feature tagged `neighborhood`. No distance gate: reverse geocoding returns the neighborhood *containing* the point, and a polygon centroid is routinely hundreds of meters from a coordinate inside it, so reusing the POI proximity threshold would reject nearly every legitimate match.
3. **Empty** — clients fall back to `Address`, exactly as before.

**Order-independence:** candidates for each tier are collected in a single pass and the tiers are resolved *after* the loop, so the tier ranking cannot depend on feature order in the response array — a neighborhood listed before a qualifying POI can never shadow the POI. Within a tier, the first feature in Mapbox's relevance order still wins (the pre-existing, test-pinned POI rule, now mirrored for neighborhoods).

**Locality exclusion (hard product rule):** a bare city name in `PlaceName` renders "Dallas → Dallas" on intra-city drives, which client QA explicitly rejected. Enforced at three layers:
- city-level types (`locality`, `place`) are **not requested** — the Mapbox `types` param is `poi,address,neighborhood` (requesting them would only waste candidate slots in the `limit=5` window since we could never use them);
- `isNeighborhood` requires the `neighborhood` tag AND rejects any feature also tagged `locality` or `place`, so even a dual-tagged feature cannot leak city text into `PlaceName`;
- no other tier consults locality features, so defensively-present locality features in a response are simply ignored.

**Address extraction is unchanged** — same code path, same first-address-feature preference, same features[0] fallback.

## Files changed

- `internal/geocode/geocode.go` — `types` param broadened to `poi,address,neighborhood` (with rationale comment); `Result.PlaceName` doc updated with the tier chain and the no-locality rule; ranking logic moved out (file was pushed past the repo's 300-line limit).
- `internal/geocode/ranking.go` (new) — `buildResult` with the order-independent tier ranking, plus `isPOI` / new `isNeighborhood` / `containsType` helpers.
- `internal/geocode/geocode_test.go` — 7 new table cases + request-format assertions (see below).

## Downstream consumers — no changes needed (verified)

- Same single Mapbox request per geocode event; `PlaceName` simply gets populated more often.
- `internal/store/writer_location_address.go`'s per-VIN `locAddrEntry` cache already stores `name` alongside `address` (MYR-144), so the cached shape needs no extension.
- Drive path (`writer_drives.go`) copies `geo.PlaceName` verbatim into `startLocation`/`endLocation`; the wire handlers' omit-when-empty behavior is untouched.
- Mild behavior note: vehicles parked at residential spots that previously cached an empty name will keep it until the normal debounce/movement rules trigger a re-geocode — no invalidation added, consistent with how MYR-144 handles all stale entries.

## Tests

New cases in `TestMapboxGeocoder_ReverseGeocode` (existing table-driven pattern):
- `POI within threshold beats neighborhood`
- `neighborhood listed before qualifying POI, POI still wins` (order-independence)
- `no POI in range, neighborhood fallback used`
- `no POI, no neighborhood, locality never used` (locality + place features present → PlaceName empty)
- `locality listed before neighborhood, neighborhood used`
- `dual-tagged neighborhood+locality excluded from PlaceName`
- `multiple neighborhoods, first wins`

`TestMapboxGeocoder_RequestFormat` updated to pin `types=poi,address,neighborhood` and assert city-level types are never requested.

### Gate results

- `go vet ./...` — clean.
- `golangci-lint run ./...` — 0 issues.
- `go build ./cmd/...` — clean.
- `go test ./...` — all packages `ok`. `internal/geocode` (the changed package) ran fully and passed, including all new cases. Caveat: `internal/store`'s `TestMain` exits 0 without running when Docker is unavailable (this sandbox has no Docker daemon) — that package's tests are covered by CI; no `internal/store` code changed in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
