### PR TITLE
MYR-173: ride_requests table + store layer

### DIFF
--- a/docs/contracts/data-classification.md
+++ b/docs/contracts/data-classification.md
@@ -201,6 +201,37 @@ Each element in the `routePoints` array is a `RoutePointRecord`:
 | `createdAt` | `DateTime` | P0 | No | Yes | Non-sensitive timestamp |
 | `updatedAt` | `DateTime` | P0 | No | Yes | Non-sensitive timestamp |
 
+### 1.9 go_ride_requests table (Go-owned, MYR-173)
+
+The P10 ride-hailing aggregate (contracts `schemas/ride-request.schema.json`; FR-9.3 list-envelope conventions, NFR-3.9 tiers, NFR-3.23 encryption). First Go-owned feature table — created by `internal/store/migrations/0002_ride_requests.up.sql` under the CG-DL-9 `go_` namespace; the Next.js app's ORM never touches it.
+
+| Column | Type | Tier | Encrypt | Log-safe | Rationale |
+|--------|------|------|---------|----------|-----------|
+| `id` | `TEXT` (cuid) | P0 | No | Yes | Opaque internal identifier |
+| `rider_id` | `TEXT` | P0 | No | Yes | User cuid — opaque identifier |
+| `owner_id` | `TEXT` | P0 | No | Yes | User cuid — opaque identifier |
+| `vehicle_id` | `TEXT` | P0 | No | Yes | Vehicle cuid — opaque identifier |
+| `pickup_lat_enc` | `TEXT` (ciphertext) | P1 | **Yes** (encrypt-only) | No | GPS coordinate — NFR-3.23. New table: no plaintext column, no dual-write rollout |
+| `pickup_lng_enc` | `TEXT` (ciphertext) | P1 | **Yes** (encrypt-only) | No | GPS coordinate — NFR-3.23 |
+| `pickup_label` | `TEXT` | P1 | No | No | Place name — reveals location (same rationale as `Drive.startLocation`) |
+| `pickup_address` | `TEXT?` | P1 | No | No | Street address — reveals location |
+| `dropoff_lat_enc` | `TEXT` (ciphertext) | P1 | **Yes** (encrypt-only) | No | GPS coordinate — NFR-3.23 |
+| `dropoff_lng_enc` | `TEXT` (ciphertext) | P1 | **Yes** (encrypt-only) | No | GPS coordinate — NFR-3.23 |
+| `dropoff_label` | `TEXT` | P1 | No | No | Place name — reveals destination |
+| `dropoff_address` | `TEXT?` | P1 | No | No | Street address — reveals destination |
+| `status` | `TEXT` (enum, CHECK) | P0 | No | Yes | Lifecycle enum: requested/accepted/declined/enroute/arrived/completed/cancelled |
+| `passenger_name` | `TEXT?` | P1 | No | No | PII — booked-for passenger's name |
+| `passenger_phone` | `TEXT?` | P1 | No | No | PII — booked-for passenger's mobile (tracking-link SMS target). Never logged |
+| `scheduled_for` | `TIMESTAMPTZ?` | P0 | No | Yes | Reservation instant — no PII without the (P1) places |
+| `reschedule_proposed_for` | `TIMESTAMPTZ?` | P0 | No | Yes | Proposed new pickup instant |
+| `reschedule_status` | `TEXT?` (enum, CHECK) | P0 | No | Yes | Sub-state enum: requested/confirmed/declined |
+| `accepted_at` | `TIMESTAMPTZ?` | P0 | No | Yes | Non-sensitive timestamp |
+| `completed_at` | `TIMESTAMPTZ?` | P0 | No | Yes | Non-sensitive timestamp |
+| `created_at` | `TIMESTAMPTZ` | P0 | No | Yes | Non-sensitive timestamp |
+| `updated_at` | `TIMESTAMPTZ` | P0 | No | Yes | Non-sensitive timestamp |
+
+> **Encrypt-only coordinates (no dual-write).** Unlike the MYR-63/64 rollouts, `go_ride_requests` is a brand-new table: coordinates are written exclusively as AES-256-GCM ciphertext (`internal/store/ride_request_scan.go`, reusing the `vehicle_gps_encryption.go` float codec). There are no plaintext coordinate columns, no backfill tool, and no `*_plaintext_remaining_total` gauge. `RideRequestRepo` therefore requires an `Encryptor` at construction (panics on nil) and treats decrypt failure as a hard read error — there is no fallback column to fall back to.
+
 ---
 
 ## 2. Redaction rules by tier
@@ -265,6 +296,10 @@ Per NFR-3.23, AES-256-GCM column-level encryption is applied to the following co
 | `Vehicle` | `originLongitude` | `Float` | `Text` (base64 ciphertext) | Nav origin longitude |
 | `Vehicle` | `navRouteCoordinates` | `Json` | `Text` (base64 ciphertext) | Route polyline coordinate array |
 | `Drive` | `routePoints` | `Json` | `Text` (base64 ciphertext) | Full GPS trail for drive playback |
+| `go_ride_requests` | `pickup_lat_enc` | `Float` (logical) | `Text` (base64 ciphertext) | Ride pickup latitude — encrypt-only, no plaintext column (MYR-173) |
+| `go_ride_requests` | `pickup_lng_enc` | `Float` (logical) | `Text` (base64 ciphertext) | Ride pickup longitude — encrypt-only |
+| `go_ride_requests` | `dropoff_lat_enc` | `Float` (logical) | `Text` (base64 ciphertext) | Ride drop-off latitude — encrypt-only |
+| `go_ride_requests` | `dropoff_lng_enc` | `Float` (logical) | `Text` (base64 ciphertext) | Ride drop-off longitude — encrypt-only |
 
 ### 3.2 P1 columns NOT encrypted (rationale)
 
@@ -287,6 +322,12 @@ These P1 columns are sensitive and must never appear in logs, but are NOT encryp
 | `Invite` | `email` | Prisma-owned; disk encryption sufficient |
 | `TripStop` | `name` | Prisma-owned; disk encryption sufficient |
 | `TripStop` | `address` | Prisma-owned; disk encryption sufficient |
+| `go_ride_requests` | `pickup_label` | Place name, not coordinate data (same rationale as `Drive.startLocation`) |
+| `go_ride_requests` | `pickup_address` | Street address, not coordinate-precision data |
+| `go_ride_requests` | `dropoff_label` | Place name, not coordinate data |
+| `go_ride_requests` | `dropoff_address` | Street address, not coordinate-precision data |
+| `go_ride_requests` | `passenger_name` | Display name; disk encryption sufficient (same rationale as `User.name`) |
+| `go_ride_requests` | `passenger_phone` | PII, never logged; disk encryption sufficient today — promote to app-level encryption if threat modeling changes |
 
 > **Design decision:** Application-level encryption is reserved for columns where a database breach would expose precise geolocation trails or credential material. Human-readable location strings (place names, addresses) are protected by Supabase disk-level encryption and the P1 log-redaction rules. If threat modeling changes (e.g., multi-tenant deployment, regulatory requirements), these columns can be promoted to app-level encryption by adding them to the AES-256-GCM scope.
 
@@ -420,13 +461,13 @@ The `contract-guard` agent/CI check enforces the following rules derived from th
 
 | Tier | Count | Description |
 |------|-------|-------------|
-| P0 | 85 | Public — timestamps, opaque IDs, aggregate stats, feature flags, enums |
-| P1 | 26 | Sensitive — GPS coordinates, location names/addresses, OAuth tokens, PII, route data |
+| P0 | 97 | Public — timestamps, opaque IDs, aggregate stats, feature flags, enums |
+| P1 | 36 | Sensitive — GPS coordinates, location names/addresses, OAuth tokens, PII, route data |
 | P2 | 0 | Access-logged — reserved for future use |
 
