### PR TITLE
MYR-180: Tesla signed vehicle-command proxy + scope gating

### DIFF
--- a/cmd/telemetry-server/wiring.go
+++ b/cmd/telemetry-server/wiring.go
@@ -16,6 +16,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 
 	"github.com/myrobotaxi/telemetry/internal/auth"
+	"github.com/myrobotaxi/telemetry/internal/commands"
 	"github.com/myrobotaxi/telemetry/internal/config"
 	"github.com/myrobotaxi/telemetry/internal/cryptox"
 	"github.com/myrobotaxi/telemetry/internal/events"
@@ -285,27 +286,34 @@ func setupHTTPHandlers(deps httpRouteDeps) {
 
 	setupFleetConfigEndpoint(deps.cfg, deps.srv, deps.authenticator, deps.vinCache, deps.accountRepo, deps.vehicleRepo, deps.logger)
 
-	// Mounted when resolveDebugFieldsGate says so — either because the
-	// server is running with --dev (token optional) or because an operator
-	// has set DEBUG_FIELDS_TOKEN on a production instance to let
-	// `ops fields watch` stream real-Tesla frames. Auth is enforced by
-	// DebugFieldsHandler via the X-Debug-Token header / ?token= query
-	// param when APIKey is non-empty.
-	if deps.debugGate.Enabled {
-		debugHandler := telemetry.NewDebugFieldsHandler(
-			deps.bus,
-			deps.logger.With(slog.String("component", "debug-fields")),
-			telemetry.DebugFieldsConfig{
-				APIKey:         deps.debugGate.Token,
-				OriginPatterns: deps.originPatterns,
-			},
-		)
-		deps.srv.HandleFunc("GET /api/debug/fields", debugHandler.ServeHTTP)
-		deps.logger.Info("/api/debug/fields endpoint enabled",
-			slog.String("gate", deps.debugGate.Reason),
-			slog.Bool("token_required", deps.debugGate.Token != ""),
-		)
+	setupVehicleCommandEndpoint(deps, snapshotAdapter)
+
+	setupDebugFieldsEndpoint(deps)
+}
+
+// setupDebugFieldsEndpoint mounts GET /api/debug/fields when
+// resolveDebugFieldsGate says so — either because the server is running
+// with --dev (token optional) or because an operator has set
+// DEBUG_FIELDS_TOKEN on a production instance to let `ops fields watch`
+// stream real-Tesla frames. Auth is enforced by DebugFieldsHandler via the
+// X-Debug-Token header / ?token= query param when APIKey is non-empty.
+func setupDebugFieldsEndpoint(deps httpRouteDeps) {
+	if !deps.debugGate.Enabled {
+		return
 	}
+	debugHandler := telemetry.NewDebugFieldsHandler(
+		deps.bus,
+		deps.logger.With(slog.String("component", "debug-fields")),
+		telemetry.DebugFieldsConfig{
+			APIKey:         deps.debugGate.Token,
+			OriginPatterns: deps.originPatterns,
+		},
+	)
+	deps.srv.HandleFunc("GET /api/debug/fields", debugHandler.ServeHTTP)
+	deps.logger.Info("/api/debug/fields endpoint enabled",
+		slog.String("gate", deps.debugGate.Reason),
+		slog.Bool("token_required", deps.debugGate.Token != ""),
+	)
 }
 
 // setupRideRequestEndpoints wires the ride-request REST surface: the
@@ -433,6 +441,52 @@ func setupFleetConfigEndpoint(
 	logger.Info("fleet config endpoints enabled (VIN + vehicleId, GET status + POST re-push)",
 		slog.String("proxy_url", cfg.Proxy().URL),
 	)
+}
+
+// setupVehicleCommandEndpoint mounts POST /api/vehicles/{vehicleId}/command/{name}
+// (MYR-180). The signed-command transport reuses the tesla-http-proxy
+// sidecar (cfg.Proxy().URL) that fleet-config push already uses — the
+// P-256 command key lives ONLY in that proxy's config, never in this
+// process (decision record: docs/operations/vehicle-commands.md §1). The
+// route is ALWAYS mounted so the SDK sees a typed error, not a 404: when
+// no proxy is configured the transport is disabled and every signer-
+// required command resolves to key_not_paired.
+func setupVehicleCommandEndpoint(deps httpRouteDeps, vehicles telemetry.VehicleSnapshotReader) {
+	proxyURL := deps.cfg.Proxy().URL
+	transport := commands.NewProxyTransport(
+		proxyURL,
+		proxyHTTPClient(proxyURL, deps.logger),
+		deps.logger.With(slog.String("component", "command-transport")),
+	)
+	executor := commands.NewExecutor(transport, deps.logger.With(slog.String("component", "command-executor")))
+
+	var opts []telemetry.VehicleCommandOption
+	if deps.cfg.TeslaOAuth().ClientID != "" {
+		refresher := telemetry.NewTokenRefresher(telemetry.TeslaOAuthConfig{
+			ClientID:     deps.cfg.TeslaOAuth().ClientID,
+			ClientSecret: deps.cfg.TeslaOAuth().ClientSecret,
+		}, deps.logger.With(slog.String("component", "command-token-refresh")))
+		opts = append(opts, telemetry.WithCommandTokenRefresher(refresher, &teslaTokenUpdaterAdapter{repo: deps.accountRepo}))
+	}
+
+	handler := telemetry.NewVehicleCommandHandler(
+		deps.authenticator,
+		vehicles,
+		&teslaTokenAdapter{repo: deps.accountRepo},
+		executor,
+		deps.logger.With(slog.String("component", "vehicle-command")),
+		opts...,
+	)
+	deps.srv.HandleFunc("POST /api/vehicles/{vehicleId}/command/{name}", handler.ServeHTTP)
+
+	if transport.Enabled() {
+		deps.logger.Info("vehicle command endpoint enabled",
+			slog.String("proxy_url", proxyURL),
+			slog.Int("commands", len(executor.Registry().Names())),
+		)
+	} else {
+		deps.logger.Warn("vehicle command endpoint mounted but signing disabled: TESLA_PROXY_URL not set — signer-required commands return key_not_paired")
+	}
 }
 
 // buildTeslaTLS creates a TLS config for the Tesla mTLS port. It loads

--- a/cmd/telemetry-server/wiring_routes_test.go
+++ b/cmd/telemetry-server/wiring_routes_test.go
@@ -118,6 +118,7 @@ func TestSetupHTTPHandlers_RouteSurface(t *testing.T) {
 		{"ride request cancel (MYR-174)", "/api/ride-requests/crr0123456789abcdef0123456789abcd/cancel"},
 		{"ride request accept (MYR-175)", "/api/ride-requests/crr0123456789abcdef0123456789abcd/accept"},
 		{"ride request decline (MYR-175)", "/api/ride-requests/crr0123456789abcdef0123456789abcd/decline"},
+		{"vehicle command (MYR-180)", "/api/vehicles/clxyz1234567890abcdef/command/door_lock"},
 	}
 	for _, rt := range postRoutes {
 		t.Run(rt.name, func(t *testing.T) {

--- a/docs/contracts/rest-api.md
+++ b/docs/contracts/rest-api.md
@@ -207,15 +207,19 @@ The REST catalog is a superset of the WebSocket catalog in [`websocket-protocol.
 | `internal_error` | 500 | Shared (WS + REST) | Implemented on REST (MYR-47); PLANNED on WS | Auto-retry with exponential backoff (NFR-3.10 curve from `websocket-protocol.md` §7.1), cap at 3 REST attempts before surfacing. | Catch-all for unexpected server failures: panics, DB errors, downstream timeouts. |
 | `service_unavailable` | 503 | **REST-only, PLANNED** | PLANNED (DV-21) | Auto-retry with exponential backoff; honor `Retry-After` header if present. | Reserved for maintenance windows and graceful-shutdown states. The server MAY return `503` during rolling deployments; v1 does not yet emit this code. Added to the REST catalog so SDK consumers can write forward-compatible handlers. |
 | `snapshot_required` | -- | **WS-only** (close code 4005 + error frame) | PLANNED (DV-02) | n/a for REST | WS-only. REST has no analogue because REST is already the snapshot channel (the "fall back to snapshot fetch" signal IS a REST call). Listed here for completeness; REST clients never receive this code. |
+| `key_not_paired` | 403 | **REST-only** | Implemented (MYR-180) | Surface to UI; **do not auto-retry** — needs owner action. | The application's virtual key is not enrolled on the vehicle (owner has not completed the `tesla.com/_ak/<domain>` pairing, MYR-115), or the command-signing transport is not configured. This is the default outcome for every signer-required command in §7.9 until pairing happens. The SDK prompts the owner to pair. |
+| `vehicle_asleep` | 503 | **REST-only** | Implemented (MYR-180) | Auto-retry with backoff (§4.1.2 curve). SDK MAY honor `Retry-After`. | The target vehicle was asleep/offline and did not come online within the executor's bounded wake+retry budget (§7.9). Transient — the executor already woke + retried internally before surfacing this. |
+| `command_failed` | 502 | **REST-only** | Implemented (MYR-180) | Surface to UI; do not blindly auto-retry (the vehicle rejected the action). | A vehicle command (§7.9) failed for a non-scope, non-pairing reason: the vehicle returned `result:false`, a signing-session/counter error survived re-handshake, or the Fleet API/proxy failed. Collapses the several vehicle-side failure modes into one typed code in v1. |
 
 ##### 4.1.1.a REST-only codes added to the shared catalog
 
-Four codes are REST-only extensions of the shared catalog: `not_found`, `invalid_request`, `service_unavailable`, and `conflict` (MYR-174).
+Seven codes are REST-only extensions of the shared catalog: `not_found`, `invalid_request`, `service_unavailable`, `conflict` (MYR-174), and `key_not_paired` / `vehicle_asleep` / `command_failed` (MYR-180).
 
 - `conflict` (HTTP 409) is emitted only over REST when a ride-request lifecycle mutation is illegal from the row's current state (§7.8 transition matrix). It has no WS analogue because the ride-request mutations are request-oriented REST endpoints; the WS transport carries only the summary `ride_status_changed` broadcast of a *successful* transition. It is a member of the shared `ErrorPayload.code` enum (added by MYR-174) so the SDK's `CoreError` union stays one enum across transports; the schema enum description marks it REST-only-on-the-wire.
 - `not_found` is not emitted over the WebSocket because the WS path enforces ownership via silent filtering in `Hub.Broadcast` (see `websocket-protocol.md` §4.5) -- a client simply does not receive frames for vehicles it does not own, and there is no equivalent "the resource does not exist" signal because the WS is stream-oriented, not request-oriented. On REST, every vehicle-scoped path param MUST return `404 not_found` for unknown IDs.
 - `invalid_request` exists only because REST accepts structured request bodies and query params that can be malformed independently of auth. The WS protocol has no v1 client->server frames that take structured payloads beyond `auth`, so malformed-body errors cannot arise there.
 - `service_unavailable` is RESERVED for the REST contract so the SDK can write forward-compatible handlers before the server begins emitting it during maintenance windows.
+- `key_not_paired`, `vehicle_asleep`, and `command_failed` are the MYR-180 vehicle-command codes (§7.9). They are REST-only because the WS transport is stream-oriented and carries no command requests — there is no WS surface on which a command could be issued or rejected. They are members of the shared enum (added by MYR-180) so the SDK's `CoreError` union stays one enum across transports; the schema enum description marks them REST-only-on-the-wire.
 
 Both `not_found` and `invalid_request` are now members of the shared `ErrorPayload.code` enum in [`schemas/ws-messages.schema.json`](schemas/ws-messages.schema.json) (added by MYR-98, the DV-20 enum slice) even though the WS never emits them, so the SDK's `CoreError` union is a single enum across both transports. This is not a drift -- the WS contract explicitly lists them as "REST-only" in the catalog description and the schema enum description marks them REST-only-on-the-wire. The shared-enum subCode `reauth_required` was added in the same change (REST-only; see §4.1). DV-20's remaining open scope is the endpoint-mounting work (§10), not the enum.
 
@@ -526,6 +530,7 @@ No contract changes are required for the new role's wire shape (the REST respons
 | `POST` | `/api/ride-requests/{id}/cancel` | Rider cancels a requested/accepted ride | Bearer (rider) | FR-9.3 |
 | `POST` | `/api/ride-requests/{id}/accept` | Owner accepts a `requested` ride (emits the MYR-176 dispatch seam) | Bearer (owner) | FR-9.3 |
 | `POST` | `/api/ride-requests/{id}/decline` | Owner declines a `requested` ride | Bearer (owner) | FR-9.3 |
+| `POST` | `/api/vehicles/{vehicleId}/command/{name}` | Send a Tesla vehicle command (P11 actuation + P10 dispatch) | Bearer + owner of vehicleId | FR-11.x, NFR-3.21 |
 
 The `POST`/`GET /api/ride-requests[...]` rows (§7.8) are the P10 ride-hailing surface: the four rider-facing endpoints are mounted as of MYR-174 and the three owner-facing endpoints (incoming feed + accept/decline) as of MYR-175. The dispatch/live-tracking transitions remain with MYR-176/177 and the reschedule endpoints with MYR-192.
 
@@ -1374,6 +1379,94 @@ The main `RideRequestStatus` lifecycle is monotonic; the reschedule negotiation 
 
 ---
 
+### 7.9 `POST /api/vehicles/{vehicleId}/command/{name}` (Tesla vehicle commands)
+
+> **Anchored:** FR-11.x (vehicle actuation), NFR-3.21 (ownership enforcement), NFR-3.22 (TLS in transit). Implemented by MYR-180.
+
+#### Purpose
+
+The owner-only actuation surface. It sends a signed Tesla Fleet vehicle command (lock, climate, charge, trunk, remote start, horn, lights) or an unsigned navigation/dispatch command to the caller's vehicle. It is the foundation for P11 (per-command issues MYR-181–183) and P10 dispatch (MYR-176 uses `navigation_gps_request`).
+
+#### Transport / architecture
+
+Modern Fleet API vehicle commands require end-to-end command signing with a virtual key the owner enrolls in the car. The server does **not** embed the signing library in-process: it forwards commands to the **tesla-http-proxy sidecar** it already runs for `fleet_telemetry_config` pushes (`TESLA_PROXY_URL`). The proxy signs signer-required commands with the P-256 virtual key (which lives ONLY in the proxy's config, never in this process) and forwards unsigned commands (`navigation_request`) straight to the Fleet API. Session caching, re-handshake, and wake are the proxy's job. Full decision record + ops runbook: [`docs/operations/vehicle-commands.md`](../operations/vehicle-commands.md).
+
+#### Request
+
+```
+POST /api/vehicles/{vehicleId}/command/{name} HTTP/1.1
+Host: api.myrobotaxi.com
+Authorization: Bearer <token>
+Content-Type: application/json
+
+{ ...command parameters (may be empty)... }
+```
+
+- `{vehicleId}` is the cuid (NOT the VIN); the server resolves it to the VIN server-side.
+- `{name}` is the command name (identical to the Tesla Fleet command name).
+- The body is the command's typed parameters; parameterless commands take an empty body.
+
+#### Command catalog
+
+| `{name}` | Scope | Signed | Params |
+|----------|-------|--------|--------|
+| `door_lock` | `vehicle_cmds` | yes | — |
+| `door_unlock` | `vehicle_cmds` | yes | — |
+| `auto_conditioning_start` | `vehicle_cmds` | yes | — |
+| `auto_conditioning_stop` | `vehicle_cmds` | yes | — |
+| `set_temps` | `vehicle_cmds` | yes | `driver_temp` (°C, required), `passenger_temp` (°C, optional; mirrors driver) |
+| `charge_start` | `vehicle_charging_cmds` | yes | — |
+| `charge_stop` | `vehicle_charging_cmds` | yes | — |
+| `set_charge_limit` | `vehicle_charging_cmds` | yes | `percent` (int 50–100) |
+| `actuate_trunk` | `vehicle_cmds` | yes | `which_trunk` (`"front"` \| `"rear"`) |
+| `remote_start_drive` | `vehicle_cmds` | yes | — |
+| `honk_horn` | `vehicle_cmds` | yes | — |
+| `flash_lights` | `vehicle_cmds` | yes | — |
+| `navigation_gps_request` | `vehicle_cmds` | no | `lat`, `lon` (required), `order` (int, default 1) — the lat/long dispatch command (MYR-176) |
+| `navigation_request` | `vehicle_cmds` | no | `value` (string address or maps URL) — text/share destination |
+
+There is no `vehicle_remote_start` Fleet scope (that is the legacy Owner API); `remote_start_drive` is a `vehicle_cmds` command. `navigation_request`/`navigation_gps_request` are UNSIGNED: Tesla processes them server-side, so the proxy forwards them to the Fleet API rather than signing them.
+
+#### Scope gating
+
+Each command maps to a Fleet OAuth scope. The server parses the granted scopes from the owner's Tesla access-token JWT (`scp` claim). If the token demonstrably lacks the required scope, the server returns `403 permission_denied` **without calling Tesla**. If the scopes cannot be parsed, enforcement is deferred to Tesla.
+
+#### Wake + session policy
+
+If the vehicle is asleep/offline the executor issues a wake and retries the command with a bounded budget (default: 3 wake+retry attempts, ~2 s backoff each). If the budget is exhausted it returns the transient `503 vehicle_asleep`, which the SDK retries with backoff. A signing-session counter/anti-replay error triggers one silent re-handshake retry (the proxy owns the session cache); a second counter error surfaces as `502 command_failed`.
+
+#### Rate limiting
+
+Per-vehicle command cooldown (token bucket, default ~1 command / 2 s with a small burst). Breaches return `429 rate_limited` with `Retry-After`.
+
+#### Success response — `200 OK`
+
+```json
+{ "status": "applied", "command": "door_lock", "vin": "***0001" }
+```
+
+The VIN is redacted to the last 4 (P0 rule; the full VIN never leaves the server). Command parameters (e.g. navigation coordinates, P1) are never persisted and never logged.
+
+#### Errors
+
+| HTTP | code | Cause |
+|------|------|-------|
+| 400 | `invalid_request` | Unknown command name, malformed body, or a parameter that failed validation (bad range, wrong type). |
+| 401 | `auth_failed` | Missing/invalid caller bearer token, or the owner's Tesla token is expired and cannot be refreshed. |
+| 403 | `vehicle_not_owned` | Caller is not the vehicle's owner. |
+| 403 | `permission_denied` | The owner's Tesla token lacks the command's scope (preflight), or Tesla rejected for access. |
+| 403 | `key_not_paired` | Virtual key not enrolled on the vehicle (pre-pairing default), or signing transport not configured. |
+| 404 | `not_found` | Unknown `vehicleId`. |
+| 429 | `rate_limited` | Per-vehicle command cooldown breached. |
+| 502 | `command_failed` | Vehicle returned `result:false`, counter error survived re-handshake, or Fleet/proxy failure. |
+| 503 | `vehicle_asleep` | Vehicle did not wake within the retry budget (retry with backoff). |
+
+#### Pre-pairing behavior (MYR-115 not yet done)
+
+Until the owner pairs the virtual key, every **signer-required** command resolves to `403 key_not_paired`. The endpoint is always mounted (never a 404) and nothing crashes when the proxy/key is absent; when `TESLA_PROXY_URL` is unset the server logs a clear "signing disabled" line at startup and returns `key_not_paired`.
+
+---
+
 ## 8. Resource schemas
 
 The canonical v1 `VehicleState` schema is [`schemas/vehicle-state.schema.json`](schemas/vehicle-state.schema.json). The REST snapshot endpoint returns that shape directly via `$ref` in the OpenAPI spec -- it is NOT re-declared.
@@ -1445,6 +1538,7 @@ Same as [`websocket-protocol.md`](websocket-protocol.md) §10 divergence managem
 
 | Date | Change | Author |
 |------|--------|--------|
+| 2026-07-10 | **Mounted the Tesla vehicle-command surface — P11 actuation + P10 dispatch foundation ([MYR-180](https://linear.app/myrobotaxi/issue/MYR-180)).** New §7.9 `POST /api/vehicles/{vehicleId}/command/{name}` (owner-only): a signed Tesla Fleet vehicle-command proxy seeded with the P11 commands (door_lock/unlock, auto_conditioning_start/stop, set_temps, charge_start/stop, set_charge_limit, actuate_trunk, remote_start_drive, honk_horn, flash_lights) and the P10 dispatch commands (navigation_gps_request for lat/long + navigation_request for text/share). §6 catalog gains a row; §7.9 documents the command catalog, scope gating, wake+session policy, per-vehicle cooldown, and pre-pairing behavior. Three new **REST-only** shared-catalog codes — `key_not_paired` (403), `vehicle_asleep` (503, transient), `command_failed` (502) — added to §4.1.1, §4.1.1.a, `wserrors`, the reachability matrix, and the `schemas/ws-messages.schema.json` `ErrorPayload.code` enum (REST-only-on-the-wire); `permission_denied` flips from PLANNED to Implemented (scope gating). **Transport decision:** the server reuses the tesla-http-proxy sidecar it already runs for `fleet_telemetry_config` (`TESLA_PROXY_URL`) rather than embedding the vehicle-command library in-process — the P-256 command key stays ONLY in the proxy config, never in this process (decision record + ops runbook: [`../operations/vehicle-commands.md`](../operations/vehicle-commands.md)). **Merge-safe before pairing (MYR-115):** the route is always mounted, every signer-required command resolves to `key_not_paired` until the owner pairs, and startup never crashes when the proxy/key is absent. Implementation: `internal/commands/` (registry, executor with wake/counter retry, scope parsing, ProxyTransport), `internal/telemetry/vehicle_command_handler.go` (+ token/cooldown), wired in `cmd/telemetry-server/wiring.go`. No stored-data / data-classification change (command params are transit-only, never persisted; VIN redacted, params never logged). | go-engineer |
 | 2026-07-09 | **Mounted the owner-facing ride-request surface — P10 ride-hailing ([MYR-175](https://linear.app/myrobotaxi/issue/MYR-175), stacked on MYR-174).** §7.8 extended with `GET /api/ride-requests/incoming` (owner's open-`requested` feed — on-demand + scheduled variants — same envelope + `(createdAt, id)` cursor as the rider list; literal segment wins over the `{id}` wildcard, regression-tested) and `POST /api/ride-requests/{id}/accept` / `/decline` (owner-only; legal only from `requested`, everything else `409 conflict` per the §7.8 matrix — matrix note updated from planned to implemented). Accept publishes the internal `ride.accepted` **dispatch seam** event (pickup/dropoff places + booked-for passenger contact) that MYR-176 subscribes to for the Tesla `navigation_request` push — internal-only, never broadcast, no Tesla calls in this story. Both decisions unicast `ride_status_changed` to the two parties. **Reschedule confirm/decline deliberately deferred to MYR-192**: the rider-side propose endpoint has no HTTP surface yet, so an owner resolve endpoint would be unreachable; the store's `ResolveReschedule` is in place. §6 catalog + §4.1.1.b emission audit extended (`permission_denied` rider-attempts-decision row, `conflict` owner-decision row). Implementation: `internal/telemetry/ride_request_owner_handler.go`, `mutateStatus` refactor in `ride_request_handler.go`, routes in `cmd/telemetry-server/wiring.go`. No schema changes. | go-engineer |
 | 2026-07-09 | **Mounted the rider-facing ride-request surface — P10 ride-hailing ([MYR-174](https://linear.app/myrobotaxi/issue/MYR-174)).** New §7.8: `POST /api/ride-requests` (create; strict `additionalProperties:false` body, derives `ownerId` + vehicle-access check identical to `/snapshot`, `201` + full `RideRequest`), `GET /api/ride-requests` (rider's own cursor-paginated list — `createdAt DESC, id DESC`, keyset cursor over `(createdAt, id)`; §4.2.2 updated), `GET /api/ride-requests/{id}` (party-only; non-party → `404` to avoid existence leak), `POST /api/ride-requests/{id}/cancel` (rider-only; `requested`/`accepted` → `cancelled`, else `409 conflict`). Added the full lifecycle **transition matrix** (§7.8) including the MYR-175 accept/decline and MYR-176/177 dispatch rows (unimplemented transitions return `409`). New shared-catalog code **`conflict`** (HTTP 409; §4.1.1, §4.1.1.a) — REST-only, added to `wserrors` + the reachability matrix; never emitted over WS. §6 endpoint catalog + §4.1.1.b emission audit extended. **Authorization enforced vs deferred:** v1 requires the caller to own the vehicle (so `ownerId == riderId`); broader shared-viewer requests (rider ≠ owner) are deferred to the app-side sharing tiers and light up when `GetUserVehicles` gains viewer-merge (PLANNED MYR-91) with no handler change. Reactive pair is the WS `ride_request_created` / `ride_status_changed` summary frames (websocket-protocol.md §4.7–4.8), per-party unicast. Implementation: `internal/telemetry/ride_request_{types,wire,handler,read_handler}.go`, `internal/store/ride_request_repo_page.go`, `internal/ws/{ride_broadcast.go,hub.go SendToUsers}`, `internal/events/ride_events.go`, wired in `cmd/telemetry-server`. No `ride-request.schema.json` change — the shapes landed in contracts v0.9.0. | go-engineer |
 | 2026-07-02 | **Mounted `GET /api/drives/{driveId}` on the Go server — DV-20 fully RESOLVED ([MYR-130](https://linear.app/myrobotaxi/issue/MYR-130)).** Closes the last unmounted DV-20 endpoint (drive detail, FR-3.4). Implemented in `internal/telemetry/drive_detail_handler.go` + `drive_detail_types.go`, backed by the wide `DriveRepo.GetByID` read (appropriate for a detail endpoint) via a new `driveDetailAdapter` in `cmd/telemetry-server/adapters.go`; wired at `GET /api/drives/{driveId}` in `wiring.go` with the same bearer-auth + ownership (`VehicleRepo.GetByID`) + role-based `DriveDetail` mask flow as the drive-route endpoint. Response is the `DriveDetail` object per §7.3 / §8 — every FR-3.4 field EXCEPT `routePoints` (served by §7.4). Error catalog: 400 `invalid_request` (empty driveId), 401 `auth_failed`, 403 `vehicle_not_owned`, 404 `not_found`, 500 `internal_error`. **Mask/OpenAPI drift fix:** `date` (required in the OpenAPI `DriveDetail` component and present in the §7.3 / fixture bodies) was missing from the §5.2.3 mask allow-list — masking would have stripped it and broken conformance; `driveDetailFields` in `internal/mask/tables.go` and the §5.2.3 table are updated in lockstep to include `date` (P0). Added `Server.ClientHandler()` accessor (`internal/server/server.go`) and a route-surface regression test (`cmd/telemetry-server/wiring_routes_test.go`) that asserts every SDK-contract REST route is mounted (unauthenticated request returns 401/400, never 404). §2.1 DV-20 callout, §6 endpoint-catalog status note, and the §10 DV-20 row flip to RESOLVED. No wire-shape / envelope / OpenAPI changes beyond the additive `date` mask fix — the DriveDetail contract was locked at MYR-12. | go-engineer |

--- a/docs/contracts/schemas/ws-messages.schema.json
+++ b/docs/contracts/schemas/ws-messages.schema.json
@@ -213,7 +213,7 @@
       "properties": {
         "code": {
           "type": "string",
-          "description": "Stable typed error code. Shared enum across the WebSocket and REST transports so the SDK's CoreError is a single union (rest-api.md §4.1.1, §4.1.1.a; ws catalog websocket-protocol.md §6.1.1). Consumer SDKs map these to typed errors per FR-7.1 and MUST NOT string-match on the sibling `message` field. WS emits today: `auth_failed`, `auth_timeout`; the remaining WS values are PLANNED (divergences DV-02 / DV-07 / DV-08 in websocket-protocol.md §10). `not_found` and `invalid_request` are REST-only on the wire (the WS path enforces ownership via silent filtering and has no structured request bodies, rest-api.md §4.1.1.a) but are members of this shared enum by mandate so the SDK union is one enum across transports — they are NOT a WS drift (DV-20 enum slice). `service_unavailable` is intentionally NOT in this enum: it is REST-only and the WS 503 analogue is a close code, not a typed frame (rest-api.md:258); the SDK declares it as a REST-only variant on its side. `rate_limited` has two carriers: (a) HTTP 429 on the WS upgrade (per-IP, pre-auth) and (b) an `error` frame paired with WS close 4003 (per-user, post-auth) — the SDK treats both as the same typed error with the extended backoff in websocket-protocol.md §6.1.1 / §7.1.",
+          "description": "Stable typed error code. Shared enum across the WebSocket and REST transports so the SDK's CoreError is a single union (rest-api.md §4.1.1, §4.1.1.a; ws catalog websocket-protocol.md §6.1.1). Consumer SDKs map these to typed errors per FR-7.1 and MUST NOT string-match on the sibling `message` field. WS emits today: `auth_failed`, `auth_timeout`; the remaining WS values are PLANNED (divergences DV-02 / DV-07 / DV-08 in websocket-protocol.md §10). `not_found` and `invalid_request` are REST-only on the wire (the WS path enforces ownership via silent filtering and has no structured request bodies, rest-api.md §4.1.1.a) but are members of this shared enum by mandate so the SDK union is one enum across transports — they are NOT a WS drift (DV-20 enum slice). `service_unavailable` is intentionally NOT in this enum: it is REST-only and the WS 503 analogue is a close code, not a typed frame (rest-api.md:258); the SDK declares it as a REST-only variant on its side. `rate_limited` has two carriers: (a) HTTP 429 on the WS upgrade (per-IP, pre-auth) and (b) an `error` frame paired with WS close 4003 (per-user, post-auth) — the SDK treats both as the same typed error with the extended backoff in websocket-protocol.md §6.1.1 / §7.1. `key_not_paired`, `vehicle_asleep`, and `command_failed` are REST-only on the wire (MYR-180 vehicle-command surface, rest-api.md §4.1.1 / §7.9): the WS transport is stream-oriented and carries no command requests. They are members of this shared enum so the SDK CoreError union stays one enum across transports.",
           "enum": [
             "auth_failed",
             "auth_timeout",
@@ -223,7 +223,10 @@
             "internal_error",
             "snapshot_required",
             "not_found",
-            "invalid_request"
+            "invalid_request",
+            "key_not_paired",
+            "vehicle_asleep",
+            "command_failed"
           ],
           "x-classification": "P0"
         },

--- a/docs/operations/vehicle-commands.md
+++ b/docs/operations/vehicle-commands.md
@@ -1,0 +1,171 @@
+# Vehicle Commands — Ops Runbook & Decision Record
+
+**Status:** v1 — MYR-180
+**Endpoint:** `POST /api/vehicles/{vehicleId}/command/{name}` (rest-api.md §7.9)
+**Owner:** `go-engineer`
+
+This document is the decision record and operations runbook for the Tesla
+signed vehicle-command proxy: how commands are transported and signed, how
+the command-signing key is managed, and the exact owner steps to pair a
+virtual key so commands start working.
+
+---
+
+## 1. Decision: reuse the tesla-http-proxy sidecar (library NOT embedded)
+
+Modern Tesla Fleet API vehicle commands require **end-to-end command
+signing** with a virtual key the owner enrolls in the vehicle. Tesla ships
+the signing protocol as an open-source Go library
+(`github.com/teslamotors/vehicle-command`) plus a reference **HTTP proxy**
+(`tesla-http-proxy`) that converts plain REST command calls into signed
+protocol messages.
+
+MYR-180 evaluated two integration paths:
+
+| Option | What it means |
+|--------|---------------|
+| **A — embed the library** | Import `vehicle-command` into this Go process; load the P-256 key into server memory; manage signed sessions and domains in-process. |
+| **B — reuse the sidecar** | Forward commands to the `tesla-http-proxy` sidecar this server **already runs** for `fleet_telemetry_config` pushes (`internal/telemetry.FleetAPIClient` → `TESLA_PROXY_URL`). |
+
+**Decision: Option B.** Although the task's default preference was library
+integration ("no extra process"), that rationale does not apply here — the
+proxy process **already exists and is already deployed**. Reusing it is
+strictly better:
+
+1. **No process saved by the library.** The proxy already runs for
+   telemetry-config signing; embedding the library would not remove a
+   process, only add code.
+2. **Key stays in exactly one place.** The P-256 command-signing key
+   already lives ONLY in the proxy's config (`TESLA_KEY_FILE_B64` →
+   `deployments/start.sh`). Embedding the library would put a **second copy
+   of the private key into this Go process's memory** — a strictly worse
+   security posture. This satisfies MYR-180's "key material is config-only,
+   never generated/committed, never in the server process" constraint by
+   construction.
+3. **Signing, session caching, wake, and unsigned-command forwarding are
+   free.** The proxy signs signer-required commands, caches per-vehicle
+   sessions (`TESLA_CACHE_FILE`), re-handshakes on counter errors, and
+   forwards unsigned commands (`navigation_request`) straight to the Fleet
+   API (`pkg/proxy/proxy.go`: `navigation_request → ErrCommandUseRESTAPI →
+   forwardRequest`). Embedding the library would re-implement all of this.
+4. **Lower risk.** The proxy is Tesla's own reference implementation of the
+   exact command REST surface. No large dependency (protobuf/crypto) is
+   pulled into this module.
+
+The command layer keeps a `Transport` seam (`internal/commands/transport.go`)
+so the concrete transport could be swapped for a library-backed one later
+without touching the registry, executor, scope-gating, or HTTP handler.
+
+### Sources
+
+- teslamotors/vehicle-command — https://github.com/teslamotors/vehicle-command (README: library vs `tesla-http-proxy`; `tesla-keygen`; `TESLA_CACHE_FILE` session cache)
+- Fleet API Vehicle Commands — https://developer.tesla.com/docs/fleet-api/endpoints/vehicle-commands
+- Fleet API scopes — https://developer.tesla.com/docs/fleet-api/authentication/overview (`vehicle_cmds`, `vehicle_charging_cmds`; there is **no** `vehicle_remote_start` Fleet scope)
+- `pkg/proxy/command.go` `navigation_request → ErrCommandUseRESTAPI`; `pkg/proxy/proxy.go` forward-on-`ErrCommandUseRESTAPI`
+
+---
+
+## 2. Key management
+
+The command-signing key is the **same domain EC key** already used for
+Tesla partner registration and the `.well-known` public key. There is
+nothing new to generate for MYR-180 if the telemetry integration is already
+set up — the command signing reuses that key inside the proxy.
+
+### 2.1 Generate the keypair (operator, offline — NEVER in prod, NEVER committed)
+
+Tesla requires an EC key on the `prime256v1` (secp256r1 / NIST P-256)
+curve. The repo already provides `scripts/generate-certs.sh`, which emits
+`certs/server.key` (the private key) and `certs/public-key.pem` (the public
+key hosted for pairing). To generate just the command key by hand:
+
+```bash
+# Private key (KEEP SECRET — never commit, never log):
+openssl ecparam -name prime256v1 -genkey -noout -out tesla-command-key.pem
+
+# Public key in the exact PEM form Tesla needs for the .well-known endpoint
+# and virtual-key pairing:
+openssl ec -in tesla-command-key.pem -pubout -out tesla-public-key.pem
+
+# Verify the curve is correct (Tesla rejects anything but prime256v1):
+openssl ec -in tesla-command-key.pem -noout -text 2>&1 | grep 'ASN1 OID'
+# -> ASN1 OID: prime256v1
+```
+
+`generate-if-absent is NOT used` anywhere in the server — the key is
+supplied by config only.
+
+### 2.2 Where each half goes
+
+| Artifact | Where it lives | Config var |
+|----------|----------------|------------|
+| Private key (`tesla-command-key.pem`) | **tesla-http-proxy sidecar only** — base64-encoded into an env var, decoded to a file at boot (`deployments/start.sh`). Never in the Go telemetry process. | `TESLA_KEY_FILE_B64` (or `TESLA_KEY_FILE` path) |
+| Public key (`tesla-public-key.pem`) | Served by the telemetry server at the well-known route (already implemented, `internal/server/server.go`). | `TESLA_PUBLIC_KEY` |
+
+The public key is hosted at the fixed Tesla URL:
+
+```
+https://<domain>/.well-known/appspecific/com.tesla.3p.public-key.pem
+```
+
+The telemetry server serves it verbatim from `TESLA_PUBLIC_KEY`; if that env
+var is empty the route is disabled (logged at startup). See
+[`../tesla-setup.md`](../tesla-setup.md) §2 for the hosting details.
+
+### 2.3 Env vars (all pre-existing; MYR-180 adds none)
+
+| Var | Consumed by | Purpose |
+|-----|-------------|---------|
+| `TESLA_PROXY_URL` | telemetry server (command transport + fleet-config) | tesla-http-proxy base URL. **Empty → command signing disabled** (every signer-required command returns `key_not_paired`, logged at startup). |
+| `AUTH_TESLA_ID` / `AUTH_TESLA_SECRET` | telemetry server | Tesla OAuth client creds; enable owner-token auto-refresh for commands (as for fleet-config). Empty → no refresh. |
+| `TESLA_KEY_FILE_B64` / `TESLA_KEY_FILE` | tesla-http-proxy sidecar | The P-256 command private key. |
+| `TESLA_PUBLIC_KEY` | telemetry server | Public key served at the `.well-known` route. |
+
+The per-vehicle command cooldown and wake/counter retry budgets are code
+constants with sane defaults (`internal/commands`, `internal/telemetry`);
+no env vars gate them in v1.
+
+---
+
+## 3. Owner virtual-key pairing runbook (MYR-115)
+
+Until the vehicle owner pairs the application's virtual key, **every
+signer-required command returns `403 key_not_paired`**. This is expected
+and safe — the endpoint is live and returns typed errors, nothing crashes.
+
+Exact owner steps, once the app is registered and the public key is hosted:
+
+1. Ensure the vehicle is **awake and nearby** (pairing needs the car and the
+   owner's key card).
+2. Open the pairing link on the owner's phone (Tesla app installed):
+
+   ```
+   https://tesla.com/_ak/<domain>          # e.g. https://tesla.com/_ak/myrobotaxi.app
+   ```
+
+3. In the Tesla app: select the vehicle(s) to pair, approve the key request.
+4. **Tap the key card** on the center console when prompted (required for
+   security).
+5. Confirm pairing succeeded — after a short delay, re-issue any
+   signer-required command (e.g. `door_lock`); it should return
+   `200 {"status":"applied"}` instead of `key_not_paired`.
+
+Notes:
+- Max 5 third-party apps per vehicle.
+- The owner can revoke access anytime in the Tesla app (subsequent commands
+  revert to `key_not_paired`).
+- Unsigned commands (`navigation_request` / `navigation_gps_request`) do NOT
+  require the virtual key, but still need `TESLA_PROXY_URL` configured and a
+  valid owner OAuth token with `vehicle_cmds` scope.
+
+---
+
+## 4. Pre-pairing / degraded behavior summary
+
+| Condition | Behavior |
+|-----------|----------|
+| `TESLA_PROXY_URL` unset | Startup logs "signing disabled"; endpoint mounted; signer-required commands → `403 key_not_paired`; navigation → `502 command_failed`. Server does not crash. |
+| Proxy set, key not paired (MYR-115 pending) | Signer-required commands → `403 key_not_paired` (proxy/Tesla reject; mapped by the executor). |
+| Owner token lacks the command scope | `403 permission_denied` — returned **without** calling Tesla (scope parsed from the token's `scp` claim). |
+| Vehicle asleep | Executor wakes + retries (bounded); on exhaustion → `503 vehicle_asleep` (SDK retries with backoff). |
+| Vehicle rejects (`result:false`) or counter error survives re-handshake | `502 command_failed`. |

--- a/docs/tesla-setup.md
+++ b/docs/tesla-setup.md
@@ -290,3 +290,8 @@ curl -sI https://myrobotaxi.app/.well-known/appspecific/com.tesla.3p.public-key.
 For details on how telemetry data flows through the server, see:
 - [Architecture Overview](./architecture.md)
 - [Data Flow Documentation](./data-flow.md)
+
+For sending **vehicle commands** (lock, climate, charge, trunk, navigation)
+— the signed vehicle-command proxy, key management, and the virtual-key
+pairing runbook — see:
+- [Vehicle Commands Ops Runbook](./operations/vehicle-commands.md)

--- a/internal/commands/doc.go
+++ b/internal/commands/doc.go
@@ -1,0 +1,39 @@
+// Package commands implements the Tesla Fleet signed vehicle-command
+// proxy layer (MYR-180): the actuation foundation for P11 (lock, climate,
+// media, charge, trunk) and P10 dispatch (navigation_request, MYR-176).
+//
+// # Architecture: reuse the tesla-http-proxy sidecar
+//
+// Modern Tesla Fleet API vehicle commands require end-to-end command
+// signing with a virtual key enrolled on the vehicle by the owner. Tesla
+// ships that signing protocol as an open-source Go library
+// (github.com/teslamotors/vehicle-command) plus a reference HTTP proxy
+// (tesla-http-proxy) that converts plain REST command calls into signed
+// protocol messages.
+//
+// This server does NOT embed the library in-process. It reuses the
+// tesla-http-proxy sidecar it already runs for fleet_telemetry_config
+// pushes (internal/telemetry.FleetAPIClient → TESLA_PROXY_URL). See the
+// decision record in docs/operations/vehicle-commands.md §1. In short:
+// the proxy process already exists, the P-256 command-signing key already
+// lives ONLY in the proxy's config (TESLA_KEY_FILE_B64), and the proxy
+// already implements signing, per-vehicle session caching, wake handling,
+// and uniform forwarding of unsigned commands (navigation_request). The
+// executor here talks to that proxy over the same transport seam.
+//
+// # Seams
+//
+//   - Registry maps a command name → {scope, signer-required, param
+//     builder}. The public API command name IS the Tesla command name.
+//   - Transport is the signed-session seam. ProxyTransport is the concrete
+//     tesla-http-proxy client; tests substitute a fake, so no test ever
+//     makes a live Tesla call.
+//   - Executor gates on scope (no Tesla call when the token lacks the
+//     scope), degrades to key_not_paired when signing is unconfigured, and
+//     runs the bounded wake+retry and session-refresh-on-counter-error
+//     policies.
+//
+// The layer is complete and testable WITHOUT a paired virtual key: until
+// pairing (MYR-115) every signer-required command resolves to the typed
+// key_not_paired error, and nothing panics when the key/proxy is absent.
+package commands

--- a/internal/commands/errors.go
+++ b/internal/commands/errors.go
@@ -1,0 +1,88 @@
+package commands
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/myrobotaxi/telemetry/internal/wserrors"
+)
+
+// CommandError is the typed failure returned by Executor.Execute. It
+// carries the HTTP status and the shared wserrors.ErrorCode so the REST
+// handler can write the rest-api.md §4.1 error envelope without a
+// status↔code lookup table. Message is developer-facing and MUST NOT
+// contain any P1 value (no coordinates, addresses, tokens, or raw VINs) —
+// the executor constructs these from opaque, non-sensitive strings only.
+type CommandError struct {
+	Code      wserrors.ErrorCode
+	Status    int
+	Message   string
+	Retryable bool
+}
+
+func (e *CommandError) Error() string {
+	return fmt.Sprintf("command %s (%d): %s", e.Code, e.Status, e.Message)
+}
+
+func errUnknownCommand(name string) *CommandError {
+	return &CommandError{
+		Code:    wserrors.ErrCodeInvalidRequest,
+		Status:  http.StatusBadRequest,
+		Message: fmt.Sprintf("unknown command %q", name),
+	}
+}
+
+func errInvalidParams(msg string) *CommandError {
+	return &CommandError{
+		Code:    wserrors.ErrCodeInvalidRequest,
+		Status:  http.StatusBadRequest,
+		Message: msg,
+	}
+}
+
+func errPermissionDenied(msg string) *CommandError {
+	return &CommandError{
+		Code:    wserrors.ErrCodePermissionDenied,
+		Status:  http.StatusForbidden,
+		Message: msg,
+	}
+}
+
+// errKeyNotPaired is the pre-pairing default for signer-required commands:
+// the virtual key is not enrolled on the vehicle (MYR-115), or the
+// command-signing transport is not configured. Terminal — the owner must
+// pair before retrying.
+func errKeyNotPaired(msg string) *CommandError {
+	return &CommandError{
+		Code:    wserrors.ErrCodeKeyNotPaired,
+		Status:  http.StatusForbidden,
+		Message: msg,
+	}
+}
+
+// errVehicleAsleep is returned only after the bounded wake+retry budget is
+// exhausted. Retryable — the SDK backs off and tries again later.
+func errVehicleAsleep() *CommandError {
+	return &CommandError{
+		Code:      wserrors.ErrCodeVehicleAsleep,
+		Status:    http.StatusServiceUnavailable,
+		Message:   "vehicle asleep or offline after wake retries",
+		Retryable: true,
+	}
+}
+
+func errCommandFailed(msg string) *CommandError {
+	return &CommandError{
+		Code:    wserrors.ErrCodeCommandFailed,
+		Status:  http.StatusBadGateway,
+		Message: msg,
+	}
+}
+
+func errInternal(msg string) *CommandError {
+	return &CommandError{
+		Code:    wserrors.ErrCodeInternalError,
+		Status:  http.StatusInternalServerError,
+		Message: msg,
+	}
+}

--- a/internal/commands/executor.go
+++ b/internal/commands/executor.go
@@ -1,0 +1,211 @@
+package commands
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"time"
+)
+
+// Default retry policy. Tesla guidance: a command against an asleep vehicle
+// returns "vehicle unavailable"; the client wakes the vehicle and retries
+// while it boots (typically a few seconds, occasionally longer). We wake +
+// retry a bounded number of times with a fixed backoff, then surface the
+// transient vehicle_asleep code so the SDK backs off. A signing session
+// counter/anti-replay error means the cached session is stale; the proxy
+// re-handshakes on the next call, so one retry suffices.
+const (
+	defaultWakeMaxAttempts = 3
+	defaultWakeBackoff     = 2 * time.Second
+	defaultCounterRetryMax = 1
+)
+
+// Config tunes the Executor retry policy.
+type Config struct {
+	WakeMaxAttempts int
+	WakeBackoff     time.Duration
+	CounterRetryMax int
+}
+
+func (c Config) withDefaults() Config {
+	if c.WakeMaxAttempts <= 0 {
+		c.WakeMaxAttempts = defaultWakeMaxAttempts
+	}
+	if c.WakeBackoff <= 0 {
+		c.WakeBackoff = defaultWakeBackoff
+	}
+	if c.CounterRetryMax < 0 {
+		c.CounterRetryMax = defaultCounterRetryMax
+	}
+	return c
+}
+
+// Executor validates, scope-gates, and dispatches vehicle commands through
+// a Transport, applying the wake+retry and session-refresh policies.
+type Executor struct {
+	registry  *Registry
+	transport Transport
+	cfg       Config
+	logger    *slog.Logger
+}
+
+// Option configures an Executor.
+type Option func(*Executor)
+
+// WithConfig overrides the default retry policy.
+func WithConfig(cfg Config) Option { return func(e *Executor) { e.cfg = cfg.withDefaults() } }
+
+// WithRegistry overrides the default command registry (tests).
+func WithRegistry(r *Registry) Option { return func(e *Executor) { e.registry = r } }
+
+// NewExecutor builds an Executor over the given transport. The logger may
+// be nil (a discard logger is substituted).
+func NewExecutor(transport Transport, logger *slog.Logger, opts ...Option) *Executor {
+	if logger == nil {
+		logger = slog.New(slog.NewTextHandler(discard{}, nil))
+	}
+	e := &Executor{
+		registry:  NewRegistry(),
+		transport: transport,
+		cfg:       Config{}.withDefaults(),
+		logger:    logger,
+	}
+	for _, opt := range opts {
+		opt(e)
+	}
+	return e
+}
+
+// Request is a single command invocation. AccessToken is the vehicle
+// owner's Tesla OAuth access token; Scopes is its parsed scope set (may be
+// not-Known, in which case scope enforcement is left to Tesla).
+type Request struct {
+	VIN         string
+	Command     string
+	Params      map[string]any
+	AccessToken string
+	Scopes      ScopeSet
+}
+
+// Result is the outcome of a successful command.
+type Result struct {
+	Command string
+	Applied bool
+}
+
+// Registry exposes the executor's command registry (for the handler to
+// validate names and for docs generation).
+func (e *Executor) Registry() *Registry { return e.registry }
+
+// Execute runs one command end to end. On failure it returns a
+// *CommandError carrying the typed code + HTTP status.
+func (e *Executor) Execute(ctx context.Context, req Request) (Result, error) {
+	cmd, ok := e.registry.Lookup(req.Command)
+	if !ok {
+		return Result{}, errUnknownCommand(req.Command)
+	}
+
+	// Scope gating: if we know the granted scopes and the required one is
+	// absent, deny WITHOUT dialing Tesla (rest-api.md §7.9). When scopes are
+	// unknown we defer to Tesla's own enforcement.
+	if req.Scopes.Known() && !req.Scopes.Has(cmd.Scope) {
+		return Result{}, errPermissionDenied("Tesla token lacks the " + string(cmd.Scope) + " scope for this command")
+	}
+
+	// Degrade gracefully when the signing transport is not configured.
+	if !e.transport.Enabled() {
+		if cmd.SignerRequired {
+			return Result{}, errKeyNotPaired("vehicle command signing is not configured (no proxy)")
+		}
+		return Result{}, errCommandFailed("vehicle command transport is not configured")
+	}
+
+	var body []byte
+	if cmd.BuildBody != nil {
+		b, err := cmd.BuildBody(req.Params)
+		if err != nil {
+			return Result{}, err // already a *CommandError (invalid_request)
+		}
+		body = b
+	}
+
+	return e.invoke(ctx, cmd, req, body)
+}
+
+// invoke runs the transport call under the wake+retry and counter-refresh
+// policies. The loop always makes progress: OK and every terminal outcome
+// return, and the transient outcomes (asleep, counter) each bound their own
+// retry counter, so it cannot spin.
+func (e *Executor) invoke(ctx context.Context, cmd Command, req Request, body []byte) (Result, error) {
+	tReq := TransportRequest{VIN: req.VIN, Command: cmd.Name, Token: req.AccessToken, Body: body}
+
+	wakeAttempts := 0
+	counterRetries := 0
+	for {
+		res, err := e.transport.Command(ctx, tReq)
+		if err != nil {
+			if ctx.Err() != nil {
+				return Result{}, errInternal("command canceled")
+			}
+			return Result{}, errCommandFailed("vehicle command transport error")
+		}
+
+		switch res.Outcome {
+		case OutcomeOK:
+			return Result{Command: cmd.Name, Applied: true}, nil
+
+		case OutcomeAsleep:
+			if wakeAttempts >= e.cfg.WakeMaxAttempts {
+				return Result{}, errVehicleAsleep()
+			}
+			wakeAttempts++
+			if wErr := e.transport.Wake(ctx, req.VIN, req.AccessToken); wErr != nil {
+				e.logger.Warn("wake request failed; will retry command anyway",
+					slog.Int("attempt", wakeAttempts),
+					slog.String("command", cmd.Name),
+				)
+			}
+			if sErr := sleepCtx(ctx, e.cfg.WakeBackoff); sErr != nil {
+				return Result{}, errInternal("command canceled during wake backoff")
+			}
+
+		case OutcomeCounterError:
+			if counterRetries >= e.cfg.CounterRetryMax {
+				return Result{}, errCommandFailed("signing session error after re-handshake")
+			}
+			counterRetries++
+			e.logger.Info("retrying command after session counter error",
+				slog.String("command", cmd.Name),
+			)
+
+		case OutcomeNotPaired:
+			return Result{}, errKeyNotPaired("virtual key not paired with vehicle")
+
+		case OutcomePermissionDenied:
+			return Result{}, errPermissionDenied("Tesla rejected command: insufficient access")
+
+		case OutcomeInvalidRequest:
+			return Result{}, errInvalidParams("Tesla rejected command parameters")
+
+		default: // OutcomeFailed
+			return Result{}, errCommandFailed("vehicle command failed")
+		}
+	}
+}
+
+// sleepCtx sleeps for d or returns early if ctx is canceled.
+func sleepCtx(ctx context.Context, d time.Duration) error {
+	timer := time.NewTimer(d)
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+		return fmt.Errorf("wake backoff: %w", ctx.Err())
+	case <-timer.C:
+		return nil
+	}
+}
+
+// discard is an io.Writer that drops everything, for the nil-logger default.
+type discard struct{}
+
+func (discard) Write(p []byte) (int, error) { return len(p), nil }

--- a/internal/commands/executor_test.go
+++ b/internal/commands/executor_test.go
@@ -1,0 +1,271 @@
+package commands
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/myrobotaxi/telemetry/internal/wserrors"
+)
+
+// fakeTransport is a scripted Transport: it returns the next queued result
+// on each Command call and records how it was used. No live Tesla calls.
+type fakeTransport struct {
+	enabled bool
+	results []TransportResult
+	cmdErr  error
+	calls   []TransportRequest
+	wakes   int
+	wakeErr error
+}
+
+func (f *fakeTransport) Enabled() bool { return f.enabled }
+
+func (f *fakeTransport) Command(_ context.Context, req TransportRequest) (TransportResult, error) {
+	f.calls = append(f.calls, req)
+	if f.cmdErr != nil {
+		return TransportResult{}, f.cmdErr
+	}
+	idx := len(f.calls) - 1
+	if idx >= len(f.results) {
+		idx = len(f.results) - 1 // repeat the last scripted result
+	}
+	return f.results[idx], nil
+}
+
+func (f *fakeTransport) Wake(_ context.Context, _, _ string) error {
+	f.wakes++
+	return f.wakeErr
+}
+
+// grantAll is a scope set that grants both command scopes.
+func grantAll() ScopeSet {
+	return ScopeSet{known: true, set: map[Scope]struct{}{
+		ScopeVehicleCmds:  {},
+		ScopeChargingCmds: {},
+	}}
+}
+
+// fastConfig shrinks the wake backoff so tests don't sleep for seconds.
+func fastConfig() Config {
+	return Config{WakeMaxAttempts: 3, WakeBackoff: time.Millisecond, CounterRetryMax: 1}
+}
+
+func asCommandError(err error, target **CommandError) bool {
+	return errors.As(err, target)
+}
+
+func wantCode(t *testing.T, err error, code wserrors.ErrorCode) {
+	t.Helper()
+	var cErr *CommandError
+	if !asCommandError(err, &cErr) {
+		t.Fatalf("error is not *CommandError: %v", err)
+	}
+	if cErr.Code != code {
+		t.Fatalf("code = %q want %q (msg: %s)", cErr.Code, code, cErr.Message)
+	}
+}
+
+func newExec(tr Transport) *Executor {
+	return NewExecutor(tr, nil, WithConfig(fastConfig()))
+}
+
+func TestExecute_UnknownCommand(t *testing.T) {
+	e := newExec(&fakeTransport{enabled: true})
+	_, err := e.Execute(context.Background(), Request{VIN: "V", Command: "does_not_exist", Scopes: grantAll()})
+	wantCode(t, err, wserrors.ErrCodeInvalidRequest)
+}
+
+func TestExecute_ScopeGatingDeniesWithoutTransport(t *testing.T) {
+	tr := &fakeTransport{enabled: true, results: []TransportResult{{Outcome: OutcomeOK}}}
+	e := newExec(tr)
+	// Token known to grant only charging scope; door_lock needs vehicle_cmds.
+	scopes := ScopeSet{known: true, set: map[Scope]struct{}{ScopeChargingCmds: {}}}
+	_, err := e.Execute(context.Background(), Request{VIN: "V", Command: "door_lock", Scopes: scopes})
+	wantCode(t, err, wserrors.ErrCodePermissionDenied)
+	if len(tr.calls) != 0 {
+		t.Fatalf("scope denial must not call the transport (calls=%d)", len(tr.calls))
+	}
+}
+
+func TestExecute_UnknownScopesDefersToTesla(t *testing.T) {
+	tr := &fakeTransport{enabled: true, results: []TransportResult{{Outcome: OutcomeOK}}}
+	e := newExec(tr)
+	// Scopes not Known -> executor proceeds and lets Tesla enforce.
+	res, err := e.Execute(context.Background(), Request{VIN: "V", Command: "door_lock", Scopes: ScopeSet{}})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !res.Applied || len(tr.calls) != 1 {
+		t.Fatalf("expected one transport call and applied result")
+	}
+}
+
+func TestExecute_KeyNotPairedWhenTransportDisabled(t *testing.T) {
+	tr := &fakeTransport{enabled: false}
+	e := newExec(tr)
+	_, err := e.Execute(context.Background(), Request{VIN: "V", Command: "door_lock", Scopes: grantAll()})
+	wantCode(t, err, wserrors.ErrCodeKeyNotPaired)
+	if len(tr.calls) != 0 {
+		t.Fatalf("disabled transport must not be dialed")
+	}
+}
+
+func TestExecute_NavigationFailsWhenTransportDisabled(t *testing.T) {
+	// navigation_request is unsigned, but without a proxy it still cannot
+	// reach the vehicle -> command_failed (not key_not_paired).
+	tr := &fakeTransport{enabled: false}
+	e := newExec(tr)
+	_, err := e.Execute(context.Background(), Request{
+		VIN: "V", Command: "navigation_request",
+		Params: map[string]any{"value": "somewhere"}, Scopes: grantAll(),
+	})
+	wantCode(t, err, wserrors.ErrCodeCommandFailed)
+}
+
+func TestExecute_HappyPathForwardsTeslaCommand(t *testing.T) {
+	tr := &fakeTransport{enabled: true, results: []TransportResult{{Outcome: OutcomeOK}}}
+	e := newExec(tr)
+	res, err := e.Execute(context.Background(), Request{
+		VIN: "5YJ", Command: "set_charge_limit",
+		Params: map[string]any{"percent": 80.0}, AccessToken: "tok", Scopes: grantAll(),
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !res.Applied || res.Command != "set_charge_limit" {
+		t.Fatalf("result = %+v", res)
+	}
+	if len(tr.calls) != 1 {
+		t.Fatalf("expected one call, got %d", len(tr.calls))
+	}
+	call := tr.calls[0]
+	if call.Command != "set_charge_limit" || call.VIN != "5YJ" || call.Token != "tok" {
+		t.Fatalf("transport request = %+v", call)
+	}
+	if string(call.Body) != `{"percent":80}` {
+		t.Fatalf("body = %s", call.Body)
+	}
+}
+
+func TestExecute_WakeRetryThenSuccess(t *testing.T) {
+	tr := &fakeTransport{enabled: true, results: []TransportResult{
+		{Outcome: OutcomeAsleep},
+		{Outcome: OutcomeAsleep},
+		{Outcome: OutcomeOK},
+	}}
+	e := newExec(tr)
+	res, err := e.Execute(context.Background(), Request{VIN: "V", Command: "door_lock", Scopes: grantAll()})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !res.Applied {
+		t.Fatalf("expected applied after wake retries")
+	}
+	if tr.wakes != 2 {
+		t.Fatalf("expected 2 wake calls, got %d", tr.wakes)
+	}
+	if len(tr.calls) != 3 {
+		t.Fatalf("expected 3 command attempts, got %d", len(tr.calls))
+	}
+}
+
+func TestExecute_WakeRetryExhausted(t *testing.T) {
+	tr := &fakeTransport{enabled: true, results: []TransportResult{{Outcome: OutcomeAsleep}}}
+	e := newExec(tr)
+	_, err := e.Execute(context.Background(), Request{VIN: "V", Command: "door_lock", Scopes: grantAll()})
+	wantCode(t, err, wserrors.ErrCodeVehicleAsleep)
+	// Initial attempt + WakeMaxAttempts retries.
+	if len(tr.calls) != fastConfig().WakeMaxAttempts+1 {
+		t.Fatalf("attempts = %d want %d", len(tr.calls), fastConfig().WakeMaxAttempts+1)
+	}
+	if tr.wakes != fastConfig().WakeMaxAttempts {
+		t.Fatalf("wakes = %d want %d", tr.wakes, fastConfig().WakeMaxAttempts)
+	}
+}
+
+func TestExecute_WakeRetrySurvivesWakeError(t *testing.T) {
+	tr := &fakeTransport{
+		enabled: true,
+		wakeErr: errors.New("wake failed"),
+		results: []TransportResult{{Outcome: OutcomeAsleep}, {Outcome: OutcomeOK}},
+	}
+	e := newExec(tr)
+	res, err := e.Execute(context.Background(), Request{VIN: "V", Command: "door_lock", Scopes: grantAll()})
+	if err != nil {
+		t.Fatalf("a wake error must not abort the retry loop: %v", err)
+	}
+	if !res.Applied {
+		t.Fatalf("expected applied")
+	}
+}
+
+func TestExecute_SessionRefreshOnCounterError(t *testing.T) {
+	tr := &fakeTransport{enabled: true, results: []TransportResult{
+		{Outcome: OutcomeCounterError},
+		{Outcome: OutcomeOK},
+	}}
+	e := newExec(tr)
+	res, err := e.Execute(context.Background(), Request{VIN: "V", Command: "door_lock", Scopes: grantAll()})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !res.Applied {
+		t.Fatalf("expected applied after one counter retry")
+	}
+	if len(tr.calls) != 2 {
+		t.Fatalf("expected 2 attempts, got %d", len(tr.calls))
+	}
+}
+
+func TestExecute_CounterErrorExhausted(t *testing.T) {
+	tr := &fakeTransport{enabled: true, results: []TransportResult{{Outcome: OutcomeCounterError}}}
+	e := newExec(tr)
+	_, err := e.Execute(context.Background(), Request{VIN: "V", Command: "door_lock", Scopes: grantAll()})
+	wantCode(t, err, wserrors.ErrCodeCommandFailed)
+	if len(tr.calls) != fastConfig().CounterRetryMax+1 {
+		t.Fatalf("attempts = %d want %d", len(tr.calls), fastConfig().CounterRetryMax+1)
+	}
+}
+
+func TestExecute_OutcomeMapping(t *testing.T) {
+	tests := []struct {
+		name    string
+		outcome Outcome
+		code    wserrors.ErrorCode
+	}{
+		{"not paired", OutcomeNotPaired, wserrors.ErrCodeKeyNotPaired},
+		{"permission denied", OutcomePermissionDenied, wserrors.ErrCodePermissionDenied},
+		{"invalid request", OutcomeInvalidRequest, wserrors.ErrCodeInvalidRequest},
+		{"failed", OutcomeFailed, wserrors.ErrCodeCommandFailed},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tr := &fakeTransport{enabled: true, results: []TransportResult{{Outcome: tt.outcome}}}
+			e := newExec(tr)
+			_, err := e.Execute(context.Background(), Request{VIN: "V", Command: "door_lock", Scopes: grantAll()})
+			wantCode(t, err, tt.code)
+		})
+	}
+}
+
+func TestExecute_InvalidParamsBeforeTransport(t *testing.T) {
+	tr := &fakeTransport{enabled: true, results: []TransportResult{{Outcome: OutcomeOK}}}
+	e := newExec(tr)
+	_, err := e.Execute(context.Background(), Request{
+		VIN: "V", Command: "set_charge_limit",
+		Params: map[string]any{"percent": 10.0}, Scopes: grantAll(),
+	})
+	wantCode(t, err, wserrors.ErrCodeInvalidRequest)
+	if len(tr.calls) != 0 {
+		t.Fatalf("invalid params must not reach the transport")
+	}
+}
+
+func TestExecute_TransportErrorIsCommandFailed(t *testing.T) {
+	tr := &fakeTransport{enabled: true, cmdErr: errors.New("boom")}
+	e := newExec(tr)
+	_, err := e.Execute(context.Background(), Request{VIN: "V", Command: "door_lock", Scopes: grantAll()})
+	wantCode(t, err, wserrors.ErrCodeCommandFailed)
+}

--- a/internal/commands/params.go
+++ b/internal/commands/params.go
@@ -1,0 +1,48 @@
+package commands
+
+import "fmt"
+
+// Param helpers extract and validate typed values from the decoded JSON
+// request body (map[string]any, so numbers arrive as float64). Each
+// returns a typed *CommandError (invalid_request) on a type or presence
+// violation, so BuildBody functions stay small and uniform.
+
+func paramFloat(p map[string]any, key string, required bool) (value float64, present bool, err error) {
+	v, ok := p[key]
+	if !ok {
+		if required {
+			return 0, false, errInvalidParams(fmt.Sprintf("missing required parameter %q", key))
+		}
+		return 0, false, nil
+	}
+	f, ok := v.(float64)
+	if !ok {
+		return 0, false, errInvalidParams(fmt.Sprintf("parameter %q must be a number", key))
+	}
+	return f, true, nil
+}
+
+func paramInt(p map[string]any, key string, required bool) (value int, present bool, err error) {
+	f, present, err := paramFloat(p, key, required)
+	if err != nil || !present {
+		return 0, present, err
+	}
+	if f != float64(int(f)) {
+		return 0, false, errInvalidParams(fmt.Sprintf("parameter %q must be an integer", key))
+	}
+	return int(f), true, nil
+}
+
+// paramString requires the key: every current caller treats a string
+// parameter as mandatory, so it returns just (value, error).
+func paramString(p map[string]any, key string) (string, error) {
+	v, ok := p[key]
+	if !ok {
+		return "", errInvalidParams(fmt.Sprintf("missing required parameter %q", key))
+	}
+	s, ok := v.(string)
+	if !ok {
+		return "", errInvalidParams(fmt.Sprintf("parameter %q must be a string", key))
+	}
+	return s, nil
+}

--- a/internal/commands/proxy_transport.go
+++ b/internal/commands/proxy_transport.go
@@ -1,0 +1,163 @@
+package commands
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+)
+
+const (
+	proxyRequestTimeout = 30 * time.Second
+	maxProxyResponse    = 1 << 16 // 64 KiB
+)
+
+// ProxyTransport is the concrete Transport: it forwards vehicle commands to
+// the tesla-http-proxy sidecar (the same TESLA_PROXY_URL the fleet-config
+// push already uses). The proxy signs signer-required commands with the
+// virtual key and forwards unsigned commands (navigation_request) straight
+// to the Fleet API. It also owns per-vehicle session caching, so there is
+// no session state to manage in this process.
+type ProxyTransport struct {
+	baseURL string
+	client  *http.Client
+	logger  *slog.Logger
+}
+
+// NewProxyTransport builds a transport pointed at the proxy base URL. When
+// baseURL is empty the transport reports Enabled()==false and the Executor
+// degrades to key_not_paired. When client is nil a default client with a
+// 30s timeout is used (the caller passes proxyHTTPClient's loopback-aware
+// client in production).
+func NewProxyTransport(baseURL string, client *http.Client, logger *slog.Logger) *ProxyTransport {
+	if client == nil {
+		client = &http.Client{Timeout: proxyRequestTimeout}
+	}
+	if logger == nil {
+		logger = slog.New(slog.NewTextHandler(discard{}, nil))
+	}
+	return &ProxyTransport{baseURL: strings.TrimRight(baseURL, "/"), client: client, logger: logger}
+}
+
+// Enabled reports whether a proxy URL is configured.
+func (t *ProxyTransport) Enabled() bool { return t.baseURL != "" }
+
+// Command POSTs to {proxy}/api/1/vehicles/{vin}/command/{command}.
+func (t *ProxyTransport) Command(ctx context.Context, req TransportRequest) (TransportResult, error) {
+	endpoint := fmt.Sprintf("%s/api/1/vehicles/%s/command/%s",
+		t.baseURL, url.PathEscape(req.VIN), url.PathEscape(req.Command))
+
+	status, respBody, err := t.post(ctx, endpoint, req.Token, req.Body)
+	if err != nil {
+		return TransportResult{}, err
+	}
+	return classifyResponse(status, respBody), nil
+}
+
+// Wake POSTs to {proxy}/api/1/vehicles/{vin}/wake_up. A non-2xx wake is
+// reported as an error but is non-fatal to the Executor's retry loop.
+func (t *ProxyTransport) Wake(ctx context.Context, vin, token string) error {
+	endpoint := fmt.Sprintf("%s/api/1/vehicles/%s/wake_up", t.baseURL, url.PathEscape(vin))
+	status, _, err := t.post(ctx, endpoint, token, nil)
+	if err != nil {
+		return err
+	}
+	if status < 200 || status >= 300 {
+		return fmt.Errorf("wake_up returned status %d", status)
+	}
+	return nil
+}
+
+// post issues the HTTP request and returns (status, body, transport-error).
+// The request target host is always the fixed, operator-configured proxy
+// base — never attacker-controlled — and only validated, PathEscape'd path
+// segments are interpolated.
+func (t *ProxyTransport) post(ctx context.Context, endpoint, token string, body []byte) (status int, respBody []byte, err error) {
+	var reader io.Reader
+	if body != nil {
+		reader = bytes.NewReader(body)
+	}
+	// #nosec G107 -- endpoint host is the fixed proxy base from config, not
+	// user input; path segments are PathEscape'd validated values.
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, reader) //nolint:gosec // host is fixed config
+	if err != nil {
+		return 0, nil, fmt.Errorf("create request: %w", err)
+	}
+	httpReq.Header.Set("Authorization", "Bearer "+token)
+	if body != nil {
+		httpReq.Header.Set("Content-Type", "application/json")
+	}
+
+	resp, err := t.client.Do(httpReq) //nolint:gosec // host is fixed config
+	if err != nil {
+		return 0, nil, fmt.Errorf("proxy request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	respBody, err = io.ReadAll(io.LimitReader(resp.Body, maxProxyResponse))
+	if err != nil {
+		return 0, nil, fmt.Errorf("read proxy response: %w", err)
+	}
+	return resp.StatusCode, respBody, nil
+}
+
+// classifyResponse maps a proxy/Fleet HTTP response to a TransportResult.
+// Tesla's command envelope is {"response":{"result":bool,"reason":string}}
+// on 200; error paths carry an {"error":...} string. The mapping is
+// keyword-based because the proxy relays Tesla's own (unstable) prose and
+// there is no stable machine code for these conditions.
+func classifyResponse(status int, body []byte) TransportResult {
+	var env struct {
+		Response struct {
+			Result bool   `json:"result"`
+			Reason string `json:"reason"`
+		} `json:"response"`
+		Error string `json:"error"`
+	}
+	_ = json.Unmarshal(body, &env)
+
+	text := strings.ToLower(string(body))
+
+	// 200 with an explicit positive result is the only success.
+	if status >= 200 && status < 300 && env.Response.Result {
+		return TransportResult{Outcome: OutcomeOK}
+	}
+
+	switch {
+	case containsAny(text, "not paired", "not been paired", "unpaired", "add your key",
+		"missing key", "keys_not_configured", "no key", "could not find", "unregistered"):
+		return TransportResult{Outcome: OutcomeNotPaired, Reason: env.Response.Reason}
+	case status == http.StatusRequestTimeout,
+		containsAny(text, "asleep", "unavailable", "not available", "offline", "waking", "vehicle is not awake"):
+		return TransportResult{Outcome: OutcomeAsleep, Reason: env.Response.Reason}
+	case containsAny(text, "counter", "anti-replay", "invalid signature", "session"):
+		return TransportResult{Outcome: OutcomeCounterError, Reason: env.Response.Reason}
+	case status == http.StatusForbidden, status == http.StatusUnauthorized,
+		containsAny(text, "scope", "not authorized", "forbidden"):
+		return TransportResult{Outcome: OutcomePermissionDenied, Reason: env.Response.Reason}
+	case status == http.StatusBadRequest,
+		containsAny(text, "invalid_command", "invalid parameter", "invalid request"):
+		return TransportResult{Outcome: OutcomeInvalidRequest, Reason: env.Response.Reason}
+	default:
+		reason := env.Response.Reason
+		if reason == "" {
+			reason = env.Error
+		}
+		return TransportResult{Outcome: OutcomeFailed, Reason: reason}
+	}
+}
+
+func containsAny(s string, subs ...string) bool {
+	for _, sub := range subs {
+		if strings.Contains(s, sub) {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/commands/proxy_transport_test.go
+++ b/internal/commands/proxy_transport_test.go
@@ -1,0 +1,102 @@
+package commands
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestProxyTransport_Enabled(t *testing.T) {
+	if NewProxyTransport("", nil, nil).Enabled() {
+		t.Fatalf("empty base URL must be disabled")
+	}
+	if !NewProxyTransport("https://proxy.local", nil, nil).Enabled() {
+		t.Fatalf("configured base URL must be enabled")
+	}
+}
+
+func TestProxyTransport_CommandResponseMapping(t *testing.T) {
+	tests := []struct {
+		name   string
+		status int
+		body   string
+		want   Outcome
+	}{
+		{"result true", 200, `{"response":{"result":true}}`, OutcomeOK},
+		{"result false reason", 200, `{"response":{"result":false,"reason":"already_locked"}}`, OutcomeFailed},
+		{"asleep 408", http.StatusRequestTimeout, `{"error":"vehicle unavailable"}`, OutcomeAsleep},
+		{"asleep reason", 200, `{"response":{"result":false,"reason":"vehicle is not awake"}}`, OutcomeAsleep},
+		{"not paired", 403, `{"error":"your key has not been paired with this vehicle"}`, OutcomeNotPaired},
+		{"permission denied", 403, `{"error":"missing scope: not authorized"}`, OutcomePermissionDenied},
+		{"counter error", 200, `{"response":{"result":false,"reason":"invalid signature: counter too low"}}`, OutcomeCounterError},
+		{"invalid request", 400, `{"error":"invalid_command"}`, OutcomeInvalidRequest},
+		{"server error", 500, `{"error":"internal"}`, OutcomeFailed},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var gotPath, gotAuth, gotBody string
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				gotPath = r.URL.Path
+				gotAuth = r.Header.Get("Authorization")
+				b, _ := io.ReadAll(r.Body)
+				gotBody = string(b)
+				w.WriteHeader(tt.status)
+				_, _ = w.Write([]byte(tt.body))
+			}))
+			defer srv.Close()
+
+			tr := NewProxyTransport(srv.URL, srv.Client(), nil)
+			res, err := tr.Command(context.Background(), TransportRequest{
+				VIN: "5YJ3E1EA1PF000001", Command: "door_lock", Token: "abc", Body: []byte(`{"x":1}`),
+			})
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if res.Outcome != tt.want {
+				t.Fatalf("outcome = %v want %v", res.Outcome, tt.want)
+			}
+			if gotPath != "/api/1/vehicles/5YJ3E1EA1PF000001/command/door_lock" {
+				t.Fatalf("path = %q", gotPath)
+			}
+			if gotAuth != "Bearer abc" {
+				t.Fatalf("auth = %q", gotAuth)
+			}
+			if !strings.Contains(gotBody, `"x":1`) {
+				t.Fatalf("body = %q", gotBody)
+			}
+		})
+	}
+}
+
+func TestProxyTransport_Wake(t *testing.T) {
+	var gotPath string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		w.WriteHeader(200)
+		_, _ = w.Write([]byte(`{"response":{"state":"online"}}`))
+	}))
+	defer srv.Close()
+
+	tr := NewProxyTransport(srv.URL, srv.Client(), nil)
+	if err := tr.Wake(context.Background(), "5YJ3E1EA1PF000001", "abc"); err != nil {
+		t.Fatalf("wake error: %v", err)
+	}
+	if gotPath != "/api/1/vehicles/5YJ3E1EA1PF000001/wake_up" {
+		t.Fatalf("wake path = %q", gotPath)
+	}
+}
+
+func TestProxyTransport_WakeNon2xxIsError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusRequestTimeout)
+	}))
+	defer srv.Close()
+	tr := NewProxyTransport(srv.URL, srv.Client(), nil)
+	if err := tr.Wake(context.Background(), "V", "abc"); err == nil {
+		t.Fatalf("expected error on non-2xx wake")
+	}
+}

--- a/internal/commands/registry.go
+++ b/internal/commands/registry.go
@@ -1,0 +1,194 @@
+package commands
+
+import (
+	"encoding/json"
+	"fmt"
+	"sort"
+	"time"
+)
+
+// Command is a registry entry: the mapping from a public command name to
+// its Tesla OAuth scope, whether it must be end-to-end signed, and how its
+// request parameters are validated and marshalled into the Tesla command
+// body. The registry key (and Name) IS the Tesla command name, so the REST
+// {name} path segment maps straight through to the Fleet API.
+type Command struct {
+	// Name is the Tesla command name (== registry key == REST {name}).
+	Name string
+	// Scope is the Fleet OAuth scope required to invoke it.
+	Scope Scope
+	// SignerRequired is true when the command must be end-to-end signed with
+	// the virtual key. navigation_request/navigation_gps_request are the
+	// exceptions: Tesla processes them server-side, so they are forwarded
+	// UNSIGNED (see notes below and MYR-176).
+	SignerRequired bool
+	// BuildBody validates params and returns the Tesla command body JSON.
+	// nil means the command takes no parameters (empty body).
+	BuildBody func(params map[string]any) ([]byte, error)
+}
+
+// Registry is the seeded catalog of commands the P11/P10 surface needs.
+type Registry struct {
+	cmds map[string]Command
+}
+
+// Lookup returns the command by name.
+func (r *Registry) Lookup(name string) (Command, bool) {
+	c, ok := r.cmds[name]
+	return c, ok
+}
+
+// Names returns the registered command names in sorted order (for docs and
+// tests).
+func (r *Registry) Names() []string {
+	out := make([]string, 0, len(r.cmds))
+	for n := range r.cmds {
+		out = append(out, n)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// NewRegistry builds the default command registry seeded with the P11
+// (lock/climate/charge/trunk/horn/lights) and P10 dispatch
+// (navigation_request/navigation_gps_request, MYR-176) commands.
+func NewRegistry() *Registry {
+	cmds := []Command{
+		// --- Doors (P11) ---
+		{Name: "door_lock", Scope: ScopeVehicleCmds, SignerRequired: true},
+		{Name: "door_unlock", Scope: ScopeVehicleCmds, SignerRequired: true},
+
+		// --- Climate (P11) ---
+		{Name: "auto_conditioning_start", Scope: ScopeVehicleCmds, SignerRequired: true},
+		{Name: "auto_conditioning_stop", Scope: ScopeVehicleCmds, SignerRequired: true},
+		{Name: "set_temps", Scope: ScopeVehicleCmds, SignerRequired: true, BuildBody: buildSetTemps},
+
+		// --- Charging (P11) ---
+		{Name: "charge_start", Scope: ScopeChargingCmds, SignerRequired: true},
+		{Name: "charge_stop", Scope: ScopeChargingCmds, SignerRequired: true},
+		{Name: "set_charge_limit", Scope: ScopeChargingCmds, SignerRequired: true, BuildBody: buildSetChargeLimit},
+
+		// --- Trunk / frunk (P11) ---
+		{Name: "actuate_trunk", Scope: ScopeVehicleCmds, SignerRequired: true, BuildBody: buildActuateTrunk},
+
+		// --- Remote start (P11). remote_start_drive is a Fleet vehicle_cmds
+		// command; there is no separate "vehicle_remote_start" Fleet scope. ---
+		{Name: "remote_start_drive", Scope: ScopeVehicleCmds, SignerRequired: true},
+
+		// --- Horn & lights (P11) ---
+		{Name: "honk_horn", Scope: ScopeVehicleCmds, SignerRequired: true},
+		{Name: "flash_lights", Scope: ScopeVehicleCmds, SignerRequired: true},
+
+		// --- Navigation / dispatch (P10, MYR-176). UNSIGNED: Tesla processes
+		// these server-side, so the proxy forwards them straight to the Fleet
+		// API rather than signing them (teslamotors/vehicle-command
+		// pkg/proxy: navigation_request -> ErrCommandUseRESTAPI -> forward).
+		// navigation_gps_request sends a lat/long destination and is the
+		// command MYR-176 dispatch should use; navigation_request sends a
+		// text address / maps-link share. ---
+		{Name: "navigation_gps_request", Scope: ScopeVehicleCmds, SignerRequired: false, BuildBody: buildNavigationGPS},
+		{Name: "navigation_request", Scope: ScopeVehicleCmds, SignerRequired: false, BuildBody: buildNavigationShare},
+	}
+
+	m := make(map[string]Command, len(cmds))
+	for _, c := range cmds {
+		m[c.Name] = c
+	}
+	return &Registry{cmds: m}
+}
+
+// marshalBody wraps json.Marshal so BuildBody errors carry package context
+// (satisfies the wrapcheck linter; a map[string]any marshal cannot fail in
+// practice).
+func marshalBody(v any) ([]byte, error) {
+	b, err := json.Marshal(v)
+	if err != nil {
+		return nil, fmt.Errorf("marshal command body: %w", err)
+	}
+	return b, nil
+}
+
+// buildSetTemps marshals {driver_temp, passenger_temp} in Celsius. If
+// passenger_temp is omitted it mirrors driver_temp.
+func buildSetTemps(p map[string]any) ([]byte, error) {
+	driver, _, err := paramFloat(p, "driver_temp", true)
+	if err != nil {
+		return nil, err
+	}
+	passenger, present, err := paramFloat(p, "passenger_temp", false)
+	if err != nil {
+		return nil, err
+	}
+	if !present {
+		passenger = driver
+	}
+	return marshalBody(map[string]any{"driver_temp": driver, "passenger_temp": passenger})
+}
+
+// buildSetChargeLimit marshals {percent} constrained to Tesla's 50–100 range.
+func buildSetChargeLimit(p map[string]any) ([]byte, error) {
+	pct, _, err := paramInt(p, "percent", true)
+	if err != nil {
+		return nil, err
+	}
+	if pct < 50 || pct > 100 {
+		return nil, errInvalidParams("parameter \"percent\" must be between 50 and 100")
+	}
+	return marshalBody(map[string]any{"percent": pct})
+}
+
+// buildActuateTrunk marshals {which_trunk} constrained to front|rear.
+func buildActuateTrunk(p map[string]any) ([]byte, error) {
+	which, err := paramString(p, "which_trunk")
+	if err != nil {
+		return nil, err
+	}
+	if which != "front" && which != "rear" {
+		return nil, errInvalidParams("parameter \"which_trunk\" must be \"front\" or \"rear\"")
+	}
+	return marshalBody(map[string]any{"which_trunk": which})
+}
+
+// buildNavigationGPS marshals {lat, lon, order} for navigation_gps_request.
+// order defaults to 1 (first stop). This is the precise command for a
+// lat/long dispatch destination (MYR-176).
+func buildNavigationGPS(p map[string]any) ([]byte, error) {
+	lat, _, err := paramFloat(p, "lat", true)
+	if err != nil {
+		return nil, err
+	}
+	lon, _, err := paramFloat(p, "lon", true)
+	if err != nil {
+		return nil, err
+	}
+	if lat < -90 || lat > 90 {
+		return nil, errInvalidParams("parameter \"lat\" out of range [-90, 90]")
+	}
+	if lon < -180 || lon > 180 {
+		return nil, errInvalidParams("parameter \"lon\" out of range [-180, 180]")
+	}
+	order, present, err := paramInt(p, "order", false)
+	if err != nil {
+		return nil, err
+	}
+	if !present {
+		order = 1
+	}
+	return marshalBody(map[string]any{"lat": lat, "lon": lon, "order": order})
+}
+
+// buildNavigationShare marshals a navigation_request share payload from a
+// text destination (a street address or a maps URL). Tesla's share schema
+// wraps the text in the Android share intent extra.
+func buildNavigationShare(p map[string]any) ([]byte, error) {
+	value, err := paramString(p, "value")
+	if err != nil {
+		return nil, err
+	}
+	return marshalBody(map[string]any{
+		"type":         "share_ext_content_raw",
+		"locale":       "en-US",
+		"timestamp_ms": fmt.Sprintf("%d", time.Now().UnixMilli()),
+		"value":        map[string]any{"android.intent.extra.TEXT": value},
+	})
+}

--- a/internal/commands/registry_test.go
+++ b/internal/commands/registry_test.go
@@ -1,0 +1,208 @@
+package commands
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestRegistrySeededCommands(t *testing.T) {
+	r := NewRegistry()
+
+	// Every command the P11/P10 surface needs, with its expected scope and
+	// signer flag. This locks the registry contract that MYR-181-183 and
+	// MYR-176 build on.
+	want := map[string]struct {
+		scope  Scope
+		signed bool
+	}{
+		"door_lock":               {ScopeVehicleCmds, true},
+		"door_unlock":             {ScopeVehicleCmds, true},
+		"auto_conditioning_start": {ScopeVehicleCmds, true},
+		"auto_conditioning_stop":  {ScopeVehicleCmds, true},
+		"set_temps":               {ScopeVehicleCmds, true},
+		"charge_start":            {ScopeChargingCmds, true},
+		"charge_stop":             {ScopeChargingCmds, true},
+		"set_charge_limit":        {ScopeChargingCmds, true},
+		"actuate_trunk":           {ScopeVehicleCmds, true},
+		"remote_start_drive":      {ScopeVehicleCmds, true},
+		"honk_horn":               {ScopeVehicleCmds, true},
+		"flash_lights":            {ScopeVehicleCmds, true},
+		"navigation_gps_request":  {ScopeVehicleCmds, false},
+		"navigation_request":      {ScopeVehicleCmds, false},
+	}
+
+	for name, w := range want {
+		t.Run(name, func(t *testing.T) {
+			cmd, ok := r.Lookup(name)
+			if !ok {
+				t.Fatalf("command %q not registered", name)
+			}
+			if cmd.Scope != w.scope {
+				t.Errorf("scope = %q want %q", cmd.Scope, w.scope)
+			}
+			if cmd.SignerRequired != w.signed {
+				t.Errorf("SignerRequired = %v want %v", cmd.SignerRequired, w.signed)
+			}
+		})
+	}
+
+	if _, ok := r.Lookup("nonexistent_command"); ok {
+		t.Fatalf("unknown command should not resolve")
+	}
+	if got := len(r.Names()); got != len(want) {
+		t.Fatalf("Names() count = %d want %d", got, len(want))
+	}
+}
+
+func TestBuildBodyValidation(t *testing.T) {
+	r := NewRegistry()
+
+	tests := []struct {
+		name    string
+		command string
+		params  map[string]any
+		wantErr bool
+		assert  func(t *testing.T, body []byte)
+	}{
+		{
+			name:    "set_temps driver only mirrors passenger",
+			command: "set_temps",
+			params:  map[string]any{"driver_temp": 21.0},
+			assert: func(t *testing.T, body []byte) {
+				var m map[string]any
+				mustJSON(t, body, &m)
+				if m["driver_temp"] != 21.0 || m["passenger_temp"] != 21.0 {
+					t.Fatalf("body = %s", body)
+				}
+			},
+		},
+		{
+			name:    "set_temps missing driver_temp",
+			command: "set_temps",
+			params:  map[string]any{},
+			wantErr: true,
+		},
+		{
+			name:    "set_temps non-numeric",
+			command: "set_temps",
+			params:  map[string]any{"driver_temp": "hot"},
+			wantErr: true,
+		},
+		{
+			name:    "set_charge_limit valid",
+			command: "set_charge_limit",
+			params:  map[string]any{"percent": 80.0},
+			assert: func(t *testing.T, body []byte) {
+				var m map[string]any
+				mustJSON(t, body, &m)
+				if m["percent"] != 80.0 {
+					t.Fatalf("body = %s", body)
+				}
+			},
+		},
+		{
+			name:    "set_charge_limit out of range",
+			command: "set_charge_limit",
+			params:  map[string]any{"percent": 20.0},
+			wantErr: true,
+		},
+		{
+			name:    "set_charge_limit non-integer",
+			command: "set_charge_limit",
+			params:  map[string]any{"percent": 80.5},
+			wantErr: true,
+		},
+		{
+			name:    "actuate_trunk rear",
+			command: "actuate_trunk",
+			params:  map[string]any{"which_trunk": "rear"},
+		},
+		{
+			name:    "actuate_trunk invalid value",
+			command: "actuate_trunk",
+			params:  map[string]any{"which_trunk": "roof"},
+			wantErr: true,
+		},
+		{
+			name:    "navigation_gps_request valid",
+			command: "navigation_gps_request",
+			params:  map[string]any{"lat": 37.7749, "lon": -122.4194},
+			assert: func(t *testing.T, body []byte) {
+				var m map[string]any
+				mustJSON(t, body, &m)
+				if m["lat"] != 37.7749 || m["order"] != 1.0 {
+					t.Fatalf("body = %s", body)
+				}
+			},
+		},
+		{
+			name:    "navigation_gps_request out-of-range lat",
+			command: "navigation_gps_request",
+			params:  map[string]any{"lat": 200.0, "lon": 0.0},
+			wantErr: true,
+		},
+		{
+			name:    "navigation_gps_request missing lon",
+			command: "navigation_gps_request",
+			params:  map[string]any{"lat": 10.0},
+			wantErr: true,
+		},
+		{
+			name:    "navigation_request share value",
+			command: "navigation_request",
+			params:  map[string]any{"value": "1 Market St, San Francisco"},
+			assert: func(t *testing.T, body []byte) {
+				var m map[string]any
+				mustJSON(t, body, &m)
+				if m["type"] != "share_ext_content_raw" {
+					t.Fatalf("body = %s", body)
+				}
+			},
+		},
+		{
+			name:    "navigation_request missing value",
+			command: "navigation_request",
+			params:  map[string]any{},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cmd, ok := r.Lookup(tt.command)
+			if !ok {
+				t.Fatalf("command %q not registered", tt.command)
+			}
+			if cmd.BuildBody == nil {
+				t.Fatalf("command %q has no BuildBody", tt.command)
+			}
+			body, err := cmd.BuildBody(tt.params)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got body %s", body)
+				}
+				var cErr *CommandError
+				if !asCommandError(err, &cErr) {
+					t.Fatalf("error is not *CommandError: %v", err)
+				}
+				if cErr.Code != "invalid_request" {
+					t.Fatalf("code = %q want invalid_request", cErr.Code)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if tt.assert != nil {
+				tt.assert(t, body)
+			}
+		})
+	}
+}
+
+func mustJSON(t *testing.T, data []byte, v any) {
+	t.Helper()
+	if err := json.Unmarshal(data, v); err != nil {
+		t.Fatalf("unmarshal %s: %v", data, err)
+	}
+}

--- a/internal/commands/scope.go
+++ b/internal/commands/scope.go
@@ -1,0 +1,81 @@
+package commands
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"strings"
+)
+
+// Scope is a Tesla Fleet API OAuth scope. Vehicle commands are gated on
+// the scope granted by the vehicle owner at Tesla-account link time.
+//
+// Fleet API defines exactly two command scopes (developer.tesla.com Fleet
+// API → Authentication → Overview): vehicle_cmds and vehicle_charging_cmds.
+// There is NO "vehicle_remote_start" Fleet scope — that name belongs to the
+// legacy Owner API. Fleet folds remote_start_drive into vehicle_cmds.
+type Scope string
+
+const (
+	// ScopeVehicleCmds covers actuation: lock/unlock, climate, trunk, horn,
+	// lights, remote start, and navigation.
+	ScopeVehicleCmds Scope = "vehicle_cmds"
+	// ScopeChargingCmds covers charging management: start/stop, charge limit,
+	// charge port, and schedules.
+	ScopeChargingCmds Scope = "vehicle_charging_cmds"
+)
+
+// ScopeSet is the set of scopes granted by a Tesla OAuth access token.
+// Known reports whether the granting scopes could be determined at all: a
+// token whose scopes cannot be parsed yields an unknown set, and the
+// executor then defers the decision to Tesla rather than pre-denying.
+type ScopeSet struct {
+	known bool
+	set   map[Scope]struct{}
+}
+
+// Known reports whether the token's scope claim was parseable.
+func (s ScopeSet) Known() bool { return s.known }
+
+// Has reports whether sc was granted. Always false on an unknown set.
+func (s ScopeSet) Has(sc Scope) bool {
+	_, ok := s.set[sc]
+	return ok
+}
+
+// ParseScopes extracts the granted scope set from a Tesla Fleet OAuth
+// access token. Fleet access tokens are JWTs whose payload carries the
+// granted scopes in the "scp" claim (a JSON array) or, on some issuers, a
+// space-delimited "scope" string. If the token is not a parseable JWT or
+// carries neither claim, the returned set is not Known and the caller
+// should let Tesla enforce scope.
+func ParseScopes(accessToken string) ScopeSet {
+	parts := strings.Split(accessToken, ".")
+	if len(parts) != 3 {
+		return ScopeSet{}
+	}
+	payload, err := base64.RawURLEncoding.DecodeString(parts[1])
+	if err != nil {
+		return ScopeSet{}
+	}
+	var claims struct {
+		Scp   []string `json:"scp"`
+		Scope string   `json:"scope"`
+	}
+	if err := json.Unmarshal(payload, &claims); err != nil {
+		return ScopeSet{}
+	}
+
+	raw := claims.Scp
+	if len(raw) == 0 && claims.Scope != "" {
+		raw = strings.Fields(claims.Scope)
+	}
+	if len(raw) == 0 {
+		return ScopeSet{}
+	}
+
+	set := make(map[Scope]struct{}, len(raw))
+	for _, s := range raw {
+		set[Scope(s)] = struct{}{}
+	}
+	return ScopeSet{known: true, set: set}
+}

--- a/internal/commands/scope_test.go
+++ b/internal/commands/scope_test.go
@@ -1,0 +1,95 @@
+package commands
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"testing"
+)
+
+// makeJWT builds an unsigned JWT-shaped string (header.payload.sig) with the
+// given payload claims. Only the payload segment is decoded by ParseScopes,
+// so the header and signature are placeholders.
+func makeJWT(t *testing.T, claims map[string]any) string {
+	t.Helper()
+	payload, err := json.Marshal(claims)
+	if err != nil {
+		t.Fatalf("marshal claims: %v", err)
+	}
+	seg := base64.RawURLEncoding.EncodeToString(payload)
+	return "eyJhbGciOiJSUzI1NiJ9." + seg + ".sig"
+}
+
+func TestParseScopes(t *testing.T) {
+	tests := []struct {
+		name       string
+		token      string
+		wantKnown  bool
+		wantHasCmd bool
+		wantHasChg bool
+	}{
+		{
+			name:       "scp array",
+			token:      makeJWTForTest(t, map[string]any{"scp": []string{"openid", "vehicle_device_data", "vehicle_cmds"}}),
+			wantKnown:  true,
+			wantHasCmd: true,
+			wantHasChg: false,
+		},
+		{
+			name:       "scp array with both command scopes",
+			token:      makeJWTForTest(t, map[string]any{"scp": []string{"vehicle_cmds", "vehicle_charging_cmds"}}),
+			wantKnown:  true,
+			wantHasCmd: true,
+			wantHasChg: true,
+		},
+		{
+			name:       "space-delimited scope string",
+			token:      makeJWTForTest(t, map[string]any{"scope": "openid vehicle_charging_cmds"}),
+			wantKnown:  true,
+			wantHasCmd: false,
+			wantHasChg: true,
+		},
+		{
+			name:      "no scope claim -> unknown",
+			token:     makeJWTForTest(t, map[string]any{"sub": "abc"}),
+			wantKnown: false,
+		},
+		{
+			name:      "not a jwt -> unknown",
+			token:     "not-a-jwt",
+			wantKnown: false,
+		},
+		{
+			name:      "malformed payload -> unknown",
+			token:     "a.$$$.c",
+			wantKnown: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := ParseScopes(tt.token)
+			if s.Known() != tt.wantKnown {
+				t.Fatalf("Known()=%v want %v", s.Known(), tt.wantKnown)
+			}
+			if !tt.wantKnown {
+				if s.Has(ScopeVehicleCmds) {
+					t.Fatalf("unknown set must not report Has")
+				}
+				return
+			}
+			if s.Has(ScopeVehicleCmds) != tt.wantHasCmd {
+				t.Fatalf("Has(vehicle_cmds)=%v want %v", s.Has(ScopeVehicleCmds), tt.wantHasCmd)
+			}
+			if s.Has(ScopeChargingCmds) != tt.wantHasChg {
+				t.Fatalf("Has(vehicle_charging_cmds)=%v want %v", s.Has(ScopeChargingCmds), tt.wantHasChg)
+			}
+		})
+	}
+}
+
+// makeJWTForTest is a thin wrapper kept separate so the helper name reads
+// clearly at the call sites above.
+func makeJWTForTest(t *testing.T, claims map[string]any) string {
+	t.Helper()
+	return makeJWT(t, claims)
+}

--- a/internal/commands/transport.go
+++ b/internal/commands/transport.go
@@ -1,0 +1,65 @@
+package commands
+
+import "context"
+
+// Outcome is the classified result of a single command attempt against the
+// Fleet transport. It is the seam that lets the Executor run its retry
+// policies (wake-on-asleep, re-handshake-on-counter) without knowing the
+// concrete HTTP/proxy wire shape, and lets tests drive every branch with a
+// fake transport instead of a live Tesla call.
+type Outcome int
+
+const (
+	// OutcomeOK — the vehicle accepted and applied the command.
+	OutcomeOK Outcome = iota
+	// OutcomeAsleep — the vehicle is asleep/offline/unavailable; the
+	// Executor wakes it and retries within a bounded budget.
+	OutcomeAsleep
+	// OutcomeCounterError — a signing session/anti-replay-counter error; the
+	// proxy re-handshakes on the next attempt, so the Executor retries once.
+	OutcomeCounterError
+	// OutcomeNotPaired — the vehicle rejected the command because the
+	// virtual key is not enrolled (owner has not paired, MYR-115).
+	OutcomeNotPaired
+	// OutcomePermissionDenied — Tesla rejected the command for access/scope
+	// reasons the preflight scope check did not catch.
+	OutcomePermissionDenied
+	// OutcomeInvalidRequest — Tesla rejected the command parameters.
+	OutcomeInvalidRequest
+	// OutcomeFailed — any other vehicle-side or upstream failure.
+	OutcomeFailed
+)
+
+// TransportRequest is a single (possibly signed) command to send to one
+// vehicle. Command is the Tesla command name (e.g. "door_lock"); Token is
+// the vehicle owner's Tesla OAuth access token; Body is the marshalled
+// Tesla command parameter JSON (nil for parameterless commands).
+type TransportRequest struct {
+	VIN     string
+	Command string
+	Token   string
+	Body    []byte
+}
+
+// TransportResult is the classified transport response. Reason is an
+// opaque, non-sensitive detail string safe for logs and error messages.
+type TransportResult struct {
+	Outcome Outcome
+	Reason  string
+}
+
+// Transport is the signed-session seam over the Fleet API. The concrete
+// implementation (ProxyTransport) forwards to the tesla-http-proxy sidecar,
+// which owns command signing and per-vehicle session caching. Tests
+// substitute a fake so no live Tesla call is ever made.
+type Transport interface {
+	// Command sends one command attempt and classifies the response.
+	Command(ctx context.Context, req TransportRequest) (TransportResult, error)
+	// Wake asks the vehicle to wake. Best-effort: the Executor calls it
+	// between asleep retries and does not treat a wake error as fatal.
+	Wake(ctx context.Context, vin, token string) error
+	// Enabled reports whether the command-signing transport is configured
+	// (proxy URL present). When false the Executor degrades to
+	// key_not_paired for signer-required commands instead of dialing.
+	Enabled() bool
+}

--- a/internal/telemetry/vehicle_command_handler.go
+++ b/internal/telemetry/vehicle_command_handler.go
@@ -1,0 +1,219 @@
+package telemetry
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"log/slog"
+	"net/http"
+
+	"github.com/myrobotaxi/telemetry/internal/commands"
+	"github.com/myrobotaxi/telemetry/internal/wserrors"
+	"github.com/myrobotaxi/telemetry/pkg/sdk"
+)
+
+// maxCommandBody caps the JSON parameter body a command request may carry.
+const maxCommandBody = 4 << 10 // 4 KiB — command params are tiny
+
+// commandExecutor is the consumer-site seam over internal/commands.Executor
+// so the handler can be unit-tested with a fake.
+type commandExecutor interface {
+	Execute(ctx context.Context, req commands.Request) (commands.Result, error)
+}
+
+// VehicleCommandHandler serves POST /api/vehicles/{vehicleId}/command/{name}:
+// the owner-only Tesla vehicle-command surface (MYR-180, rest-api.md §7.9).
+// It validates the caller JWT, enforces vehicle ownership, applies a
+// per-vehicle command cooldown, resolves the owner's (auto-refreshed) Tesla
+// token, and dispatches through the command Executor.
+type VehicleCommandHandler struct {
+	auth      tokenValidator
+	vehicles  VehicleSnapshotReader
+	tokens    TeslaTokenProvider
+	refresher TeslaTokenRefresher // nil disables auto-refresh
+	updater   TeslaTokenUpdater   // nil disables DB persistence of refresh
+	executor  commandExecutor
+	cooldown  *vehicleCooldown
+	logger    *slog.Logger
+}
+
+// VehicleCommandOption configures optional dependencies.
+type VehicleCommandOption func(*VehicleCommandHandler)
+
+// WithCommandTokenRefresher enables Tesla token auto-refresh, mirroring the
+// fleet-config handler's refresh path.
+func WithCommandTokenRefresher(refresher TeslaTokenRefresher, updater TeslaTokenUpdater) VehicleCommandOption {
+	return func(h *VehicleCommandHandler) {
+		h.refresher = refresher
+		h.updater = updater
+	}
+}
+
+// NewVehicleCommandHandler constructs the handler.
+func NewVehicleCommandHandler(
+	auth tokenValidator,
+	vehicles VehicleSnapshotReader,
+	tokens TeslaTokenProvider,
+	executor commandExecutor,
+	logger *slog.Logger,
+	opts ...VehicleCommandOption,
+) *VehicleCommandHandler {
+	h := &VehicleCommandHandler{
+		auth:     auth,
+		vehicles: vehicles,
+		tokens:   tokens,
+		executor: executor,
+		cooldown: newVehicleCooldown(defaultCommandCooldown, defaultCommandBurst),
+		logger:   logger,
+	}
+	for _, opt := range opts {
+		opt(h)
+	}
+	return h
+}
+
+// ServeHTTP handles POST /api/vehicles/{vehicleId}/command/{name}.
+func (h *VehicleCommandHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		h.writeError(w, http.StatusMethodNotAllowed, wserrors.ErrCodeInvalidRequest, "method not allowed")
+		return
+	}
+
+	vehicleID := r.PathValue("vehicleId")
+	name := r.PathValue("name")
+	if vehicleID == "" || name == "" {
+		h.writeError(w, http.StatusBadRequest, wserrors.ErrCodeInvalidRequest, "missing vehicleId or command name")
+		return
+	}
+
+	token := extractBearerToken(r)
+	if token == "" {
+		h.writeError(w, http.StatusUnauthorized, wserrors.ErrCodeAuthFailed, "missing Authorization header")
+		return
+	}
+
+	ctx := r.Context()
+	userID, err := h.auth.ValidateToken(ctx, token)
+	if err != nil {
+		h.writeError(w, http.StatusUnauthorized, wserrors.ErrCodeAuthFailed, "invalid or expired token")
+		return
+	}
+
+	row, ok := h.authorizeVehicle(ctx, w, vehicleID, userID)
+	if !ok {
+		return
+	}
+
+	if !h.cooldown.allow(vehicleID) {
+		w.Header().Set("Retry-After", "2")
+		h.writeError(w, http.StatusTooManyRequests, wserrors.ErrCodeRateLimited, "command cooldown: too many commands for this vehicle")
+		return
+	}
+
+	params, ok := h.decodeParams(w, r)
+	if !ok {
+		return
+	}
+
+	teslaTok, ok := h.resolveTeslaToken(ctx, w, userID)
+	if !ok {
+		return
+	}
+
+	res, err := h.executor.Execute(ctx, commands.Request{
+		VIN:         row.VIN,
+		Command:     name,
+		Params:      params,
+		AccessToken: teslaTok.AccessToken,
+		Scopes:      commands.ParseScopes(teslaTok.AccessToken),
+	})
+	if err != nil {
+		h.writeCommandError(w, name, row.VIN, err)
+		return
+	}
+
+	h.logger.Info("vehicle command applied",
+		slog.String("vin", redactVIN(row.VIN)),
+		slog.String("command", res.Command),
+	)
+	h.writeJSON(w, http.StatusOK, vehicleCommandResponse{
+		Status:  "applied",
+		Command: res.Command,
+		VIN:     redactVIN(row.VIN),
+	})
+}
+
+// authorizeVehicle loads the vehicle and enforces owner-only access.
+func (h *VehicleCommandHandler) authorizeVehicle(ctx context.Context, w http.ResponseWriter, vehicleID, userID string) (VehicleSnapshotRow, bool) {
+	row, err := h.vehicles.GetByID(ctx, vehicleID)
+	if err != nil {
+		if errors.Is(err, sdk.ErrNotFound) {
+			h.writeError(w, http.StatusNotFound, wserrors.ErrCodeNotFound, "vehicle not found")
+			return VehicleSnapshotRow{}, false
+		}
+		h.logger.Error("vehicle command: vehicle lookup failed", slog.String("error", err.Error()))
+		h.writeError(w, http.StatusInternalServerError, wserrors.ErrCodeInternalError, "internal error")
+		return VehicleSnapshotRow{}, false
+	}
+	if row.UserID != userID {
+		h.writeError(w, http.StatusForbidden, wserrors.ErrCodeVehicleNotOwned, "you do not own this vehicle")
+		return VehicleSnapshotRow{}, false
+	}
+	return row, true
+}
+
+// decodeParams reads the optional JSON parameter body. An empty body yields
+// nil params (parameterless commands). Malformed JSON is a 400.
+func (h *VehicleCommandHandler) decodeParams(w http.ResponseWriter, r *http.Request) (map[string]any, bool) {
+	body, err := io.ReadAll(io.LimitReader(r.Body, maxCommandBody))
+	if err != nil {
+		h.writeError(w, http.StatusBadRequest, wserrors.ErrCodeInvalidRequest, "could not read request body")
+		return nil, false
+	}
+	if len(body) == 0 {
+		return nil, true
+	}
+	var params map[string]any
+	if err := json.Unmarshal(body, &params); err != nil {
+		h.writeError(w, http.StatusBadRequest, wserrors.ErrCodeInvalidRequest, "malformed JSON body")
+		return nil, false
+	}
+	return params, true
+}
+
+// writeCommandError translates a *commands.CommandError into the REST error
+// envelope. Any non-typed error collapses to a 500.
+func (h *VehicleCommandHandler) writeCommandError(w http.ResponseWriter, name, vin string, err error) {
+	var cmdErr *commands.CommandError
+	if errors.As(err, &cmdErr) {
+		h.logger.Info("vehicle command rejected",
+			slog.String("vin", redactVIN(vin)),
+			slog.String("command", name),
+			slog.String("code", string(cmdErr.Code)),
+		)
+		h.writeError(w, cmdErr.Status, cmdErr.Code, cmdErr.Message)
+		return
+	}
+	h.logger.Error("vehicle command: unexpected error", slog.String("error", err.Error()))
+	h.writeError(w, http.StatusInternalServerError, wserrors.ErrCodeInternalError, "internal error")
+}
+
+func (h *VehicleCommandHandler) writeJSON(w http.ResponseWriter, status int, v any) {
+	w.Header().Set("Content-Type", "application/json; charset=utf-8")
+	w.WriteHeader(status)
+	if err := json.NewEncoder(w).Encode(v); err != nil {
+		h.logger.Error("vehicle command: writeJSON encode failed", slog.String("error", err.Error()))
+	}
+}
+
+func (h *VehicleCommandHandler) writeError(w http.ResponseWriter, status int, code wserrors.ErrorCode, msg string) {
+	wserrors.WriteErrorEnvelope(w, h.logger, status, code, msg)
+}
+
+// vehicleCommandResponse is the success body. VIN is redacted to last-4.
+type vehicleCommandResponse struct {
+	Status  string `json:"status"`
+	Command string `json:"command"`
+	VIN     string `json:"vin"`
+}

--- a/internal/telemetry/vehicle_command_handler_test.go
+++ b/internal/telemetry/vehicle_command_handler_test.go
@@ -1,0 +1,192 @@
+package telemetry
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/myrobotaxi/telemetry/internal/commands"
+	"github.com/myrobotaxi/telemetry/internal/wserrors"
+	"github.com/myrobotaxi/telemetry/pkg/sdk"
+)
+
+// fakeCommandExecutor records the request it received and returns a scripted
+// result/error — the handler is tested without touching internal/commands'
+// transport or any Tesla endpoint.
+type fakeCommandExecutor struct {
+	result commands.Result
+	err    error
+	got    commands.Request
+	calls  int
+}
+
+func (f *fakeCommandExecutor) Execute(_ context.Context, req commands.Request) (commands.Result, error) {
+	f.calls++
+	f.got = req
+	return f.result, f.err
+}
+
+func newCommandHandler(exec commandExecutor, reader *stubVehicleSnapshotReader, validator *stubTokenValidator) *VehicleCommandHandler {
+	return NewVehicleCommandHandler(
+		validator,
+		reader,
+		validTeslaToken(),
+		exec,
+		discardLogger(),
+	)
+}
+
+func postCommand(h *VehicleCommandHandler, vehicleID, name, body, authHeader string) *httptest.ResponseRecorder {
+	var reader *strings.Reader
+	if body == "" {
+		reader = strings.NewReader("")
+	} else {
+		reader = strings.NewReader(body)
+	}
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodPost, "/api/vehicles/"+vehicleID+"/command/"+name, reader)
+	if authHeader != "" {
+		req.Header.Set("Authorization", authHeader)
+	}
+	req.SetPathValue("vehicleId", vehicleID)
+	req.SetPathValue("name", name)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	return rec
+}
+
+func decodeErrCode(t *testing.T, rec *httptest.ResponseRecorder) wserrors.ErrorCode {
+	t.Helper()
+	var env wserrors.ErrorEnvelope
+	if err := json.Unmarshal(rec.Body.Bytes(), &env); err != nil {
+		t.Fatalf("decode envelope: %v (body=%s)", err, rec.Body.String())
+	}
+	return env.Error.Code
+}
+
+func TestVehicleCommandHandler_MethodNotAllowed(t *testing.T) {
+	h := newCommandHandler(&fakeCommandExecutor{}, &stubVehicleSnapshotReader{}, &stubTokenValidator{userID: "u1"})
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/api/vehicles/v1/command/door_lock", nil)
+	req.SetPathValue("vehicleId", "v1")
+	req.SetPathValue("name", "door_lock")
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	if rec.Code != http.StatusMethodNotAllowed {
+		t.Fatalf("status = %d want 405", rec.Code)
+	}
+}
+
+func TestVehicleCommandHandler_MissingAuth(t *testing.T) {
+	h := newCommandHandler(&fakeCommandExecutor{}, &stubVehicleSnapshotReader{}, &stubTokenValidator{userID: "u1"})
+	rec := postCommand(h, "v1", "door_lock", "", "")
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("status = %d want 401", rec.Code)
+	}
+	if decodeErrCode(t, rec) != wserrors.ErrCodeAuthFailed {
+		t.Fatalf("code = %q", decodeErrCode(t, rec))
+	}
+}
+
+func TestVehicleCommandHandler_InvalidToken(t *testing.T) {
+	h := newCommandHandler(&fakeCommandExecutor{}, &stubVehicleSnapshotReader{}, &stubTokenValidator{err: errors.New("bad token")})
+	rec := postCommand(h, "v1", "door_lock", "", "Bearer x")
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("status = %d want 401", rec.Code)
+	}
+}
+
+func TestVehicleCommandHandler_OwnershipMismatch(t *testing.T) {
+	reader := &stubVehicleSnapshotReader{row: fixtureSnapshotRow("owner-1")}
+	h := newCommandHandler(&fakeCommandExecutor{}, reader, &stubTokenValidator{userID: "not-owner"})
+	rec := postCommand(h, fixtureSnapshotRowID, "door_lock", "", "Bearer x")
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("status = %d want 403", rec.Code)
+	}
+	if decodeErrCode(t, rec) != wserrors.ErrCodeVehicleNotOwned {
+		t.Fatalf("code = %q want vehicle_not_owned", decodeErrCode(t, rec))
+	}
+}
+
+func TestVehicleCommandHandler_VehicleNotFound(t *testing.T) {
+	reader := &stubVehicleSnapshotReader{err: sdk.ErrNotFound}
+	h := newCommandHandler(&fakeCommandExecutor{}, reader, &stubTokenValidator{userID: "u1"})
+	rec := postCommand(h, "v1", "door_lock", "", "Bearer x")
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("status = %d want 404", rec.Code)
+	}
+}
+
+func TestVehicleCommandHandler_MalformedBody(t *testing.T) {
+	reader := &stubVehicleSnapshotReader{row: fixtureSnapshotRow("u1")}
+	h := newCommandHandler(&fakeCommandExecutor{}, reader, &stubTokenValidator{userID: "u1"})
+	rec := postCommand(h, fixtureSnapshotRowID, "set_temps", "{not json", "Bearer x")
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d want 400", rec.Code)
+	}
+	if decodeErrCode(t, rec) != wserrors.ErrCodeInvalidRequest {
+		t.Fatalf("code = %q", decodeErrCode(t, rec))
+	}
+}
+
+func TestVehicleCommandHandler_Success(t *testing.T) {
+	reader := &stubVehicleSnapshotReader{row: fixtureSnapshotRow("u1")}
+	exec := &fakeCommandExecutor{result: commands.Result{Command: "door_lock", Applied: true}}
+	h := newCommandHandler(exec, reader, &stubTokenValidator{userID: "u1"})
+
+	rec := postCommand(h, fixtureSnapshotRowID, "door_lock", "", "Bearer x")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d want 200 (body=%s)", rec.Code, rec.Body.String())
+	}
+	// The executor received the full VIN and the caller's Tesla access token.
+	if exec.got.VIN != "5YJ3E1EA1PF000001" || exec.got.Command != "door_lock" {
+		t.Fatalf("executor request = %+v", exec.got)
+	}
+	if exec.got.AccessToken != "tesla-oauth-token-abc" {
+		t.Fatalf("executor got wrong token: %q", exec.got.AccessToken)
+	}
+	// The success body redacts the VIN to last-4.
+	var body vehicleCommandResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if body.Status != "applied" || strings.Contains(body.VIN, "5YJ3E1") {
+		t.Fatalf("response = %+v (VIN must be redacted)", body)
+	}
+}
+
+func TestVehicleCommandHandler_TypedCommandErrorPropagates(t *testing.T) {
+	reader := &stubVehicleSnapshotReader{row: fixtureSnapshotRow("u1")}
+	// The executor returns the pre-pairing key_not_paired error.
+	exec := &fakeCommandExecutor{err: &commands.CommandError{
+		Code:    wserrors.ErrCodeKeyNotPaired,
+		Status:  http.StatusForbidden,
+		Message: "virtual key not paired with vehicle",
+	}}
+	h := newCommandHandler(exec, reader, &stubTokenValidator{userID: "u1"})
+	rec := postCommand(h, fixtureSnapshotRowID, "door_lock", "", "Bearer x")
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("status = %d want 403", rec.Code)
+	}
+	if decodeErrCode(t, rec) != wserrors.ErrCodeKeyNotPaired {
+		t.Fatalf("code = %q want key_not_paired", decodeErrCode(t, rec))
+	}
+}
+
+func TestVehicleCommandHandler_PerVehicleCooldown(t *testing.T) {
+	reader := &stubVehicleSnapshotReader{row: fixtureSnapshotRow("u1")}
+	exec := &fakeCommandExecutor{result: commands.Result{Command: "door_lock", Applied: true}}
+	h := newCommandHandler(exec, reader, &stubTokenValidator{userID: "u1"})
+
+	// Burst is defaultCommandBurst (2); the third rapid command trips the cap.
+	var lastCode int
+	for i := 0; i < defaultCommandBurst+1; i++ {
+		rec := postCommand(h, fixtureSnapshotRowID, "door_lock", "", "Bearer x")
+		lastCode = rec.Code
+	}
+	if lastCode != http.StatusTooManyRequests {
+		t.Fatalf("expected 429 after burst, got %d", lastCode)
+	}
+}

--- a/internal/telemetry/vehicle_command_token.go
+++ b/internal/telemetry/vehicle_command_token.go
@@ -1,0 +1,91 @@
+package telemetry
+
+import (
+	"context"
+	"net/http"
+	"sync"
+	"time"
+
+	"golang.org/x/time/rate"
+
+	"github.com/myrobotaxi/telemetry/internal/wserrors"
+)
+
+const (
+	// defaultCommandCooldown is the minimum spacing between commands to the
+	// same vehicle; defaultCommandBurst allows a small burst so a UI that
+	// fires lock+climate together isn't rejected. Per-vehicle, in-memory.
+	defaultCommandCooldown = 2 * time.Second
+	defaultCommandBurst    = 2
+)
+
+// vehicleCooldown is a per-vehicle command rate limiter (token bucket). It
+// throttles commands to a single vehicle without capping unrelated
+// vehicles, protecting both the car and the Fleet API from command floods.
+type vehicleCooldown struct {
+	mu       sync.Mutex
+	limiters map[string]*rate.Limiter
+	every    time.Duration
+	burst    int
+}
+
+func newVehicleCooldown(every time.Duration, burst int) *vehicleCooldown {
+	return &vehicleCooldown{
+		limiters: make(map[string]*rate.Limiter),
+		every:    every,
+		burst:    burst,
+	}
+}
+
+// allow reports whether a command to vehicleID is permitted now, consuming
+// a token if so.
+func (c *vehicleCooldown) allow(vehicleID string) bool {
+	c.mu.Lock()
+	lim, ok := c.limiters[vehicleID]
+	if !ok {
+		lim = rate.NewLimiter(rate.Every(c.every), c.burst)
+		c.limiters[vehicleID] = lim
+	}
+	c.mu.Unlock()
+	return lim.Allow()
+}
+
+// resolveTeslaToken fetches the caller's Tesla OAuth token, refreshing it if
+// expired (when a refresher is configured). Mirrors the fleet-config
+// handler's token path so both surfaces share the same refresh semantics.
+// On failure it writes the error response and returns ok=false.
+func (h *VehicleCommandHandler) resolveTeslaToken(ctx context.Context, w http.ResponseWriter, userID string) (TeslaToken, bool) {
+	tok, err := h.tokens.GetTeslaToken(ctx, userID)
+	if err != nil {
+		h.writeError(w, http.StatusUnauthorized, wserrors.ErrCodeAuthFailed, "Tesla account not linked")
+		return TeslaToken{}, false
+	}
+
+	if tok.ExpiresAt.IsZero() || !tok.ExpiresAt.Before(time.Now()) {
+		return tok, true
+	}
+
+	if h.refresher == nil || tok.RefreshToken == "" {
+		h.writeError(w, http.StatusUnauthorized, wserrors.ErrCodeAuthFailed, "Tesla token expired — re-link your Tesla account")
+		return TeslaToken{}, false
+	}
+
+	refreshed, err := h.refresher.Refresh(ctx, tok.RefreshToken)
+	if err != nil {
+		h.writeError(w, http.StatusUnauthorized, wserrors.ErrCodeAuthFailed, "Tesla token expired — re-link your Tesla account")
+		return TeslaToken{}, false
+	}
+
+	expiresAt := refreshed.ExpiresAt()
+	if h.updater != nil {
+		if uErr := h.updater.UpdateTeslaToken(ctx, userID, refreshed.AccessToken, refreshed.RefreshToken, expiresAt.Unix()); uErr != nil {
+			h.logger.Error("vehicle command: failed to persist refreshed token")
+		}
+	}
+
+	return TeslaToken{
+		AccessToken:  refreshed.AccessToken,
+		RefreshToken: refreshed.RefreshToken,
+		ExpiresAt:    expiresAt,
+	}, true
+}

--- a/internal/wserrors/wserrors.go
+++ b/internal/wserrors/wserrors.go
@@ -90,6 +90,35 @@ const (
 	ErrCodeConflict ErrorCode = "conflict"
 )
 
+// Vehicle-command codes added by MYR-180 (Tesla signed vehicle-command
+// proxy). All three are REST-only on the wire — the WS transport is
+// stream-oriented and never carries command requests. They are members
+// of the shared enum so the SDK's CoreError union stays one enum across
+// transports (rest-api.md §4.1.1, §7.9). See docs/operations/vehicle-commands.md.
+const (
+	// ErrCodeKeyNotPaired is REST 403 — a signed vehicle command cannot be
+	// executed because the application's virtual key is not enrolled on the
+	// vehicle (owner has not completed the tesla.com/_ak/<domain> pairing,
+	// MYR-115), or the command-signing transport is not configured. Terminal:
+	// the SDK surfaces it to the UI and prompts the owner to pair; it MUST
+	// NOT auto-retry. This is the default pre-pairing outcome for every
+	// signer-required command.
+	ErrCodeKeyNotPaired ErrorCode = "key_not_paired"
+	// ErrCodeVehicleAsleep is REST 503 — the target vehicle was asleep or
+	// offline and did not come online within the executor's bounded
+	// wake+retry budget. Transient: the SDK auto-retries with backoff
+	// (rest-api.md §7.9 wake policy). Callers that receive OK never see this
+	// code — the executor wakes and retries internally first.
+	ErrCodeVehicleAsleep ErrorCode = "vehicle_asleep"
+	// ErrCodeCommandFailed is REST 502 — the vehicle or the Fleet API
+	// rejected or failed the command for a non-scope, non-pairing reason
+	// (result:false with a vehicle-side reason, a session/counter error that
+	// survived re-handshake, or an upstream Fleet/proxy failure). Terminal
+	// for the operation; the SDK surfaces the failure. Collapses the several
+	// vehicle-side failure modes into one typed code in v1.
+	ErrCodeCommandFailed ErrorCode = "command_failed"
+)
+
 // AllCodes returns every ErrorCode defined in this package, in catalog
 // order. Used by the reachability test to iterate the closed enum and
 // assert each code is in either the implemented or the documented-as-
@@ -107,6 +136,9 @@ func AllCodes() []ErrorCode {
 		ErrCodeServiceUnavailable,
 		ErrCodeSnapshotRequired,
 		ErrCodeConflict,
+		ErrCodeKeyNotPaired,
+		ErrCodeVehicleAsleep,
+		ErrCodeCommandFailed,
 	}
 }
 

--- a/internal/wserrors/wserrors_test.go
+++ b/internal/wserrors/wserrors_test.go
@@ -36,7 +36,10 @@ var reachabilityMatrix = []reachability{
 	{code: ErrCodeInternalError, scenario: "internal/telemetry/vehicle_status_handler_test.go (REST 500 lookup failure)"},
 	{code: ErrCodeConflict, scenario: "internal/telemetry/ride_request_handler_test.go (REST 409 illegal lifecycle transition)"},
 	{code: ErrCodeRateLimited, scenario: "internal/ws/handler_ratelimit_test.go (HTTP 429 envelope on upgrade)"},
-	{code: ErrCodePermissionDenied, skipUntil: "DV-07 — emitted alongside MYR-46 per-vehicle subscribe"},
+	{code: ErrCodePermissionDenied, scenario: "internal/commands/executor_test.go (scope gating + Tesla-rejected), internal/telemetry/vehicle_command_handler_test.go"},
+	{code: ErrCodeKeyNotPaired, scenario: "internal/commands/executor_test.go (transport disabled + not-paired outcome)"},
+	{code: ErrCodeVehicleAsleep, scenario: "internal/commands/executor_test.go (wake+retry budget exhausted)"},
+	{code: ErrCodeCommandFailed, scenario: "internal/commands/executor_test.go (result:false + counter-error exhausted)"},
 	{code: ErrCodeServiceUnavailable, skipUntil: "REST-only forward-compatibility code; not yet emitted (rest-api.md §4.1.1.a)"},
 	{code: ErrCodeSnapshotRequired, skipUntil: "DV-02 — envelope sequence numbers"},
 }


### PR DESCRIPTION
## MYR-180: Tesla signed vehicle-command proxy + scope gating

The actuation foundation for P11 (lock/climate/media/charge/trunk) and P10 dispatch (`navigation_request`, MYR-176). Adds `POST /api/vehicles/{vehicleId}/command/{name}` — owner-only, typed-error, merge-safe **before any virtual key is paired**.

### Library vs proxy decision — reuse the tesla-http-proxy sidecar

The task's default lean was library integration ("no extra process"), but that rationale doesn't apply here: **the server already runs `tesla-http-proxy` as a sidecar** (`FleetAPIClient` → `TESLA_PROXY_URL`, used for `fleet_telemetry_config`), and the P-256 command key already lives ONLY in that proxy's config (`TESLA_KEY_FILE_B64`). So we forward commands to the existing proxy instead of embedding `github.com/teslamotors/vehicle-command`:

1. No process is saved by the library — the proxy already runs.
2. Embedding would put a **second copy of the private key into this Go process's memory**; reuse keeps the key in exactly one place (config-only, never in-process) — a strictly better security posture and exactly what MYR-180 mandates.
3. Signing, per-vehicle session caching, wake, and unsigned-command forwarding (`navigation_request → ErrCommandUseRESTAPI → forwardRequest`) are all the proxy's job — free.
4. Lower risk, no large dependency; the proxy is Tesla's own reference implementation.

A `Transport` seam keeps a library-backed transport swappable later. Sources: [vehicle-command](https://github.com/teslamotors/vehicle-command), [Fleet API vehicle-commands](https://developer.tesla.com/docs/fleet-api/endpoints/vehicle-commands), [Fleet auth/scopes](https://developer.tesla.com/docs/fleet-api/authentication/overview). Full decision record + ops runbook: `docs/operations/vehicle-commands.md`.

### Command registry

| `{name}` | Scope | Signed | Params |
|----------|-------|--------|--------|
| `door_lock`, `door_unlock` | `vehicle_cmds` | yes | — |
| `auto_conditioning_start`, `auto_conditioning_stop` | `vehicle_cmds` | yes | — |
| `set_temps` | `vehicle_cmds` | yes | `driver_temp` (req), `passenger_temp` (opt) |
| `charge_start`, `charge_stop` | `vehicle_charging_cmds` | yes | — |
| `set_charge_limit` | `vehicle_charging_cmds` | yes | `percent` 50–100 |
| `actuate_trunk` | `vehicle_cmds` | yes | `which_trunk` front\|rear |
| `remote_start_drive` | `vehicle_cmds` | yes | — |
| `honk_horn`, `flash_lights` | `vehicle_cmds` | yes | — |
| `navigation_gps_request` | `vehicle_cmds` | **no** | `lat`, `lon`, `order` (default 1) |
| `navigation_request` | `vehicle_cmds` | **no** | `value` (address / maps URL) |

### navigation_request finding for MYR-176

`navigation_request` is **not** an end-to-end-signed command — the vehicle-command proxy returns `ErrCommandUseRESTAPI` and forwards it **unsigned** to the Fleet API ("these endpoints require server-side processing"). For **lat/long dispatch (MYR-176)** the correct command is **`navigation_gps_request`** (`{lat, lon, order}`), also unsigned. Both are seeded; `navigation_request` (text/share, `share_ext_content_raw`) is kept for address/maps-link destinations. Scope for both: `vehicle_cmds`. Note there is **no `vehicle_remote_start` Fleet scope** (legacy Owner API) — `remote_start_drive` is `vehicle_cmds`.

### Scope gating, wake & session policy

- Scopes parsed from the owner's Tesla access-token `scp` claim; missing required scope → `403 permission_denied` **without calling Tesla**. Unparseable scopes → defer to Tesla.
- Asleep → bounded wake+retry (3 attempts, ~2s backoff); exhausted → transient `503 vehicle_asleep`. Counter/anti-replay error → one silent re-handshake retry (proxy owns the session cache); second → `502 command_failed`.
- Per-vehicle command cooldown (token bucket) → `429 rate_limited`.

### Error envelope

Three new REST-only shared-catalog codes: `key_not_paired` (403), `vehicle_asleep` (503, transient), `command_failed` (502) — added to `wserrors`, the reachability matrix, `schemas/ws-messages.schema.json`, and rest-api.md §4.1.1. `permission_denied` flips to emitted. No new stored data (params transit-only, never persisted/logged; VIN redacted) → no data-classification change.

### Key runbook (owner pairing, once ready)

Domain EC key (P-256) is the command-signing key: private half in the proxy (`TESLA_KEY_FILE_B64`), public half served at the existing `.well-known/appspecific/com.tesla.3p.public-key.pem` route (`TESLA_PUBLIC_KEY`). openssl keygen recipe in the runbook. Owner: wake vehicle → open `https://tesla.com/_ak/<domain>` → select vehicle, approve → tap key card. Until then every signer-required command returns `key_not_paired`; startup never crashes without the proxy/key.

### Tests (all green)

- `internal/commands`: `TestParseScopes`, `TestRegistrySeededCommands`, `TestBuildBodyValidation`, `TestExecute_*` (unknown command, scope-gating-without-transport, unknown-scopes-defer, key-not-paired-when-disabled, nav-fails-when-disabled, happy-path-forwards, wake-retry-then-success / exhausted / survives-wake-error, session-refresh-on-counter / exhausted, outcome mapping, invalid-params-before-transport, transport-error), `TestProxyTransport_*` (enabled, response mapping via httptest, wake). No live Tesla calls — faked transport + httptest proxy.
- `internal/telemetry`: `TestVehicleCommandHandler_*` (method, missing/invalid auth, ownership mismatch, not found, malformed body, success + VIN redaction, typed-error propagation, per-vehicle cooldown).
- `cmd/telemetry-server`: route-surface regression asserts the new POST route is mounted.

`go test ./...`, `go vet ./...`, `golangci-lint run ./...` — all green (store suite via colima; `tests/contract` schema conformance passes).

### MYR-176 and MYR-181–183 can now assume

- A `commands.Registry` + `Executor` behind a `Transport` seam; command name == Tesla name; add a command = one registry entry.
- `navigation_gps_request` is the lat/long dispatch command (unsigned, `vehicle_cmds`); MYR-176's `ride.accepted` seam should call it.
- Typed errors (`key_not_paired`, `vehicle_asleep`, `command_failed`, `permission_denied`) and the pre-pairing `key_not_paired` default are wired end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