-> **Count audit trail.** The P0 count was bumped from 83 → 85 by [MYR-11](https://linear.app/myrobotaxi/issue/MYR-11) when it added `Vehicle.chargeState` (Tesla proto field **179** `DetailedChargeState`, enum — see DV-19 for the 2026-04-23 empirical finding that switched the source from proto 2 to proto 179) and `Vehicle.timeToFull` (Tesla proto field 43, `Float` **hours (decimal)**) to the v1 charge atomic group. Both fields are P0 because they describe charge state, not identity or location. See §1.3 Vehicle table and `vehicle-state-schema.md` §2.2 for the wire contract. The `timeToFull` unit was empirically verified as hours (1.0667h capture) on 2026-04-22 — [DV-17 RESOLVED](https://linear.app/myrobotaxi/issue/MYR-25#comment-4f1dcee9-ab10-4039-acc5-9e7ef25c3762). Future count changes MUST add a one-line entry here so the total is auditable without `git blame`.
+> **Count audit trail.** The P0 count was bumped from 83 → 85 by [MYR-11](https://linear.app/myrobotaxi/issue/MYR-11) when it added `Vehicle.chargeState` (Tesla proto field **179** `DetailedChargeState`, enum — see DV-19 for the 2026-04-23 empirical finding that switched the source from proto 2 to proto 179) and `Vehicle.timeToFull` (Tesla proto field 43, `Float` **hours (decimal)**) to the v1 charge atomic group. Both fields are P0 because they describe charge state, not identity or location. See §1.3 Vehicle table and `vehicle-state-schema.md` §2.2 for the wire contract. The `timeToFull` unit was empirically verified as hours (1.0667h capture) on 2026-04-22 — [DV-17 RESOLVED](https://linear.app/myrobotaxi/issue/MYR-25#comment-4f1dcee9-ab10-4039-acc5-9e7ef25c3762). Future count changes MUST add a one-line entry here so the total is auditable without `git blame`. P0 85 → 97 and P1 26 → 36 by MYR-173: the new Go-owned `go_ride_requests` table (§1.9) adds 12 P0 columns (ids, status enums, timestamps), 4 P1 encrypted coordinate columns (encrypt-only, §3.1), and 6 P1 log-redaction-only columns (place labels/addresses + booked-for passenger name/phone, §3.2).
 
-### P1 fields requiring AES-256-GCM encryption (11 columns)
+### P1 fields requiring AES-256-GCM encryption (15 columns)
 
 1. `Account.access_token`
 2. `Account.refresh_token`
@@ -439,8 +480,12 @@ The `contract-guard` agent/CI check enforces the following rules derived from th
 9. `Vehicle.originLongitude`
 10. `Vehicle.navRouteCoordinates`
 11. `Drive.routePoints`
+12. `go_ride_requests.pickup_lat_enc`
+13. `go_ride_requests.pickup_lng_enc`
+14. `go_ride_requests.dropoff_lat_enc`
+15. `go_ride_requests.dropoff_lng_enc`
 
-### P1 fields with log-redaction only (no app-level encryption, 15 columns)
+### P1 fields with log-redaction only (no app-level encryption, 21 columns)
 
 1. `User.name`
 2. `User.email`
@@ -457,3 +502,9 @@ The `contract-guard` agent/CI check enforces the following rules derived from th
 13. `Invite.email`
 14. `TripStop.name`
 15. `TripStop.address`
+16. `go_ride_requests.pickup_label`
+17. `go_ride_requests.pickup_address`
+18. `go_ride_requests.dropoff_label`
+19. `go_ride_requests.dropoff_address`
+20. `go_ride_requests.passenger_name`
+21. `go_ride_requests.passenger_phone`

--- a/internal/store/errors.go
+++ b/internal/store/errors.go
@@ -16,6 +16,12 @@ var (
 	// Wraps sdk.ErrNotFound so callers can use errors.Is(err, sdk.ErrNotFound).
 	ErrDriveNotFound = fmt.Errorf("drive %w", sdk.ErrNotFound)
 
+	// ErrRideRequestNotFound is returned when a ride-request lookup (or a
+	// conditional update, e.g. resolving a reschedule that was never
+	// proposed) matches no row.
+	// Wraps sdk.ErrNotFound so callers can use errors.Is(err, sdk.ErrNotFound).
+	ErrRideRequestNotFound = fmt.Errorf("ride request %w", sdk.ErrNotFound)
+
 	// ErrTeslaTokenNotFound is returned when no Tesla OAuth token exists
 	// for a user in the Prisma-owned Account table.
 	// Wraps sdk.ErrNotFound so callers can use errors.Is(err, sdk.ErrNotFound).

--- a/internal/store/migrations/0002_ride_requests.down.sql
+++ b/internal/store/migrations/0002_ride_requests.down.sql
@@ -1,0 +1,6 @@
+-- 0002_ride_requests.down.sql
+--
+-- Reverts MYR-173: drops the Go-owned go_ride_requests table (indexes and
+-- CHECK constraints drop with it).
+
+DROP TABLE IF EXISTS go_ride_requests;

--- a/internal/store/migrations/0002_ride_requests.up.sql
+++ b/internal/store/migrations/0002_ride_requests.up.sql
@@ -1,0 +1,78 @@
+-- 0002_ride_requests.up.sql
+--
+-- MYR-173: go_ride_requests — the P10 ride-hailing aggregate. One row per
+-- ride request a rider sends to a vehicle owner (contracts
+-- schemas/ride-request.schema.json is the wire source of truth; this table
+-- is its persisted mirror).
+--
+-- Naming convention (CG-DL-9): Go-owned table, "go_" prefix. Columns are
+-- snake_case (Go-owned tables are not bound to the camelCase style of the
+-- Next.js app's schema). rider_id / owner_id reference user cuids and
+-- vehicle_id references a vehicle cuid, but NO foreign keys are declared:
+-- CG-DL-9 forbids Go migration SQL from referencing tables owned by the
+-- sibling app's schema.
+--
+-- Encryption (NFR-3.23, docs/contracts/data-classification.md §1.9):
+-- pickup/dropoff GPS coordinates are P1 and stored ONLY as AES-256-GCM
+-- ciphertext (*_enc TEXT columns, base64 [version][nonce][ct+tag]). The
+-- table is new, so there is no plaintext column and no dual-write rollout —
+-- encrypt-only from day one. Labels/addresses and passenger fields are P1
+-- log-redacted but not app-level encrypted (same rationale as the
+-- reverse-geocoded strings in §3.2).
+
+CREATE TABLE IF NOT EXISTS go_ride_requests (
+    id                      TEXT PRIMARY KEY,
+    rider_id                TEXT        NOT NULL,
+    owner_id                TEXT        NOT NULL,
+    vehicle_id              TEXT        NOT NULL,
+
+    pickup_lat_enc          TEXT        NOT NULL,
+    pickup_lng_enc          TEXT        NOT NULL,
+    pickup_label            TEXT        NOT NULL,
+    pickup_address          TEXT,
+
+    dropoff_lat_enc         TEXT        NOT NULL,
+    dropoff_lng_enc         TEXT        NOT NULL,
+    dropoff_label           TEXT        NOT NULL,
+    dropoff_address         TEXT,
+
+    -- Main lifecycle (contracts $defs.RideRequestStatus). The CHECK keeps
+    -- bugs out of the column; adding a lifecycle state is a contract change
+    -- and ships with its own migration.
+    status                  TEXT        NOT NULL DEFAULT 'requested'
+        CONSTRAINT go_ride_requests_status_check CHECK (
+            status IN ('requested', 'accepted', 'declined', 'enroute',
+                       'arrived', 'completed', 'cancelled')
+        ),
+
+    -- Booked-for passenger (contracts passengerName / passengerPhone).
+    passenger_name          TEXT,
+    passenger_phone         TEXT,
+
+    -- Scheduled rides + the reschedule negotiation (orthogonal sub-state;
+    -- contracts $defs.RescheduleStatus). NULL reschedule_status = no
+    -- reschedule ever proposed.
+    scheduled_for           TIMESTAMPTZ,
+    reschedule_proposed_for TIMESTAMPTZ,
+    reschedule_status       TEXT
+        CONSTRAINT go_ride_requests_reschedule_status_check CHECK (
+            reschedule_status IN ('requested', 'confirmed', 'declined')
+        ),
+
+    accepted_at             TIMESTAMPTZ,
+    completed_at            TIMESTAMPTZ,
+    created_at              TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at              TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+-- Rider history / scheduled lists: newest first per rider (MYR-174).
+CREATE INDEX IF NOT EXISTS idx_go_ride_requests_rider
+    ON go_ride_requests (rider_id, created_at DESC, id DESC);
+
+-- Owner incoming feed, filterable by status (MYR-175).
+CREATE INDEX IF NOT EXISTS idx_go_ride_requests_owner_status
+    ON go_ride_requests (owner_id, status, created_at DESC, id DESC);
+
+-- Per-car dispatch lookups (MYR-176).
+CREATE INDEX IF NOT EXISTS idx_go_ride_requests_vehicle
+    ON go_ride_requests (vehicle_id, created_at DESC, id DESC);

--- a/internal/store/ride_request_queries.go
+++ b/internal/store/ride_request_queries.go
@@ -1,0 +1,99 @@
+// SQL for the Go-owned go_ride_requests table (MYR-173). Unlike the
+// Prisma-owned tables, columns are snake_case and unquoted — see
+// migrations/0002_ride_requests.up.sql for the schema and the CG-DL-9
+// naming rationale.
+
+package store
+
+// rideRequestColumns is every column read into RideRequestRecord, in scan
+// order. Coordinates travel as *_enc ciphertext; the repo decrypts them
+// into RidePlace.Latitude/Longitude after scanning.
+const rideRequestColumns = `id, rider_id, owner_id, vehicle_id,
+	pickup_lat_enc, pickup_lng_enc, pickup_label, pickup_address,
+	dropoff_lat_enc, dropoff_lng_enc, dropoff_label, dropoff_address,
+	status, passenger_name, passenger_phone,
+	scheduled_for, reschedule_proposed_for, reschedule_status,
+	accepted_at, completed_at, created_at, updated_at`
+
+const queryRideRequestInsert = `INSERT INTO go_ride_requests (
+	id, rider_id, owner_id, vehicle_id,
+	pickup_lat_enc, pickup_lng_enc, pickup_label, pickup_address,
+	dropoff_lat_enc, dropoff_lng_enc, dropoff_label, dropoff_address,
+	status, passenger_name, passenger_phone, scheduled_for
+) VALUES (
+	$1, $2, $3, $4,
+	$5, $6, $7, $8,
+	$9, $10, $11, $12,
+	$13, $14, $15, $16
+)
+RETURNING created_at, updated_at`
+
+const queryRideRequestByID = `SELECT ` + rideRequestColumns + `
+FROM go_ride_requests
+WHERE id = $1`
+
+// Newest first, id as the tie-break — matches the contracts
+// RideRequestsListResponse ordering (createdAt DESC, id DESC) and the
+// idx_go_ride_requests_rider index.
+const queryRideRequestsByRider = `SELECT ` + rideRequestColumns + `
+FROM go_ride_requests
+WHERE rider_id = $1
+ORDER BY created_at DESC, id DESC
+LIMIT $2`
+
+const queryRideRequestsByOwner = `SELECT ` + rideRequestColumns + `
+FROM go_ride_requests
+WHERE owner_id = $1
+ORDER BY created_at DESC, id DESC
+LIMIT $2`
+
+const queryRideRequestsByOwnerAndStatus = `SELECT ` + rideRequestColumns + `
+FROM go_ride_requests
+WHERE owner_id = $1 AND status = $2
+ORDER BY created_at DESC, id DESC
+LIMIT $3`
+
+// queryRideRequestUpdateStatus persists a lifecycle transition with its
+// timestamp side-effects in one statement: entering 'accepted' stamps
+// accepted_at, entering 'completed' stamps completed_at (each only on
+// first entry — re-updates never move an already-set stamp), and every
+// transition touches updated_at.
+const queryRideRequestUpdateStatus = `UPDATE go_ride_requests SET
+	status = $2,
+	accepted_at = CASE
+		WHEN $2 = 'accepted' AND accepted_at IS NULL THEN NOW()
+		ELSE accepted_at
+	END,
+	completed_at = CASE
+		WHEN $2 = 'completed' AND completed_at IS NULL THEN NOW()
+		ELSE completed_at
+	END,
+	updated_at = NOW()
+WHERE id = $1
+RETURNING ` + rideRequestColumns
+
+// queryRideRequestProposeReschedule opens (or replaces) a reschedule
+// negotiation: records the rider's proposed pickup time and flips the
+// sub-state to 'requested' (shared-screens.jsx ScheduledRideSheet — the
+// owner is asked to re-confirm). The main status column is untouched.
+const queryRideRequestProposeReschedule = `UPDATE go_ride_requests SET
+	reschedule_proposed_for = $2,
+	reschedule_status = 'requested',
+	updated_at = NOW()
+WHERE id = $1
+RETURNING ` + rideRequestColumns
+
+// queryRideRequestResolveReschedule closes a pending negotiation.
+// Confirmed ($2 = true): scheduled_for adopts the proposed time and the
+// sub-state becomes 'confirmed'. Declined: the sub-state becomes
+// 'declined' and scheduled_for keeps the original reservation. The
+// proposed time is retained either way for audit (contracts
+// rescheduleProposedFor). Only rows with an open 'requested' negotiation
+// match — resolving twice (or resolving a ride that was never asked to
+// move) affects zero rows and surfaces as ErrRideRequestNotFound.
+const queryRideRequestResolveReschedule = `UPDATE go_ride_requests SET
+	scheduled_for = CASE WHEN $2 THEN reschedule_proposed_for ELSE scheduled_for END,
+	reschedule_status = CASE WHEN $2 THEN 'confirmed' ELSE 'declined' END,
+	updated_at = NOW()
+WHERE id = $1 AND reschedule_status = 'requested'
+RETURNING ` + rideRequestColumns

--- a/internal/store/ride_request_repo.go
+++ b/internal/store/ride_request_repo.go
@@ -1,0 +1,186 @@
+// Package store — RideRequestRepo (MYR-173) persists the P10 ride-hailing
+// aggregate in the Go-owned go_ride_requests table.
+//
+// Encryption contract (NFR-3.23, data-classification.md §1.9): pickup and
+// dropoff coordinates are P1 GPS data stored encrypt-only — the table has
+// no plaintext coordinate columns, so unlike the Vehicle GPS dual-write
+// (MYR-63) there is no fallback path and the Encryptor is mandatory at
+// construction. Encrypt failures fail the write (a ride request without a
+// pickup is useless, unlike telemetry where fail-open protects the
+// stream); decrypt failures fail the read.
+//
+// No HTTP surface here — MYR-174 (rider API) and MYR-175 (owner
+// accept/decline) bind handlers onto these accessors.
+
+package store
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/myrobotaxi/telemetry/internal/cryptox"
+)
+
+// RideRequestRepo manages ride-request records. All coordinate columns are
+// AES-256-GCM ciphertext; the repo is the encrypt/decrypt boundary
+// (NFR-3.25 — callers only ever see plaintext RidePlace values).
+type RideRequestRepo struct {
+	pool      *pgxpool.Pool
+	metrics   Metrics
+	encryptor cryptox.Encryptor
+}
+
+// NewRideRequestRepo constructs the repo. The Encryptor is required —
+// go_ride_requests stores GPS coordinates encrypt-only, so a nil Encryptor
+// can neither write nor read a single row. Panics on nil to fail loud at
+// construction (mirrors NewDriveRepoWithEncryption).
+func NewRideRequestRepo(pool *pgxpool.Pool, metrics Metrics, encryptor cryptox.Encryptor) *RideRequestRepo {
+	if encryptor == nil {
+		panic("store.NewRideRequestRepo: encryptor must not be nil")
+	}
+	return &RideRequestRepo{pool: pool, metrics: metrics, encryptor: encryptor}
+}
+
+// rideRequestIDRandomBytes sizes the random suffix of a generated ride
+// request id: 16 bytes -> 32 hex chars + the "c" prefix, within the cuid
+// length envelope used by the platform's other tables (see
+// internal/mask/audit.go newAuditID for the convention).
+const rideRequestIDRandomBytes = 16
+
+// newRideRequestID generates a cuid-shaped identifier for a new row.
+func newRideRequestID() string {
+	b := make([]byte, rideRequestIDRandomBytes)
+	if _, err := rand.Read(b); err != nil {
+		// OS RNG unavailable is unrecoverable; a timestamp-derived id keeps
+		// the request usable rather than panicking mid-request.
+		return fmt.Sprintf("c%x", time.Now().UnixNano())
+	}
+	return "c" + hex.EncodeToString(b)
+}
+
+// Create inserts a new ride request. Zero-value fields get their creation
+// defaults: an empty ID is generated, an empty Status becomes 'requested'.
+// AcceptedAt/CompletedAt/Reschedule* are ignored on insert — they only
+// come into existence through UpdateStatus / ProposeReschedule. Returns
+// the stored record with DB-assigned created_at/updated_at.
+func (r *RideRequestRepo) Create(ctx context.Context, req RideRequestRecord) (RideRequestRecord, error) {
+	if req.ID == "" {
+		req.ID = newRideRequestID()
+	}
+	if req.Status == "" {
+		req.Status = RideRequestStatusRequested
+	}
+
+	pickupLatEnc, pickupLngEnc, err := r.encryptPlace(req.Pickup)
+	if err != nil {
+		return RideRequestRecord{}, fmt.Errorf("RideRequestRepo.Create(%s): pickup: %w", req.ID, err)
+	}
+	dropoffLatEnc, dropoffLngEnc, err := r.encryptPlace(req.Dropoff)
+	if err != nil {
+		return RideRequestRecord{}, fmt.Errorf("RideRequestRepo.Create(%s): dropoff: %w", req.ID, err)
+	}
+
+	start := time.Now()
+	row := r.pool.QueryRow(ctx, queryRideRequestInsert,
+		req.ID, req.RiderID, req.OwnerID, req.VehicleID,
+		pickupLatEnc, pickupLngEnc, req.Pickup.Label, req.Pickup.Address,
+		dropoffLatEnc, dropoffLngEnc, req.Dropoff.Label, req.Dropoff.Address,
+		string(req.Status), req.PassengerName, req.PassengerPhone, req.ScheduledFor,
+	)
+	err = row.Scan(&req.CreatedAt, &req.UpdatedAt)
+	r.metrics.ObserveQueryDuration("ride_request.create", time.Since(start).Seconds())
+	if err != nil {
+		r.metrics.IncQueryError("ride_request.create")
+		return RideRequestRecord{}, fmt.Errorf("RideRequestRepo.Create(%s): %w", req.ID, err)
+	}
+	req.AcceptedAt, req.CompletedAt = nil, nil
+	req.RescheduleProposedFor, req.RescheduleStatus = nil, nil
+	return req, nil
+}
+
+// GetByID returns a single ride request. Returns ErrRideRequestNotFound
+// when no row has that id.
+func (r *RideRequestRepo) GetByID(ctx context.Context, id string) (RideRequestRecord, error) {
+	start := time.Now()
+	row := r.pool.QueryRow(ctx, queryRideRequestByID, id)
+	rec, err := r.scanRideRequest(row)
+	r.metrics.ObserveQueryDuration("ride_request.get_by_id", time.Since(start).Seconds())
+	if errors.Is(err, pgx.ErrNoRows) {
+		return RideRequestRecord{}, fmt.Errorf("RideRequestRepo.GetByID(%s): %w", id, ErrRideRequestNotFound)
+	}
+	if err != nil {
+		r.metrics.IncQueryError("ride_request.get_by_id")
+		return RideRequestRecord{}, fmt.Errorf("RideRequestRepo.GetByID(%s): %w", id, err)
+	}
+	return rec, nil
+}
+
+// UpdateStatus persists a lifecycle transition with its timestamp
+// side-effects: entering 'accepted' stamps AcceptedAt, entering
+// 'completed' stamps CompletedAt (first entry only — an already-set stamp
+// never moves), and every transition touches UpdatedAt. Transition
+// legality (who may move a ride to which state) is the callers' concern —
+// MYR-175 owner accept/decline and MYR-176 dispatch enforce it; the store
+// stays a dumb persistence layer. Returns the post-update record, or
+// ErrRideRequestNotFound.
+func (r *RideRequestRepo) UpdateStatus(ctx context.Context, id string, status RideRequestStatus) (RideRequestRecord, error) {
+	start := time.Now()
+	row := r.pool.QueryRow(ctx, queryRideRequestUpdateStatus, id, string(status))
+	rec, err := r.scanRideRequest(row)
+	r.metrics.ObserveQueryDuration("ride_request.update_status", time.Since(start).Seconds())
+	if errors.Is(err, pgx.ErrNoRows) {
+		return RideRequestRecord{}, fmt.Errorf("RideRequestRepo.UpdateStatus(%s): %w", id, ErrRideRequestNotFound)
+	}
+	if err != nil {
+		r.metrics.IncQueryError("ride_request.update_status")
+		return RideRequestRecord{}, fmt.Errorf("RideRequestRepo.UpdateStatus(%s): %w", id, err)
+	}
+	return rec, nil
+}
+
+// ProposeReschedule records the rider's proposed new pickup time and opens
+// the reschedule negotiation (RescheduleStatus 'requested' — the owner is
+// asked to re-confirm; MYR-192). The main Status is untouched: the design
+// keeps the reservation alive while the ask is pending. Returns the
+// post-update record, or ErrRideRequestNotFound.
+func (r *RideRequestRepo) ProposeReschedule(ctx context.Context, id string, proposedFor time.Time) (RideRequestRecord, error) {
+	start := time.Now()
+	row := r.pool.QueryRow(ctx, queryRideRequestProposeReschedule, id, proposedFor)
+	rec, err := r.scanRideRequest(row)
+	r.metrics.ObserveQueryDuration("ride_request.propose_reschedule", time.Since(start).Seconds())
+	if errors.Is(err, pgx.ErrNoRows) {
+		return RideRequestRecord{}, fmt.Errorf("RideRequestRepo.ProposeReschedule(%s): %w", id, ErrRideRequestNotFound)
+	}
+	if err != nil {
+		r.metrics.IncQueryError("ride_request.propose_reschedule")
+		return RideRequestRecord{}, fmt.Errorf("RideRequestRepo.ProposeReschedule(%s): %w", id, err)
+	}
+	return rec, nil
+}
+
+// ResolveReschedule closes an open reschedule negotiation. confirmed=true
+// adopts the proposed time into ScheduledFor and marks the sub-state
+// 'confirmed'; confirmed=false marks it 'declined' and keeps the original
+// reservation. Rows without an open 'requested' negotiation don't match —
+// that (or a missing id) returns ErrRideRequestNotFound.
+func (r *RideRequestRepo) ResolveReschedule(ctx context.Context, id string, confirmed bool) (RideRequestRecord, error) {
+	start := time.Now()
+	row := r.pool.QueryRow(ctx, queryRideRequestResolveReschedule, id, confirmed)
+	rec, err := r.scanRideRequest(row)
+	r.metrics.ObserveQueryDuration("ride_request.resolve_reschedule", time.Since(start).Seconds())
+	if errors.Is(err, pgx.ErrNoRows) {
+		return RideRequestRecord{}, fmt.Errorf("RideRequestRepo.ResolveReschedule(%s): %w", id, ErrRideRequestNotFound)
+	}
+	if err != nil {
+		r.metrics.IncQueryError("ride_request.resolve_reschedule")
+		return RideRequestRecord{}, fmt.Errorf("RideRequestRepo.ResolveReschedule(%s): %w", id, err)
+	}
+	return rec, nil
+}

--- a/internal/store/ride_request_repo_list.go
+++ b/internal/store/ride_request_repo_list.go
@@ -1,0 +1,85 @@
+// RideRequestRepo list read paths (MYR-173): the rider's history /
+// scheduled lists (MYR-174) and the owner's incoming feed filterable by
+// status (MYR-175). Ordered created_at DESC, id DESC to match the
+// contracts RideRequestsListResponse envelope; cursor encoding on top of
+// this ordering is the HTTP layer's concern.
+
+package store
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+)
+
+// defaultRideRequestListLimit caps unbounded list calls (limit <= 0).
+const defaultRideRequestListLimit = 100
+
+// ListByRider returns up to limit ride requests created by the rider,
+// newest first. limit <= 0 applies defaultRideRequestListLimit.
+func (r *RideRequestRepo) ListByRider(ctx context.Context, riderID string, limit int) ([]RideRequestRecord, error) {
+	recs, err := r.list(ctx, "ride_request.list_by_rider", queryRideRequestsByRider, riderID, normalizeLimit(limit))
+	if err != nil {
+		return nil, fmt.Errorf("RideRequestRepo.ListByRider(%s): %w", riderID, err)
+	}
+	return recs, nil
+}
+
+// ListByOwner returns up to limit ride requests addressed to the owner,
+// newest first, optionally filtered to one lifecycle status (nil = all —
+// e.g. RideRequestStatusRequested for the incoming-request feed).
+func (r *RideRequestRepo) ListByOwner(ctx context.Context, ownerID string, status *RideRequestStatus, limit int) ([]RideRequestRecord, error) {
+	var (
+		recs []RideRequestRecord
+		err  error
+	)
+	if status == nil {
+		recs, err = r.list(ctx, "ride_request.list_by_owner", queryRideRequestsByOwner, ownerID, normalizeLimit(limit))
+	} else {
+		recs, err = r.list(ctx, "ride_request.list_by_owner", queryRideRequestsByOwnerAndStatus, ownerID, string(*status), normalizeLimit(limit))
+	}
+	if err != nil {
+		return nil, fmt.Errorf("RideRequestRepo.ListByOwner(%s): %w", ownerID, err)
+	}
+	return recs, nil
+}
+
+func normalizeLimit(limit int) int {
+	if limit <= 0 {
+		return defaultRideRequestListLimit
+	}
+	return limit
+}
+
+// list runs one of the rideRequestColumns SELECTs and scans + decrypts
+// every row. Returns an empty (non-nil) slice when nothing matches so
+// callers can marshal it straight into the envelope's `items: []`.
+func (r *RideRequestRepo) list(ctx context.Context, op, query string, args ...any) ([]RideRequestRecord, error) {
+	start := time.Now()
+	rows, err := r.pool.Query(ctx, query, args...)
+	if err != nil {
+		r.metrics.ObserveQueryDuration(op, time.Since(start).Seconds())
+		r.metrics.IncQueryError(op)
+		return nil, fmt.Errorf("query: %w", err)
+	}
+	defer rows.Close()
+
+	recs := make([]RideRequestRecord, 0)
+	for rows.Next() {
+		rec, scanErr := r.scanRideRequest(pgx.Row(rows))
+		if scanErr != nil {
+			r.metrics.ObserveQueryDuration(op, time.Since(start).Seconds())
+			r.metrics.IncQueryError(op)
+			return nil, scanErr
+		}
+		recs = append(recs, rec)
+	}
+	r.metrics.ObserveQueryDuration(op, time.Since(start).Seconds())
+	if err := rows.Err(); err != nil {
+		r.metrics.IncQueryError(op)
+		return nil, fmt.Errorf("rows: %w", err)
+	}
+	return recs, nil
+}

--- a/internal/store/ride_request_repo_test.go
+++ b/internal/store/ride_request_repo_test.go
@@ -1,0 +1,492 @@
+package store_test
+
+import (
+	"context"
+	"errors"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/myrobotaxi/telemetry/internal/cryptox"
+	"github.com/myrobotaxi/telemetry/internal/store"
+	"github.com/myrobotaxi/telemetry/pkg/sdk"
+)
+
+// setupRideRequestRepo applies the embedded migrations (idempotent — the
+// go_ride_requests table arrives with 0002), truncates the table, and
+// returns a repo wired with a fresh random-key encryptor. Each test owns
+// its data (CLAUDE.md "No test pollution").
+func setupRideRequestRepo(t *testing.T) (*store.RideRequestRepo, cryptox.Encryptor) {
+	t.Helper()
+	if !dockerAvailable {
+		t.Skip("Docker not available -- skipping ride-request integration test")
+	}
+	ctx := context.Background()
+	if err := store.RunMigrations(ctx, testConnStr, testLogger()); err != nil {
+		t.Fatalf("RunMigrations: %v", err)
+	}
+	if _, err := testPool.Exec(ctx, `DELETE FROM go_ride_requests`); err != nil {
+		t.Fatalf("clean go_ride_requests: %v", err)
+	}
+	enc := newTestEncryptor(t)
+	return store.NewRideRequestRepo(testPool, store.NoopMetrics{}, enc), enc
+}
+
+// fullRideRequest is a scheduled, booked-for-someone-else request — every
+// optional Create field populated.
+func fullRideRequest() store.RideRequestRecord {
+	sched := time.Date(2026, 6, 18, 16, 0, 0, 0, time.UTC)
+	return store.RideRequestRecord{
+		RiderID:   "clrider1234567890abcdef",
+		OwnerID:   "clowner1234567890abcdef",
+		VehicleID: "clxyz1234567890abcdef",
+		Pickup: store.RidePlace{
+			Latitude: 37.7955, Longitude: -122.3937,
+			Label: "Home", Address: strPtr("221 Folsom St, San Francisco"),
+		},
+		Dropoff: store.RidePlace{
+			Latitude: 37.7766, Longitude: -122.3946,
+			Label: "Caltrain · 4th & King",
+		},
+		PassengerName:  strPtr("Maya Chen"),
+		PassengerPhone: strPtr("(415) 555-0142"),
+		ScheduledFor:   &sched,
+	}
+}
+
+// minimalRideRequest is an on-demand ride for the rider themselves.
+func minimalRideRequest() store.RideRequestRecord {
+	return store.RideRequestRecord{
+		RiderID:   "clrider1234567890abcdef",
+		OwnerID:   "clowner1234567890abcdef",
+		VehicleID: "clxyz1234567890abcdef",
+		Pickup: store.RidePlace{
+			Latitude: 37.7749, Longitude: -122.4194, Label: "Current location",
+		},
+		Dropoff: store.RidePlace{
+			Latitude: 37.7599, Longitude: -122.4148, Label: "Tartine Bakery",
+		},
+	}
+}
+
+// TestRideRequestMigration_TableApplied proves migration 0002 lands the
+// table (and that re-running stays idempotent — RunMigrations is invoked
+// again by every other test's setup).
+func TestRideRequestMigration_TableApplied(t *testing.T) {
+	_, _ = setupRideRequestRepo(t)
+	var n int
+	if err := testPool.QueryRow(context.Background(),
+		`SELECT COUNT(*) FROM go_ride_requests`).Scan(&n); err != nil {
+		t.Fatalf("go_ride_requests not queryable after migrations: %v", err)
+	}
+	if n != 0 {
+		t.Fatalf("expected empty table, got %d rows", n)
+	}
+}
+
+func TestRideRequestRepo_CreateAndGetRoundTrip(t *testing.T) {
+	repo, _ := setupRideRequestRepo(t)
+	ctx := context.Background()
+
+	tests := []struct {
+		name string
+		in   store.RideRequestRecord
+	}{
+		{name: "full scheduled booked-for request", in: fullRideRequest()},
+		{name: "minimal on-demand request", in: minimalRideRequest()},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			created, err := repo.Create(ctx, tt.in)
+			if err != nil {
+				t.Fatalf("Create: %v", err)
+			}
+			if created.ID == "" || !strings.HasPrefix(created.ID, "c") {
+				t.Errorf("expected generated cuid-shaped id, got %q", created.ID)
+			}
+			if created.Status != store.RideRequestStatusRequested {
+				t.Errorf("expected default status 'requested', got %q", created.Status)
+			}
+			if created.CreatedAt.IsZero() || created.UpdatedAt.IsZero() {
+				t.Error("expected DB-assigned created_at/updated_at")
+			}
+
+			got, err := repo.GetByID(ctx, created.ID)
+			if err != nil {
+				t.Fatalf("GetByID: %v", err)
+			}
+			if got.Pickup.Latitude != tt.in.Pickup.Latitude || got.Pickup.Longitude != tt.in.Pickup.Longitude {
+				t.Errorf("pickup coords: got (%v,%v) want (%v,%v)",
+					got.Pickup.Latitude, got.Pickup.Longitude, tt.in.Pickup.Latitude, tt.in.Pickup.Longitude)
+			}
+			if got.Dropoff.Latitude != tt.in.Dropoff.Latitude || got.Dropoff.Longitude != tt.in.Dropoff.Longitude {
+				t.Errorf("dropoff coords: got (%v,%v) want (%v,%v)",
+					got.Dropoff.Latitude, got.Dropoff.Longitude, tt.in.Dropoff.Latitude, tt.in.Dropoff.Longitude)
+			}
+			if got.Pickup.Label != tt.in.Pickup.Label || got.Dropoff.Label != tt.in.Dropoff.Label {
+				t.Errorf("labels: got (%q,%q) want (%q,%q)",
+					got.Pickup.Label, got.Dropoff.Label, tt.in.Pickup.Label, tt.in.Dropoff.Label)
+			}
+			assertPtrEq(t, "pickup address", got.Pickup.Address, tt.in.Pickup.Address)
+			assertPtrEq(t, "passenger name", got.PassengerName, tt.in.PassengerName)
+			assertPtrEq(t, "passenger phone", got.PassengerPhone, tt.in.PassengerPhone)
+			if (got.ScheduledFor == nil) != (tt.in.ScheduledFor == nil) {
+				t.Errorf("scheduledFor presence mismatch: got %v want %v", got.ScheduledFor, tt.in.ScheduledFor)
+			}
+			if got.ScheduledFor != nil && !got.ScheduledFor.Equal(*tt.in.ScheduledFor) {
+				t.Errorf("scheduledFor: got %v want %v", got.ScheduledFor, tt.in.ScheduledFor)
+			}
+			if got.AcceptedAt != nil || got.CompletedAt != nil {
+				t.Error("fresh request must not carry accepted_at/completed_at")
+			}
+			if got.RescheduleStatus != nil || got.RescheduleProposedFor != nil {
+				t.Error("fresh request must not carry a reschedule sub-state")
+			}
+		})
+	}
+}
+
+// TestRideRequestRepo_CoordinatesStoredEncrypted proves the encrypt-only
+// contract (NFR-3.23): raw *_enc columns never contain the plaintext
+// coordinate string.
+func TestRideRequestRepo_CoordinatesStoredEncrypted(t *testing.T) {
+	repo, enc := setupRideRequestRepo(t)
+	ctx := context.Background()
+
+	created, err := repo.Create(ctx, minimalRideRequest())
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	var pickupLatEnc, dropoffLngEnc string
+	err = testPool.QueryRow(ctx,
+		`SELECT pickup_lat_enc, dropoff_lng_enc FROM go_ride_requests WHERE id = $1`,
+		created.ID).Scan(&pickupLatEnc, &dropoffLngEnc)
+	if err != nil {
+		t.Fatalf("raw select: %v", err)
+	}
+
+	latPlain := strconv.FormatFloat(37.7749, 'g', -1, 64)
+	if pickupLatEnc == latPlain || strings.Contains(pickupLatEnc, latPlain) {
+		t.Errorf("pickup_lat_enc %q looks like plaintext", pickupLatEnc)
+	}
+	// Ciphertext decrypts back to the exact shortest-round-trip string.
+	got, err := enc.DecryptString(pickupLatEnc)
+	if err != nil {
+		t.Fatalf("DecryptString(pickup_lat_enc): %v", err)
+	}
+	if got != latPlain {
+		t.Errorf("decrypted pickup lat = %q, want %q", got, latPlain)
+	}
+	lngPlain := strconv.FormatFloat(-122.4148, 'g', -1, 64)
+	if dropoffLngEnc == lngPlain || strings.Contains(dropoffLngEnc, lngPlain) {
+		t.Errorf("dropoff_lng_enc %q looks like plaintext", dropoffLngEnc)
+	}
+}
+
+func TestRideRequestRepo_GetByID_NotFound(t *testing.T) {
+	repo, _ := setupRideRequestRepo(t)
+	_, err := repo.GetByID(context.Background(), "cnope")
+	if !errors.Is(err, store.ErrRideRequestNotFound) {
+		t.Fatalf("expected ErrRideRequestNotFound, got %v", err)
+	}
+	if !errors.Is(err, sdk.ErrNotFound) {
+		t.Fatalf("expected error to wrap sdk.ErrNotFound, got %v", err)
+	}
+}
+
+func TestRideRequestRepo_Lists(t *testing.T) {
+	repo, _ := setupRideRequestRepo(t)
+	ctx := context.Background()
+
+	mk := func(mut func(*store.RideRequestRecord)) store.RideRequestRecord {
+		rec := minimalRideRequest()
+		mut(&rec)
+		created, err := repo.Create(ctx, rec)
+		if err != nil {
+			t.Fatalf("Create: %v", err)
+		}
+		return created
+	}
+
+	r1 := mk(func(r *store.RideRequestRecord) {}) // rider A -> owner A
+	r2 := mk(func(r *store.RideRequestRecord) {}) // rider A -> owner A
+	r3 := mk(func(r *store.RideRequestRecord) { r.RiderID = "clriderB000000000000000" })
+	if _, err := repo.UpdateStatus(ctx, r2.ID, store.RideRequestStatusAccepted); err != nil {
+		t.Fatalf("UpdateStatus: %v", err)
+	}
+
+	t.Run("ListByRider returns only that rider's rows, newest first", func(t *testing.T) {
+		got, err := repo.ListByRider(ctx, r1.RiderID, 0)
+		if err != nil {
+			t.Fatalf("ListByRider: %v", err)
+		}
+		if len(got) != 2 {
+			t.Fatalf("expected 2 rows, got %d", len(got))
+		}
+		// r1 and r2 were created in the same NOW() neighborhood; ordering is
+		// (created_at DESC, id DESC) — assert both present and no r3.
+		ids := map[string]bool{got[0].ID: true, got[1].ID: true}
+		if !ids[r1.ID] || !ids[r2.ID] {
+			t.Errorf("expected rows %s and %s, got %v", r1.ID, r2.ID, ids)
+		}
+		if !got[0].CreatedAt.Before(time.Now().Add(time.Hour)) {
+			t.Error("sanity: created_at in the future")
+		}
+	})
+
+	t.Run("ListByRider honors limit", func(t *testing.T) {
+		got, err := repo.ListByRider(ctx, r1.RiderID, 1)
+		if err != nil {
+			t.Fatalf("ListByRider: %v", err)
+		}
+		if len(got) != 1 {
+			t.Fatalf("expected 1 row with limit 1, got %d", len(got))
+		}
+	})
+
+	t.Run("ListByOwner without status filter returns all", func(t *testing.T) {
+		got, err := repo.ListByOwner(ctx, r1.OwnerID, nil, 0)
+		if err != nil {
+			t.Fatalf("ListByOwner: %v", err)
+		}
+		if len(got) != 3 {
+			t.Fatalf("expected 3 rows (incl. rider B's), got %d", len(got))
+		}
+	})
+
+	t.Run("ListByOwner filters by status", func(t *testing.T) {
+		status := store.RideRequestStatusRequested
+		got, err := repo.ListByOwner(ctx, r1.OwnerID, &status, 0)
+		if err != nil {
+			t.Fatalf("ListByOwner: %v", err)
+		}
+		if len(got) != 2 {
+			t.Fatalf("expected 2 'requested' rows, got %d", len(got))
+		}
+		for _, rec := range got {
+			if rec.ID == r2.ID {
+				t.Error("accepted row r2 must be filtered out")
+			}
+		}
+	})
+
+	t.Run("empty result is an empty slice, not nil", func(t *testing.T) {
+		got, err := repo.ListByRider(ctx, "clnobody", 0)
+		if err != nil {
+			t.Fatalf("ListByRider: %v", err)
+		}
+		if got == nil || len(got) != 0 {
+			t.Fatalf("expected empty non-nil slice, got %#v", got)
+		}
+	})
+
+	_ = r3
+}
+
+func TestRideRequestRepo_UpdateStatus(t *testing.T) {
+	repo, _ := setupRideRequestRepo(t)
+	ctx := context.Background()
+
+	tests := []struct {
+		name          string
+		transitions   []store.RideRequestStatus
+		wantAccepted  bool
+		wantCompleted bool
+	}{
+		{
+			name:        "accepted stamps accepted_at only",
+			transitions: []store.RideRequestStatus{store.RideRequestStatusAccepted},
+			wantAccepted: true,
+		},
+		{
+			name:          "full lifecycle stamps both",
+			transitions:   []store.RideRequestStatus{store.RideRequestStatusAccepted, store.RideRequestStatusEnroute, store.RideRequestStatusArrived, store.RideRequestStatusCompleted},
+			wantAccepted:  true,
+			wantCompleted: true,
+		},
+		{
+			name:        "declined stamps neither",
+			transitions: []store.RideRequestStatus{store.RideRequestStatusDeclined},
+		},
+		{
+			name:        "cancelled stamps neither",
+			transitions: []store.RideRequestStatus{store.RideRequestStatusCancelled},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			created, err := repo.Create(ctx, minimalRideRequest())
+			if err != nil {
+				t.Fatalf("Create: %v", err)
+			}
+			var rec store.RideRequestRecord
+			for _, s := range tt.transitions {
+				rec, err = repo.UpdateStatus(ctx, created.ID, s)
+				if err != nil {
+					t.Fatalf("UpdateStatus(%s): %v", s, err)
+				}
+			}
+			if rec.Status != tt.transitions[len(tt.transitions)-1] {
+				t.Errorf("status = %q, want %q", rec.Status, tt.transitions[len(tt.transitions)-1])
+			}
+			if (rec.AcceptedAt != nil) != tt.wantAccepted {
+				t.Errorf("accepted_at set = %v, want %v", rec.AcceptedAt != nil, tt.wantAccepted)
+			}
+			if (rec.CompletedAt != nil) != tt.wantCompleted {
+				t.Errorf("completed_at set = %v, want %v", rec.CompletedAt != nil, tt.wantCompleted)
+			}
+			if tt.wantAccepted && rec.AcceptedAt.Before(rec.CreatedAt) {
+				t.Errorf("accepted_at %v precedes created_at %v", rec.AcceptedAt, rec.CreatedAt)
+			}
+			if tt.wantCompleted && rec.CompletedAt.Before(*rec.AcceptedAt) {
+				t.Errorf("completed_at %v precedes accepted_at %v", rec.CompletedAt, rec.AcceptedAt)
+			}
+			if !rec.UpdatedAt.After(rec.CreatedAt) && !rec.UpdatedAt.Equal(rec.CreatedAt) {
+				t.Errorf("updated_at %v not >= created_at %v", rec.UpdatedAt, rec.CreatedAt)
+			}
+		})
+	}
+
+	t.Run("re-entering accepted never moves the original stamp", func(t *testing.T) {
+		created, err := repo.Create(ctx, minimalRideRequest())
+		if err != nil {
+			t.Fatalf("Create: %v", err)
+		}
+		first, err := repo.UpdateStatus(ctx, created.ID, store.RideRequestStatusAccepted)
+		if err != nil {
+			t.Fatalf("UpdateStatus: %v", err)
+		}
+		again, err := repo.UpdateStatus(ctx, created.ID, store.RideRequestStatusAccepted)
+		if err != nil {
+			t.Fatalf("UpdateStatus (again): %v", err)
+		}
+		if !again.AcceptedAt.Equal(*first.AcceptedAt) {
+			t.Errorf("accepted_at moved on re-accept: %v -> %v", first.AcceptedAt, again.AcceptedAt)
+		}
+	})
+
+	t.Run("unknown id returns ErrRideRequestNotFound", func(t *testing.T) {
+		_, err := repo.UpdateStatus(ctx, "cnope", store.RideRequestStatusAccepted)
+		if !errors.Is(err, store.ErrRideRequestNotFound) {
+			t.Fatalf("expected ErrRideRequestNotFound, got %v", err)
+		}
+	})
+
+	t.Run("status outside the contract enum is rejected by the CHECK", func(t *testing.T) {
+		created, err := repo.Create(ctx, minimalRideRequest())
+		if err != nil {
+			t.Fatalf("Create: %v", err)
+		}
+		if _, err := repo.UpdateStatus(ctx, created.ID, "hovering"); err == nil {
+			t.Fatal("expected CHECK-constraint error for unknown status, got nil")
+		}
+	})
+}
+
+func TestRideRequestRepo_Reschedule(t *testing.T) {
+	repo, _ := setupRideRequestRepo(t)
+	ctx := context.Background()
+	proposed := time.Date(2026, 6, 19, 16, 30, 0, 0, time.UTC)
+
+	newAcceptedScheduled := func(t *testing.T) store.RideRequestRecord {
+		t.Helper()
+		created, err := repo.Create(ctx, fullRideRequest())
+		if err != nil {
+			t.Fatalf("Create: %v", err)
+		}
+		accepted, err := repo.UpdateStatus(ctx, created.ID, store.RideRequestStatusAccepted)
+		if err != nil {
+			t.Fatalf("UpdateStatus: %v", err)
+		}
+		return accepted
+	}
+
+	t.Run("propose opens the negotiation without touching the main status", func(t *testing.T) {
+		ride := newAcceptedScheduled(t)
+		rec, err := repo.ProposeReschedule(ctx, ride.ID, proposed)
+		if err != nil {
+			t.Fatalf("ProposeReschedule: %v", err)
+		}
+		if rec.Status != store.RideRequestStatusAccepted {
+			t.Errorf("main status changed to %q; reschedule must be orthogonal", rec.Status)
+		}
+		if rec.RescheduleStatus == nil || *rec.RescheduleStatus != store.RescheduleStatusRequested {
+			t.Errorf("reschedule_status = %v, want 'requested'", rec.RescheduleStatus)
+		}
+		if rec.RescheduleProposedFor == nil || !rec.RescheduleProposedFor.Equal(proposed) {
+			t.Errorf("reschedule_proposed_for = %v, want %v", rec.RescheduleProposedFor, proposed)
+		}
+		if !rec.ScheduledFor.Equal(*ride.ScheduledFor) {
+			t.Errorf("scheduled_for moved on propose: %v -> %v", ride.ScheduledFor, rec.ScheduledFor)
+		}
+	})
+
+	t.Run("confirm adopts the proposed time into scheduled_for", func(t *testing.T) {
+		ride := newAcceptedScheduled(t)
+		if _, err := repo.ProposeReschedule(ctx, ride.ID, proposed); err != nil {
+			t.Fatalf("ProposeReschedule: %v", err)
+		}
+		rec, err := repo.ResolveReschedule(ctx, ride.ID, true)
+		if err != nil {
+			t.Fatalf("ResolveReschedule(confirm): %v", err)
+		}
+		if rec.ScheduledFor == nil || !rec.ScheduledFor.Equal(proposed) {
+			t.Errorf("scheduled_for = %v, want confirmed time %v", rec.ScheduledFor, proposed)
+		}
+		if rec.RescheduleStatus == nil || *rec.RescheduleStatus != store.RescheduleStatusConfirmed {
+			t.Errorf("reschedule_status = %v, want 'confirmed'", rec.RescheduleStatus)
+		}
+		if rec.RescheduleProposedFor == nil {
+			t.Error("proposed time must be retained for audit after confirm")
+		}
+	})
+
+	t.Run("decline keeps the original reservation", func(t *testing.T) {
+		ride := newAcceptedScheduled(t)
+		if _, err := repo.ProposeReschedule(ctx, ride.ID, proposed); err != nil {
+			t.Fatalf("ProposeReschedule: %v", err)
+		}
+		rec, err := repo.ResolveReschedule(ctx, ride.ID, false)
+		if err != nil {
+			t.Fatalf("ResolveReschedule(decline): %v", err)
+		}
+		if !rec.ScheduledFor.Equal(*ride.ScheduledFor) {
+			t.Errorf("scheduled_for = %v, want original %v", rec.ScheduledFor, ride.ScheduledFor)
+		}
+		if rec.RescheduleStatus == nil || *rec.RescheduleStatus != store.RescheduleStatusDeclined {
+			t.Errorf("reschedule_status = %v, want 'declined'", rec.RescheduleStatus)
+		}
+	})
+
+	t.Run("resolving without an open negotiation is not found", func(t *testing.T) {
+		ride := newAcceptedScheduled(t)
+		if _, err := repo.ResolveReschedule(ctx, ride.ID, true); !errors.Is(err, store.ErrRideRequestNotFound) {
+			t.Fatalf("expected ErrRideRequestNotFound for never-proposed ride, got %v", err)
+		}
+		if _, err := repo.ProposeReschedule(ctx, ride.ID, proposed); err != nil {
+			t.Fatalf("ProposeReschedule: %v", err)
+		}
+		if _, err := repo.ResolveReschedule(ctx, ride.ID, true); err != nil {
+			t.Fatalf("ResolveReschedule: %v", err)
+		}
+		if _, err := repo.ResolveReschedule(ctx, ride.ID, true); !errors.Is(err, store.ErrRideRequestNotFound) {
+			t.Fatalf("expected ErrRideRequestNotFound on double-resolve, got %v", err)
+		}
+	})
+}
+
+// assertPtrEq compares two optional strings by value.
+func assertPtrEq(t *testing.T, field string, got, want *string) {
+	t.Helper()
+	switch {
+	case got == nil && want == nil:
+	case got == nil || want == nil:
+		t.Errorf("%s: got %v want %v", field, got, want)
+	case *got != *want:
+		t.Errorf("%s: got %q want %q", field, *got, *want)
+	}
+}

--- a/internal/store/ride_request_scan.go
+++ b/internal/store/ride_request_scan.go
@@ -1,0 +1,93 @@
+// RideRequestRepo scan + coordinate-crypto helpers (MYR-173). Split from
+// ride_request_repo.go so the accessor file stays focused on the public
+// surface. Reuses the lossless float<->string codec from
+// vehicle_gps_encryption.go (strconv round-trip, byte-compatible with the
+// TS helpers) so a future cross-repo reader decrypts identically.
+
+package store
+
+import (
+	"fmt"
+
+	"github.com/jackc/pgx/v5"
+)
+
+// encryptPlace encrypts a place's coordinate pair for the *_enc columns.
+// Unlike the Vehicle dual-write path there is no plaintext fallback column,
+// so any encrypt failure fails the write.
+func (r *RideRequestRepo) encryptPlace(p RidePlace) (latEnc, lngEnc string, err error) {
+	lat := p.Latitude
+	lng := p.Longitude
+	latEnc, err = floatToEncString(&lat, r.encryptor)
+	if err != nil {
+		return "", "", fmt.Errorf("encrypt latitude: %w", err)
+	}
+	lngEnc, err = floatToEncString(&lng, r.encryptor)
+	if err != nil {
+		return "", "", fmt.Errorf("encrypt longitude: %w", err)
+	}
+	return latEnc, lngEnc, nil
+}
+
+// decryptCoord decrypts one required coordinate column. A NULL/empty or
+// non-numeric result is corruption (the column is NOT NULL and encrypt-only
+// — there is no legitimate absent state), so it escalates to an error
+// rather than the (nil, nil) absent sentinel the Vehicle fallback path
+// tolerates.
+func (r *RideRequestRepo) decryptCoord(column, ciphertext string) (float64, error) {
+	v, err := encStringToFloat(&ciphertext, r.encryptor)
+	if err != nil {
+		return 0, fmt.Errorf("decrypt %s: %w", column, err)
+	}
+	if v == nil {
+		return 0, fmt.Errorf("decrypt %s: corrupt or empty ciphertext", column)
+	}
+	return *v, nil
+}
+
+// scanRideRequest scans one rideRequestColumns row and decrypts the
+// coordinate ciphertexts into the returned record. pgx.ErrNoRows passes
+// through unwrapped so callers can map it to ErrRideRequestNotFound.
+func (r *RideRequestRepo) scanRideRequest(row pgx.Row) (RideRequestRecord, error) {
+	var (
+		rec           RideRequestRecord
+		pickupLatEnc  string
+		pickupLngEnc  string
+		dropoffLatEnc string
+		dropoffLngEnc string
+		status        string
+		reschedStatus *string
+	)
+	err := row.Scan(
+		&rec.ID, &rec.RiderID, &rec.OwnerID, &rec.VehicleID,
+		&pickupLatEnc, &pickupLngEnc, &rec.Pickup.Label, &rec.Pickup.Address,
+		&dropoffLatEnc, &dropoffLngEnc, &rec.Dropoff.Label, &rec.Dropoff.Address,
+		&status, &rec.PassengerName, &rec.PassengerPhone,
+		&rec.ScheduledFor, &rec.RescheduleProposedFor, &reschedStatus,
+		&rec.AcceptedAt, &rec.CompletedAt, &rec.CreatedAt, &rec.UpdatedAt,
+	)
+	if err != nil {
+		// %w keeps pgx.ErrNoRows visible to the callers' errors.Is mapping.
+		return RideRequestRecord{}, fmt.Errorf("scan ride request: %w", err)
+	}
+
+	rec.Status = RideRequestStatus(status)
+	if reschedStatus != nil {
+		rs := RescheduleStatus(*reschedStatus)
+		rec.RescheduleStatus = &rs
+	}
+
+	if rec.Pickup.Latitude, err = r.decryptCoord("pickup_lat_enc", pickupLatEnc); err != nil {
+		return RideRequestRecord{}, err
+	}
+	if rec.Pickup.Longitude, err = r.decryptCoord("pickup_lng_enc", pickupLngEnc); err != nil {
+		return RideRequestRecord{}, err
+	}
+	if rec.Dropoff.Latitude, err = r.decryptCoord("dropoff_lat_enc", dropoffLatEnc); err != nil {
+		return RideRequestRecord{}, err
+	}
+	if rec.Dropoff.Longitude, err = r.decryptCoord("dropoff_lng_enc", dropoffLngEnc); err != nil {
+		return RideRequestRecord{}, err
+	}
+	return rec, nil
+}

--- a/internal/store/ride_request_types.go
+++ b/internal/store/ride_request_types.go
@@ -1,0 +1,84 @@
+// Ride-request domain types (MYR-173). The wire source of truth is the
+// contracts package (schemas/ride-request.schema.json); these structs are
+// the persisted mirror backed by the Go-owned go_ride_requests table
+// (migrations/0002_ride_requests.up.sql).
+//
+// Classification (docs/contracts/data-classification.md §1.9): pickup and
+// dropoff coordinates are P1 GPS data — stored encrypt-only (AES-256-GCM,
+// NFR-3.23) and never logged. Labels, addresses, and the booked-for
+// passenger name/phone are P1 log-redacted. IDs, status, and timestamps
+// are P0.
+
+package store
+
+import "time"
+
+// RideRequestStatus mirrors the contracts RideRequestStatus wire enum —
+// the main ride lifecycle. The reschedule negotiation is deliberately a
+// separate sub-state (RescheduleStatus), not a member of this enum.
+type RideRequestStatus string
+
+const (
+	RideRequestStatusRequested RideRequestStatus = "requested"
+	RideRequestStatusAccepted  RideRequestStatus = "accepted"
+	RideRequestStatusDeclined  RideRequestStatus = "declined"
+	RideRequestStatusEnroute   RideRequestStatus = "enroute"
+	RideRequestStatusArrived   RideRequestStatus = "arrived"
+	RideRequestStatusCompleted RideRequestStatus = "completed"
+	RideRequestStatusCancelled RideRequestStatus = "cancelled"
+)
+
+// RescheduleStatus mirrors the contracts RescheduleStatus wire enum — the
+// reschedule-negotiation sub-state, orthogonal to RideRequestStatus. A nil
+// *RescheduleStatus on RideRequestRecord means no reschedule was ever
+// proposed for the ride.
+type RescheduleStatus string
+
+const (
+	RescheduleStatusRequested RescheduleStatus = "requested"
+	RescheduleStatusConfirmed RescheduleStatus = "confirmed"
+	RescheduleStatusDeclined  RescheduleStatus = "declined"
+)
+
+// RidePlace is a pickup or drop-off point — contracts $defs.RidePlace.
+// Latitude/Longitude are P1 GPS coordinates: the repo encrypts them into
+// the *_enc columns on write and decrypts on read; they never touch the
+// database (or logs) in plaintext.
+type RidePlace struct {
+	Latitude  float64
+	Longitude float64
+	Label     string
+	Address   *string // nullable; secondary street-address line
+}
+
+// RideRequestRecord maps to the Go-owned go_ride_requests table and
+// mirrors the contracts RideRequest object field-for-field (wire camelCase
+// -> Go exported names; wire omit-when-absent -> nil pointers).
+type RideRequestRecord struct {
+	ID        string
+	RiderID   string
+	OwnerID   string
+	VehicleID string
+
+	Pickup  RidePlace
+	Dropoff RidePlace
+
+	Status RideRequestStatus
+
+	// Booked-for passenger ("Someone else" rides). Both nil when the rider
+	// is riding themselves.
+	PassengerName  *string
+	PassengerPhone *string
+
+	// Scheduled rides + reschedule negotiation. ScheduledFor nil = an
+	// on-demand ("Now") ride. RescheduleProposedFor/RescheduleStatus nil =
+	// no reschedule ever proposed.
+	ScheduledFor          *time.Time
+	RescheduleProposedFor *time.Time
+	RescheduleStatus      *RescheduleStatus
+
+	AcceptedAt  *time.Time
+	CompletedAt *time.Time
+	CreatedAt   time.Time
+	UpdatedAt   time.Time
+}


### PR DESCRIPTION
## Summary

MYR-173 foundation for P10 ride-hailing: the `go_ride_requests` table (migration 0002) + `RideRequestRepo` store layer, matching the new contract (`myrobotaxi/contracts#15`, `schemas/ride-request.schema.json`). No HTTP handlers — MYR-174 (rider API) and MYR-175 (owner accept/decline) bind onto these accessors.

## Schema / table design

- **`go_` namespace, snake_case, no FKs** — CG-DL-9: Go-owned tables must be `go_`/`_telemetry_` prefixed and Go migration SQL must never reference tables owned by the sibling app's schema, so `rider_id`/`owner_id`/`vehicle_id` are plain TEXT cuids. Replicated the CI grep locally: clean.
- **Status lifecycle** — TEXT + CHECK on the 7 contract values (`requested/accepted/declined/enroute/arrived/completed/cancelled`); per-state design citations live in the contract schema. Adding a state is a contract change and ships with its own migration.
- **Reschedule sub-state** (MYR-192-ready) — `reschedule_proposed_for TIMESTAMPTZ` + `reschedule_status TEXT CHECK (requested/confirmed/declined)`, orthogonal to `status`: the design keeps the reservation alive while the owner re-confirms (design/app/shared-screens.jsx:51,316-338), so a reschedule ask never touches the main lifecycle. Confirm adopts the proposed time into `scheduled_for`; the proposal is retained for audit.
- **Booked-for** — `passenger_name`/`passenger_phone` (nullable, P1): the phone is the tracking-link SMS target (design/app/ride-request.jsx:133-141), needed by MYR-174/176.
- **Coordinates encrypt-only (NFR-3.23)** — `pickup/dropoff_{lat,lng}_enc TEXT NOT NULL` AES-256-GCM ciphertext; being a NEW table there is no plaintext column, no dual-write rollout, no backfill gauge (unlike MYR-63/64). Reuses the `vehicle_gps_encryption.go` float codec so ciphertext is byte-compatible with the platform's other GPS columns. `NewRideRequestRepo` panics on a nil Encryptor; decrypt failure is a hard read error (no fallback column exists).
- **Indexes** — `(rider_id, created_at DESC, id DESC)` for MYR-174 lists, `(owner_id, status, created_at DESC, id DESC)` for the MYR-175 incoming feed, `(vehicle_id, …)` for MYR-176 dispatch. Ordering matches the contract envelope (createdAt DESC, id DESC).

## Store surface (`internal/store/ride_request_*.go`)

`Create` (generates cuid-shaped id, defaults status `requested`), `GetByID`, `ListByRider(limit)`, `ListByOwner(status?, limit)`, `UpdateStatus` (single statement stamps `accepted_at` on first entry to `accepted`, `completed_at` on first entry to `completed`, always `updated_at`; transition *legality* is deliberately left to the MYR-175/176 handlers), `ProposeReschedule`, `ResolveReschedule` (confirm/decline; only matches an open `requested` negotiation — double-resolve is `ErrRideRequestNotFound`). New `ErrRideRequestNotFound` wraps `sdk.ErrNotFound`. Metrics follow the `ride_request.*` operation-name convention.

`docs/contracts/data-classification.md` gains §1.9 (22 columns classified: 12 P0, 4 P1-encrypted, 6 P1 log-redacted), §3.1/§3.2 scope rows, and updated summary counts with the required audit-trail entry.

## Test evidence

`go test ./... -count=1` — full pass, all packages (real Postgres via testcontainers, store suite executed — not skipped). New tests in `internal/store/ride_request_repo_test.go`:

- `TestRideRequestMigration_TableApplied` — 0002 applies; setup re-runs `RunMigrations` per test proving idempotency
- `TestRideRequestRepo_CreateAndGetRoundTrip` — full (scheduled + booked-for) and minimal shapes round-trip, incl. coordinate decrypt and nil-ness of every optional
- `TestRideRequestRepo_CoordinatesStoredEncrypted` — raw `*_enc` columns contain no plaintext; ciphertext decrypts to the exact shortest-round-trip float string
- `TestRideRequestRepo_GetByID_NotFound` — wraps `sdk.ErrNotFound`
- `TestRideRequestRepo_Lists` — rider scoping, owner status filter, limit, empty-is-`[]`-not-nil
- `TestRideRequestRepo_UpdateStatus` — table-driven transitions: accepted stamps `accepted_at` only; full lifecycle stamps both; declined/cancelled stamp neither; re-accept never moves the original stamp; unknown id → not-found; out-of-enum status rejected by CHECK
- `TestRideRequestRepo_Reschedule` — propose leaves main status untouched; confirm moves `scheduled_for`; decline keeps original; resolve without an open negotiation → not-found

`go vet ./...`, `go build ./cmd/...`, `golangci-lint run ./...` — 0 issues.

## Companion PR

Contract source of truth: myrobotaxi/contracts#15 (schema + TS/Swift codegen).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
