### PR TITLE
MYR-193: identity module — native Sign in with Apple + ES256 tokens + refresh rotation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,6 +12,36 @@ DATABASE_URL=postgres://postgres:dev@postgres:5432/myrobotaxi
 # Generate with: openssl rand -hex 32
 AUTH_SECRET=CHANGEME-run-openssl-rand-hex-32
 
+# ---- Identity module: Sign in with Apple + ES256 tokens (MYR-193, ADR-001) ---
+# The Go server mints its OWN access tokens (ES256, asymmetric) in addition to
+# accepting the legacy HS256 AUTH_SECRET tokens above. Setting the ES256 key
+# ENABLES the identity module (/api/auth/* + the JWKS endpoint); leaving it
+# unset keeps the server a pure HS256 validator.
+#
+# ES256 signing key (P-256 / prime256v1, PKCS#8 PEM). The identity module is
+# the ONLY holder of the private key; the public keys are published at
+# GET /api/auth/.well-known/jwks.json. Generate with:
+#   openssl ecparam -genkey -name prime256v1 -noout -out ec-private.pem
+#   openssl pkcs8 -topk8 -nocrypt -in ec-private.pem -out ec-private-pkcs8.pem
+# Then EITHER paste the PEM into AUTH_ES256_PRIVATE_KEY, OR base64-encode it
+# for Fly/containers (single line, no newlines):
+#   base64 -i ec-private-pkcs8.pem | tr -d '\n'   # -> AUTH_ES256_PRIVATE_KEY_B64
+# In --dev with neither set, an EPHEMERAL key is generated (loud warning);
+# tokens do not survive a restart. Production REQUIRES a static key (fail-fast).
+# AUTH_ES256_PRIVATE_KEY=
+# AUTH_ES256_PRIVATE_KEY_B64=
+#
+# Expected audience (`aud`) on Apple identity tokens — the native app's
+# bundle/service id. Unset disables the POST /api/auth/apple endpoint (refresh
+# / revoke / JWKS still serve).
+# APPLE_NATIVE_CLIENT_ID=app.myrobotaxi.ios
+#
+# First-sign-in bootstrap override (optional, defensive): binds a known user's
+# verified email to their existing user CUID even if email-match would miss
+# (e.g. an Apple private-relay address). Format: email=cuid[,email=cuid].
+# No secret — just a mapping. Example (the client's account):
+# AUTH_APPLE_BOOTSTRAP=owner@example.com=cmmgr4b1p0005l104ifpctlg8
+
 # ---- Encryption (NFR-3.23, NFR-3.24) -----------------------------------------
 # AES-256 key for column-level encryption. Required at startup.
 # Generate with: openssl rand -base64 32

--- a/cmd/telemetry-server/main.go
+++ b/cmd/telemetry-server/main.go
@@ -72,7 +72,7 @@ func main() {
 	}
 }
 
-func run() error { //nolint:funlen // composition root — sequential dependency wiring; helpers extracted to wiring.go
+func run() error { //nolint:funlen,cyclop // composition root — sequential dependency wiring; helpers extracted to wiring.go
 	// --- Flag parsing ---
 	var (
 		configPath = flag.String("config", "", "path to JSON configuration file")
@@ -308,8 +308,22 @@ func run() error { //nolint:funlen // composition root — sequential dependency
 
 	go hub.RunHeartbeat(ctx, cfg.WebSocket().HeartbeatInterval)
 
+	// --- Identity module keystore (MYR-193, ADR-001) ---
+	// The ES256 signing keystore backs both access-token minting and the
+	// dual-alg validator's ES256 verification. Nil => module disabled
+	// (HS256-only). Built before the authenticator so its public-key resolver
+	// can be injected into JWT validation.
+	keystore, err := buildKeystore(cfg, *devMode, logger)
+	if err != nil {
+		return fmt.Errorf("building identity keystore: %w", err)
+	}
+	var es256Resolver auth.ES256KeyResolver
+	if keystore != nil {
+		es256Resolver = keystore
+	}
+
 	// --- Client authenticator ---
-	authenticator := setupAuthenticator(cfg, db.Pool(), *devMode, logger)
+	authenticator := setupAuthenticator(cfg, db.Pool(), *devMode, es256Resolver, logger)
 
 	// --- vehicle_deleted cleanup pipeline (FR-10.1 / data-lifecycle.md §3.5, MYR-73) ---
 	// Postgres LISTEN/NOTIFY goroutine + dispatcher that fans the event
@@ -344,6 +358,12 @@ func run() error { //nolint:funlen // composition root — sequential dependency
 		originPatterns: originPatterns,
 		logger:         logger,
 	})
+
+	// --- Identity module endpoints (MYR-193, ADR-001) ---
+	// Native Sign in with Apple, ES256 access-token minting, refresh
+	// rotation, and the public JWKS at /api/auth/.well-known/jwks.json.
+	// No-op when the keystore is disabled.
+	setupIdentityEndpoints(cfg, srv, keystore, db.Pool(), logger)
 
 	// --- Tesla mTLS ---
 	if err := setupTeslaTLS(cfg, srv, logger); err != nil {

--- a/cmd/telemetry-server/wiring.go
+++ b/cmd/telemetry-server/wiring.go
@@ -151,11 +151,18 @@ func startPoolStatsCollector(ctx context.Context, db *store.DB, interval time.Du
 
 // setupAuthenticator returns a NoopAuthenticator in dev mode (accepts any
 // token) or a JWTAuthenticator wired against the auth secret + DB pool in
-// production mode.
-func setupAuthenticator(cfg *config.Config, dbPool *pgxpool.Pool, devMode bool, logger *slog.Logger) ws.Authenticator {
+// production mode. When es256 is non-nil the validator additionally accepts
+// ES256 tokens minted by the identity module (ADR-001 §3, dual-alg); legacy
+// HS256 acceptance is unchanged either way.
+func setupAuthenticator(cfg *config.Config, dbPool *pgxpool.Pool, devMode bool, es256 auth.ES256KeyResolver, logger *slog.Logger) ws.Authenticator {
 	if devMode {
 		logger.Warn("dev mode enabled: WebSocket auth disabled, accepting any token")
 		return &ws.NoopAuthenticator{}
+	}
+	var opts []auth.Option
+	if es256 != nil {
+		opts = append(opts, auth.WithES256Resolver(es256))
+		logger.Info("ES256 access-token validation enabled (identity module keystore)")
 	}
 	logger.Info("JWT authentication enabled for WebSocket clients")
 	return auth.NewJWTAuthenticator(
@@ -163,6 +170,7 @@ func setupAuthenticator(cfg *config.Config, dbPool *pgxpool.Pool, devMode bool, 
 		cfg.Auth().TokenIssuer,
 		cfg.Auth().TokenAudience,
 		dbPool,
+		opts...,
 	)
 }
 

--- a/cmd/telemetry-server/wiring_identity.go
+++ b/cmd/telemetry-server/wiring_identity.go
@@ -1,0 +1,78 @@
+package main
+
+import (
+	"log/slog"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/myrobotaxi/telemetry/internal/config"
+	"github.com/myrobotaxi/telemetry/internal/identity"
+	"github.com/myrobotaxi/telemetry/internal/server"
+)
+
+// buildKeystore constructs the identity module's ES256 keystore (ADR-001 §2).
+// Precedence: a static config key (production) wins; otherwise, in --dev, an
+// ephemeral key is generated with a loud warning; otherwise the module is
+// disabled and nil is returned (the server stays a pure HS256 validator).
+func buildKeystore(cfg *config.Config, devMode bool, logger *slog.Logger) (*identity.Keystore, error) {
+	if pem := cfg.Identity().ES256PrivateKeyPEM; pem != "" {
+		ks, err := identity.NewKeystoreFromPEM(pem)
+		if err != nil {
+			return nil, err
+		}
+		logger.Info("identity ES256 signing key loaded", slog.String("kid", ks.SigningKID()))
+		return ks, nil
+	}
+	if devMode {
+		ks, err := identity.NewEphemeralKeystore()
+		if err != nil {
+			return nil, err
+		}
+		logger.Warn("identity: DEV EPHEMERAL ES256 KEY — tokens do not survive restart; set AUTH_ES256_PRIVATE_KEY for a stable key",
+			slog.String("kid", ks.SigningKID()))
+		return ks, nil
+	}
+	logger.Warn("identity module disabled: AUTH_ES256_PRIVATE_KEY not set (Sign in with Apple + ES256 minting unavailable; HS256 validation unaffected)")
+	return nil, nil //nolint:nilnil // nil keystore + nil error is the documented "module disabled" signal
+}
+
+// setupIdentityEndpoints wires the identity module's /api/auth/* surface when
+// a keystore is present. The Apple sign-in endpoint additionally requires
+// APPLE_NATIVE_CLIENT_ID; when unset, /api/auth/apple 404s but refresh /
+// revoke / JWKS still serve (a deploy can rotate keys before Apple is live).
+func setupIdentityEndpoints(cfg *config.Config, srv *server.Server, keystore *identity.Keystore, pool *pgxpool.Pool, logger *slog.Logger) {
+	if keystore == nil {
+		return
+	}
+	idCfg := cfg.Identity()
+	appleEnabled := idCfg.AppleClientID != ""
+
+	minter := identity.NewTokenMinter(keystore, cfg.Auth().TokenIssuer, cfg.Auth().TokenAudience, idCfg.AccessTokenTTL)
+	appleValidator := identity.NewAppleValidator(idCfg.AppleClientID, "", nil)
+	svc := identity.NewService(identity.ServiceConfig{
+		Store:             identity.NewPgStore(pool),
+		Apple:             appleValidator,
+		Minter:            minter,
+		BootstrapEmailMap: idCfg.BootstrapEmailToCUID,
+		RefreshTTL:        idCfg.RefreshTokenTTL,
+		Logger:            logger.With(slog.String("component", "identity")),
+	})
+	handler := identity.NewHandler(identity.HandlerConfig{
+		Service:            svc,
+		Keystore:           keystore,
+		AppleEnabled:       appleEnabled,
+		RateLimitPerMinute: idCfg.AuthRateLimitPerMinute,
+		RateLimitBurst:     idCfg.AuthRateLimitBurst,
+		Logger:             logger.With(slog.String("component", "auth-endpoints")),
+	})
+
+	srv.HandleFunc("POST /api/auth/apple", handler.ServeApple)
+	srv.HandleFunc("POST /api/auth/refresh", handler.ServeRefresh)
+	srv.HandleFunc("POST /api/auth/revoke", handler.ServeRevoke)
+	srv.HandleFunc("GET /api/auth/.well-known/jwks.json", handler.ServeJWKS)
+
+	logger.Info("identity endpoints enabled",
+		slog.Bool("apple_sign_in", appleEnabled),
+		slog.String("jwks_kid", keystore.SigningKID()),
+	)
+}

--- a/docs/architecture/adr-001-identity-module.md
+++ b/docs/architecture/adr-001-identity-module.md
@@ -1,0 +1,208 @@
+# ADR-001: Identity as a bounded module in the Go telemetry server
+
+- Status: Accepted
+- Date: 2026-07-10
+- Deciders: Client (architecture review 2026-07-10), go-engineer, security
+- Linear: MYR-193
+- Supersedes: the `react-frontend` NextAuth-only login path (now DEPRECATED)
+
+## Context
+
+`react-frontend` (the original Next.js web app) is deprecated. The Go
+telemetry server is the production backend for MyRoboTaxi and is the only
+service that will be actively developed. The iOS app (native SwiftUI,
+MyRoboTaxi) needs a first-class authentication path that does not depend on
+a browser OAuth round-trip: native **Sign in with Apple**.
+
+Until now the server only *validated* tokens — it never *minted* them. The
+tokens were HS256 JWTs signed with the shared `AUTH_SECRET`, minted by the
+Next.js app (and, for the dev bench, by `sdk-testbench`'s `/api/backend-token`
+route). The shared-secret model is acceptable for a single trusted minter,
+but it does not scale to the server itself becoming an issuer: a symmetric
+secret held by both the verifier and every minter has no key-isolation story,
+and shipping the same secret to a public JWKS is impossible.
+
+We also must not break the live app: every existing browser client and the
+testbench continue to present HS256 tokens signed with `AUTH_SECRET`. Those
+MUST keep working unchanged during and after this change.
+
+The existing user records are keyed by Prisma CUIDs in the **shared Supabase
+Postgres** database (the same DB the Next.js app's Prisma schema owns). The
+client's own user CUID `cmmgr4b1p0005l104ifpctlg8` is referenced by his
+vehicles and rides; his Apple sign-in MUST resolve to that exact CUID.
+
+## Decision
+
+### 1. Identity is a strictly-bounded module, not a new service
+
+Identity lives in `internal/identity` as a **module inside the
+modular-monolith**, owning auth end-to-end:
+
+- its own tables under the CG-DL-9 `go_` namespace: `go_identity_apple`,
+  `go_refresh_tokens`, `go_users`;
+- its own signing-key secret class (the ES256 private key — see below),
+  never shared with any other module;
+- its own endpoints under `/api/auth/*`;
+- the rest of the app consumes only the **validated user identity** (a user
+  CUID string), exactly as it does today through
+  `auth.JWTAuthenticator.ValidateToken`.
+
+We deliberately did **not** split identity into a separate process. At v1
+scale (NFR-3.6: ~1,000 users) a separate IAM service would add a network
+hop, a second deploy, and a second Postgres connection pool for no benefit.
+The module boundary (package + table namespace + secret class) gives us the
+isolation that matters (blast radius, ownership, an extraction seam) without
+the operational cost. This mirrors the MYR-180 decision to reuse the
+existing `tesla-http-proxy` sidecar rather than embed the vehicle-command
+library: **isolate the secret, not necessarily the process.**
+
+**Split triggers** (when to extract `internal/identity` into its own
+service): (a) a second consumer service needs to validate tokens
+independently of this process; (b) auth traffic or blast-radius requires an
+independent deploy/scale cadence; (c) a compliance boundary (SOC2/PCI) forces
+process isolation of the credential store. None hold at v1.
+
+**First candidate for further isolation is NOT IAM.** The Tesla command
+signer — the P-256 key that signs vehicle commands — is already isolated in
+the `tesla-http-proxy` sidecar (MYR-180); it is the most security-sensitive
+key in the system and the natural first target for hardening (e.g. an HSM /
+KMS-backed signer). IAM's ES256 key is lower-blast-radius (a leaked signing
+key lets an attacker mint access tokens, but the refresh-token family
+reuse-detection and 1h access TTL bound the damage, and rotation via JWKS
+`kid` is cheap).
+
+### 2. Asymmetric access tokens (ES256) with a JWKS publication path
+
+New access tokens minted by this server are **ES256** (ECDSA P-256), with the
+signing `kid` in the JWT header. The public key(s) are published at
+`GET /api/auth/.well-known/jwks.json`. The identity module alone holds the
+private key.
+
+Rationale for ES256 over RS256: smaller keys and signatures (P-256 sig ≈ 64
+bytes vs RSA-2048 ≈ 256 bytes) — meaningful on watchOS/cellular (NFR-3.36) —
+and the same curve family Apple itself uses for its identity tokens, so we
+already carry ECDSA verification code.
+
+**Key provenance.** The private key is a config secret
+(`AUTH_ES256_PRIVATE_KEY`, PEM PKCS#8, base64-optional via
+`AUTH_ES256_PRIVATE_KEY_B64` for Fly). There is **no** generate-if-absent in
+production — a missing key is a fail-fast startup error. A DEBUG/dev
+fallback (`--dev`) generates an **ephemeral** P-256 key with a loud
+`WARN` log; tokens signed with it do not survive a restart, which is the
+intended dev behaviour. The `kid` is the RFC 7638 JWK SHA-256 thumbprint of
+the public key, so it is stable and derivable from the key alone.
+
+Generation recipe (runbook, also in the PR body and `.env.example`):
+
+```
+# P-256 private key, PKCS#8 PEM:
+openssl ecparam -genkey -name prime256v1 -noout -out ec-private.pem
+openssl pkcs8 -topk8 -nocrypt -in ec-private.pem -out ec-private-pkcs8.pem
+# For Fly / container env (single line, no newlines):
+base64 -i ec-private-pkcs8.pem | tr -d '\n'   # -> AUTH_ES256_PRIVATE_KEY_B64
+```
+
+### 3. One validator, dual-algorithm, algorithm pinned per token
+
+The server's existing JWT **validation** accepts BOTH:
+
+- **legacy HS256** — current shared-secret tokens (unchanged; the whole live
+  app depends on them); and
+- **new ES256** — verified against the locally-held keypair's public keys,
+  resolved by `kid`.
+
+There is exactly one validator (`auth.JWTAuthenticator.ValidateToken`), the
+single `Authenticator` used by both the WebSocket handler and every REST
+handler. The algorithm is **pinned per token by the header `alg` + `kid`**
+with strict allowlists, so the classic alg-confusion attacks are impossible:
+
+- valid methods are allowlisted to exactly `{HS256, ES256}` (`none` and every
+  other alg are rejected before the key callback runs);
+- the key callback is **type-driven**: an HMAC-typed token gets the
+  `[]byte` shared secret and *only* that; an ECDSA-typed token gets an
+  `*ecdsa.PublicKey` resolved by `kid` and *only* that. An attacker who takes
+  the published ES256 public key and signs an HS256 token with it as an HMAC
+  key fails, because the HS256 branch returns the real `AUTH_SECRET`, never
+  the public key; an attacker who presents an ES256 token cannot have it
+  verified with the HMAC secret, because the ECDSA branch requires an EC
+  public key;
+- `iss`/`aud`/`exp` are checked identically for both algs. Both the Next.js
+  minter and this server mint with `iss=myrobotaxi`, `aud=telemetry` (the
+  existing `AuthConfig` values), so the validator's issuer/audience checks are
+  uniform across algs.
+
+The ES256 public-key resolver is provided by the identity module's keystore
+and injected into the `JWTAuthenticator` at construction. When no ES256
+keystore is configured (e.g. legacy deploys), the validator silently remains
+HS256-only — ES256 tokens are simply rejected as "unknown kid".
+
+### 4. Linkage: same-DB email-match (topology finding)
+
+**Topology: the Go server and the Next.js app share ONE Supabase Postgres
+database.** Evidence: `CLAUDE.md` ("Same Supabase PostgreSQL as MyRoboTaxi
+Next.js app"); `internal/auth/jwt_auth.go` reads the Prisma-owned `"User"`
+and `"Vehicle"` tables directly; `sdk-testbench`'s `/api/backend-token`
+route resolves identity by querying the shared `"Account"` table
+(`(provider, providerAccountId) -> "User".id`) over the same `DATABASE_URL`;
+the Prisma `User` model (`react-frontend/prisma/schema.prisma`) declares
+`email String? @unique` and `emailVerified DateTime?`.
+
+Therefore, on first Apple sign-in for an unknown `apple_sub`, the module
+resolves the user in this precedence:
+
+1. **Bootstrap override** (`AUTH_APPLE_BOOTSTRAP` — a
+   `email=cuid[,email=cuid...]` map). A defensive, config-seeded safety net
+   so the client's first sign-in binds to `cmmgr4b1p0005l104ifpctlg8` even if
+   his Apple Relay email differs from his DB email. Documented, no secret.
+2. **Verified-email match** against the Prisma `"User"` table
+   (read-only `SELECT "id" FROM "User" WHERE "email" = $1`, and only when
+   Apple asserts `email_verified`). This is how a returning web user's Apple
+   sign-in binds to their existing CUID.
+3. **Fresh mint** into the Go-owned `go_users` table (a cuid-shaped id) for a
+   genuinely new user with no legacy row. `go_users` never writes to any
+   Prisma table (CG-DL-9); the user-existence check used by the validator is
+   widened to accept a CUID present in **either** `"User"` or `go_users`.
+
+The chosen `apple_sub -> user_id` binding is persisted once in
+`go_identity_apple` and reused on every subsequent sign-in — email is never
+re-matched after the first bind, so a later email change cannot silently
+re-point an Apple account. **We never write to Prisma-owned tables**
+(CG-DL-9); the legacy `"User"` table is read-only from Go.
+
+### 5. Refresh tokens: single-use rotation with family reuse-detection
+
+Refresh tokens are opaque 256-bit random strings. Only their SHA-256 hashes
+are stored (`go_refresh_tokens.token_hash` PK). Each token belongs to a
+**family** (`family_id`); a refresh is **single-use** and **rotates** to a new
+token in the same family. Presenting a token that has already been rotated (or
+one that is revoked) is treated as **theft**: the entire family is revoked and
+the caller gets `401`. The family has a **sliding 90-day** life — each
+rotation issues a token expiring `now + 90d`. `/api/auth/revoke` revokes the
+whole family.
+
+### 6. Audit without touching the Prisma AuditLog enum
+
+Auth events (sign-in, refresh, reuse-detection, revoke) are audit-logged via a
+dedicated structured `slog` audit logger inside the module — user id + event
+only, **no PII** (no email, name, token, or token hash). We deliberately do
+**not** write these to the Prisma-owned `"AuditLog"` table: its `action` enum
+is contract-owned (data-lifecycle.md §4.2) and restricted to the three
+system actions the Go server may insert (`drives_pruned`, `mask_applied`,
+`tokens_refreshed`); adding auth actions would be a cross-repo Prisma change
+(CG-DL-8) out of scope here, and would couple the identity module to a table
+it does not own. The in-module slog audit stream keeps identity's audit trail
+inside identity's boundary.
+
+## Consequences
+
+- The iOS app gets a native, browser-free sign-in and a long-lived refresh
+  session, consuming only `{accessToken, refreshToken, user}`.
+- The server becomes a token **issuer** with a clean key-isolation and
+  rotation story (JWKS `kid`), without a second process.
+- Legacy HS256 keeps working verbatim; there is no flag day.
+- New auth surface = new attack surface: mitigated by per-IP rate limiting on
+  the auth endpoints, hash-only refresh storage, family reuse-detection, a 1h
+  access TTL, and strict per-token algorithm pinning.
+- A future extraction of `internal/identity` into a standalone IAM service is
+  a package-move + a shared JWKS URL, not a redesign — the module boundary was
+  chosen with that seam in mind.

--- a/docs/architecture/migrations.md
+++ b/docs/architecture/migrations.md
@@ -37,10 +37,12 @@ Migration SQL files live in `internal/store/migrations/`:
 
 ```
 internal/store/migrations/
-  0001_init.up.sql      — bootstraps _telemetry_server_meta (placeholder)
-  0001_init.down.sql    — drops _telemetry_server_meta
-  NNNN_<name>.up.sql    — future migrations (sequential, zero-padded)
-  NNNN_<name>.down.sql  — rollback for each migration
+  0001_init.up.sql          — bootstraps _telemetry_server_meta (placeholder)
+  0001_init.down.sql        — drops _telemetry_server_meta
+  0002_ride_requests.up.sql — go_ride_requests (P10 ride-hailing, MYR-173)
+  0003_identity.up.sql      — go_users / go_identity_apple / go_refresh_tokens (MYR-193, ADR-001)
+  NNNN_<name>.up.sql        — future migrations (sequential, zero-padded)
+  NNNN_<name>.down.sql      — rollback for each migration
 ```
 
 The `migrationFiles` embed.FS in `internal/store/migrations.go` compiles all `*.sql` files into the binary at build time. No external migration files are required at runtime.

--- a/docs/contracts/data-classification.md
+++ b/docs/contracts/data-classification.md
@@ -234,6 +234,50 @@ The P10 ride-hailing aggregate (contracts `schemas/ride-request.schema.json`; FR
 
 > **Wire surface (MYR-174).** The rider-facing REST endpoints (`rest-api.md` §7.8) return the full `RideRequest` object — including the decrypted P1 `pickup`/`dropoff` coordinates + labels and the P1 passenger name/phone — but only to a **party** (rider or vehicle owner), over TLS, transported plaintext at the crypto boundary exactly like the vehicle-GPS REST paths (NFR-3.25). The reactive WS frames (`ride_request_created` / `ride_status_changed`, `websocket-protocol.md` §4.7–4.8) are **summary-only** and deliberately carry **none** of the P1 place/passenger data: they emit the P0 ids/status/timestamps plus the P1 `riderId` (an opaque user cuid, same tier + handling as `AuthOkPayload.userId`) and are **per-party unicast** (`Hub.SendToUsers`, never a vehicle-keyed broadcast). So the encrypted coordinates and PII never leave the server on the broadcast path — clients that need them refetch the party-only REST detail. Error-message construction on this surface uses opaque ids only (Rule CG-DC-2); the `409 conflict` / `404 not_found` reasons carry a status string or an id, never a coordinate/label/name.
 
+### 1.10 go_users table (Go-owned, MYR-193)
+
+Apple-native users minted by the identity module (ADR-001) who have no legacy Prisma `"User"` row. Created by `internal/store/migrations/0003_identity.up.sql` under the CG-DL-9 `go_` namespace.
+
+| Column | Type | Tier | Encrypt | Log-safe | Rationale |
+|--------|------|------|---------|----------|-----------|
+| `id` | `TEXT` (cuid) | P0 | No | Yes | User cuid — opaque internal identifier |
+| `email` | `TEXT?` | P1 | No | No | PII — verified email captured at first sign-in (nullable when Apple hides it) |
+| `name` | `TEXT?` | P1 | No | No | PII — display name from first sign-in |
+| `created_at` | `TIMESTAMPTZ` | P0 | No | Yes | Non-sensitive timestamp |
+| `updated_at` | `TIMESTAMPTZ` | P0 | No | Yes | Non-sensitive timestamp |
+
+### 1.11 go_identity_apple table (Go-owned, MYR-193)
+
+The authoritative `apple_sub -> user_id` binding, written once on first sign-in and reused verbatim thereafter (ADR-001 §4). Same `0003` migration.
+
+| Column | Type | Tier | Encrypt | Log-safe | Rationale |
+|--------|------|------|---------|----------|-----------|
+| `apple_sub` | `TEXT` | P0 | No | Yes | Apple's stable pseudonymous subject id — opaque, not PII |
+| `user_id` | `TEXT` (cuid) | P0 | No | Yes | Resolved user cuid (Prisma `"User".id` or `go_users.id`) — opaque |
+| `email` | `TEXT?` | P1 | No | No | PII — email captured at first sign-in |
+| `name` | `TEXT?` | P1 | No | No | PII — name captured at first sign-in |
+| `created_at` | `TIMESTAMPTZ` | P0 | No | Yes | Non-sensitive timestamp |
+| `last_login_at` | `TIMESTAMPTZ` | P0 | No | Yes | Non-sensitive timestamp |
+
+### 1.12 go_refresh_tokens table (Go-owned, MYR-193)
+
+Hash-only refresh-token store with single-use rotation and family reuse-detection (ADR-001 §5). Same `0003` migration. **The raw refresh token is never persisted** — only its SHA-256 digest — and access tokens are not stored at all.
+
+| Column | Type | Tier | Encrypt | Log-safe | Rationale |
+|--------|------|------|---------|----------|-----------|
+| `token_hash` | `TEXT` (sha256 hex) | P1 | No | No | Lookup key for a bearer credential — never logged. Storing only the one-way hash IS the protection (like a password hash), so no additional app-level encryption |
+| `family_id` | `TEXT` (cuid) | P0 | No | Yes | Rotation-lineage id — opaque |
+| `user_id` | `TEXT` (cuid) | P0 | No | Yes | Owning user cuid — opaque |
+| `issued_at` | `TIMESTAMPTZ` | P0 | No | Yes | Non-sensitive timestamp |
+| `expires_at` | `TIMESTAMPTZ` | P0 | No | Yes | Non-sensitive timestamp |
+| `rotated_from` | `TEXT?` (sha256 hex) | P1 | No | No | Previous token hash in the chain — same tier as `token_hash` |
+| `rotated_to` | `TEXT?` (sha256 hex) | P1 | No | No | Successor token hash — same tier as `token_hash` |
+| `revoked` | `BOOLEAN` | P0 | No | Yes | Non-sensitive flag |
+| `revoked_at` | `TIMESTAMPTZ?` | P0 | No | Yes | Non-sensitive timestamp |
+| `reason` | `TEXT?` (enum) | P0 | No | Yes | Lifecycle enum: `rotated`/`revoked`/`reuse_detected` |
+
+> **Token secrecy (MYR-193).** The ES256 access token and the raw refresh token are **P1** (credentials, same tier as `AuthPayload.token`). Neither is stored server-side (access tokens are stateless; refresh tokens are stored only as a SHA-256 hash). The identity module's auth audit trail (`slog`, ADR-001 §6) records the event + opaque user/family ids only — never an email, name, raw token, or token hash. The `/api/auth/*` error envelopes carry a generic `auth_failed` / `invalid_request` message with no PII and no reuse/linkage oracle (Rule CG-DC-2).
+
 ---
 
 ## 2. Redaction rules by tier

--- a/docs/contracts/rest-api.md
+++ b/docs/contracts/rest-api.md
@@ -140,6 +140,13 @@ The server's REST middleware MUST:
 
 The entire REST auth middleware is PLANNED; no REST auth middleware exists in the current server -- see §10 DV-19.
 
+**Dual-algorithm validation (MYR-193, ADR-001).** As of MYR-193 the single `Authenticator` accepts tokens signed with EITHER algorithm, pinned per token by the header `alg` + `kid` with a strict allowlist:
+
+- **HS256** — the legacy shared-secret tokens minted by the Next.js app / testbench with `AUTH_SECRET` (unchanged; the whole live app depends on them).
+- **ES256** — the new asymmetric access tokens minted by the Go server's own identity module (`internal/identity`), verified against the local keypair's public keys resolved by the token's `kid`. The public keys are published at `GET /api/auth/.well-known/jwks.json` (§7.10).
+
+Both carry `iss=myrobotaxi`, `aud=telemetry`, `sub=<user CUID>`, so issuer/audience/expiry checks are identical across algorithms. The key callback is type-driven — an HMAC-typed token only ever receives the shared secret, an ECDSA-typed token only ever receives an EC public key — so algorithm-confusion attacks (e.g. signing an HS256 token with the published ES256 public key as the HMAC key) are rejected. The fail-closed user-existence check (§3.2 step 4, FR-10.1) now accepts a `sub` present in EITHER the Prisma `"User"` table OR the Go-owned `go_users` table (Apple-native users have no legacy Prisma row).
+
 ### 3.3 Auth failure and retry (FR-6.2)
 
 When the SDK receives an HTTP response whose status code is `401`:
@@ -285,6 +292,8 @@ When the cap is breached the server returns `429 rate_limited` with the standard
 The REST rate limit is **independent** of the WebSocket `MaxConnectionsPerUser` per-user concurrent-connection cap (WS DV-08). A user may have 5 open WebSocket sessions AND 120 REST requests/min simultaneously. This is intentional: the two limits protect different exhaustion modes (concurrent holdings vs request flood).
 
 Unlike the WebSocket `rate_limited` error, REST `rate_limited` in v1 does **not** emit a `subCode: device_cap` -- `device_cap` is specific to the per-user concurrent-connection cap on the WS path. REST rate-limit breaches surface to the UI as a generic "too many requests" signal; per-device UX messaging is not part of v1 REST.
+
+**Pre-auth cap on `/api/auth/*` (MYR-193, IMPLEMENTED).** The identity endpoints (§7.10) cannot use the per-user cap above — they run *before* a user is authenticated. They are instead protected by a **per-IP token-bucket** limit (default 30 req/min, burst 10; configurable via `identity.auth_rate_limit_per_minute` / `identity.auth_rate_limit_burst`), keyed on the leftmost `X-Forwarded-For` entry (the edge appends). On breach the server returns `429 rate_limited` with a `Retry-After` header — the same envelope and SDK backoff behaviour as above. This guards the sign-in / refresh surface against credential spraying and refresh-token brute force.
 
 ### 4.2 Pagination
 
@@ -531,8 +540,14 @@ No contract changes are required for the new role's wire shape (the REST respons
 | `POST` | `/api/ride-requests/{id}/accept` | Owner accepts a `requested` ride (emits the MYR-176 dispatch seam) | Bearer (owner) | FR-9.3 |
 | `POST` | `/api/ride-requests/{id}/decline` | Owner declines a `requested` ride | Bearer (owner) | FR-9.3 |
 | `POST` | `/api/vehicles/{vehicleId}/command/{name}` | Send a Tesla vehicle command (P11 actuation + P10 dispatch) | Bearer + owner of vehicleId | FR-11.x, NFR-3.21 |
+| `POST` | `/api/auth/apple` | Native Sign in with Apple → ES256 access + refresh pair | None (pre-auth; per-IP rate-limited) | FR-6.1, MYR-193 |
+| `POST` | `/api/auth/refresh` | Single-use refresh-token rotation | Refresh token in body (pre-auth; per-IP rate-limited) | FR-6.2, MYR-193 |
+| `POST` | `/api/auth/revoke` | Revoke a refresh-token family (sign-out) | Refresh token in body (pre-auth; per-IP rate-limited) | MYR-193 |
+| `GET` | `/api/auth/.well-known/jwks.json` | Public ES256 verification keys (JWKS) | None (public) | MYR-193 |
 
 The `POST`/`GET /api/ride-requests[...]` rows (§7.8) are the P10 ride-hailing surface: the four rider-facing endpoints are mounted as of MYR-174 and the three owner-facing endpoints (incoming feed + accept/decline) as of MYR-175. The dispatch/live-tracking transitions remain with MYR-176/177 and the reschedule endpoints with MYR-192.
+
+The `/api/auth/*` rows (§7.10) are the identity module's auth surface (MYR-193, ADR-001 `docs/architecture/adr-001-identity-module.md`): native Sign in with Apple, ES256 access-token minting with a published JWKS, and rotating refresh tokens. Unlike every other row, these are **pre-authentication** endpoints (they mint or rotate the very credential the others require), so they are not Bearer-gated — they are protected by a per-IP token-bucket rate limit instead (§4.1.2).
 
 `GET /api/vehicles` (§7.0) is mounted by the Go server as of MYR-91 (2026-05-10). `GET /api/vehicles/{vehicleId}/snapshot` (§7.1) and `GET /api/vehicles/{vehicleId}/drives` (§7.2) are mounted as of MYR-133 (2026-06-03). `GET /api/drives/{driveId}/route` (§7.4) is mounted as of PR #260 (DV-20), and `GET /api/drives/{driveId}` (§7.3) as of MYR-130 (2026-07-02) — DV-20 is fully RESOLVED (see §10). `GET /api/users/me/export` (and the §7.6 / §7.5 endpoints) is served by the Next.js app per §10 DV-23 and is NOT in scope for the Go server's DV-20 mount.
 
@@ -1464,6 +1479,97 @@ The VIN is redacted to the last 4 (P0 rule; the full VIN never leaves the server
 #### Pre-pairing behavior (MYR-115 not yet done)
 
 Until the owner pairs the virtual key, every **signer-required** command resolves to `403 key_not_paired`. The endpoint is always mounted (never a 404) and nothing crashes when the proxy/key is absent; when `TESLA_PROXY_URL` is unset the server logs a clear "signing disabled" line at startup and returns `key_not_paired`.
+### 7.10 Authentication (identity module — MYR-193)
+
+> **Anchored:** FR-6.1, FR-6.2, MYR-193. Design record: `docs/architecture/adr-001-identity-module.md`.
+
+The identity module (`internal/identity`) is the server's own token issuer. These endpoints are **pre-authentication** (no Bearer header) and are protected by a per-IP rate limit (§4.1.2). All bodies are `application/json`. Errors use the standard envelope (§4.1); auth failures collapse to `401 auth_failed` with a generic message — there is no reuse/linkage oracle and no PII in any error.
+
+The endpoints are mounted only when an ES256 signing key is configured (`AUTH_ES256_PRIVATE_KEY`); `POST /api/auth/apple` additionally requires `APPLE_NATIVE_CLIENT_ID` and otherwise returns `404 not_found`.
+
+#### 7.10.1 `POST /api/auth/apple`
+
+Validate a native Sign in with Apple identity token and issue a token pair.
+
+**Request**
+
+```
+POST /api/auth/apple
+Content-Type: application/json
+```
+
+| Field | Type | Required | Notes |
+|-------|------|----------|-------|
+| `identityToken` | string | Yes | The Apple identity token (JWT) from `ASAuthorizationAppleIDCredential.identityToken`. |
+| `fullName` | string | No | Apple returns the name only on the first authorization; the client forwards it so it can be persisted on first sign-in. |
+| `email` | string | No | Advisory only — the server links on the token's verified-email claim, never this field. |
+| `nonce` | string | No | If present, must equal the token's `nonce` claim. |
+
+Server validation: RS256 signature against Apple's JWKS (`https://appleid.apple.com/auth/keys`, cached with `kid` rotation), `iss=https://appleid.apple.com`, `aud=APPLE_NATIVE_CLIENT_ID`, `exp`/`iat`. The user is resolved (and bound on first sign-in) per ADR-001 §4: existing `apple_sub` binding → config bootstrap override → verified-email match against `"User"` → fresh `go_users` mint.
+
+**Response — 200 OK**
+
+```json
+{
+  "accessToken": "<ES256 JWT>",
+  "expiresIn": 3600,
+  "refreshToken": "<opaque>",
+  "user": { "id": "cmmgr4b1p0005l104ifpctlg8", "name": "Ada Lovelace", "email": "ada@example.com" }
+}
+```
+
+| Field | Type | Classification | Notes |
+|-------|------|----------------|-------|
+| `accessToken` | string | P1 | ES256 JWT, `sub`=user CUID, `iss=myrobotaxi`, `aud=telemetry`, ~1h. Use as the Bearer token everywhere else. |
+| `expiresIn` | integer | P0 | Access-token lifetime in seconds. |
+| `refreshToken` | string | P1 | Opaque single-use token; store securely (Keychain), send only to `/api/auth/refresh` \| `/revoke`. |
+| `user.id` | string | P0 | User CUID. |
+| `user.name` / `user.email` | string | P1 | Present when known; omitted otherwise. |
+
+**Response — error**
+
+| HTTP | `error.code` | When |
+|------|--------------|------|
+| 400 | `invalid_request` | Missing `identityToken`, malformed / unknown-field body |
+| 401 | `auth_failed` | Apple token invalid (signature/iss/aud/exp/nonce) |
+| 404 | `not_found` | Apple sign-in not enabled (`APPLE_NATIVE_CLIENT_ID` unset) |
+| 429 | `rate_limited` | Per-IP cap exceeded |
+
+#### 7.10.2 `POST /api/auth/refresh`
+
+Rotate a refresh token (single-use). Presenting a spent or revoked token is treated as theft: the whole family is revoked (`401`).
+
+**Request** — `{ "refreshToken": "<opaque>" }`
+
+**Response — 200 OK** — same shape as §7.9.1 (a fresh `accessToken` + a new `refreshToken`; `user` carries at least `id`). The previous refresh token is now invalid.
+
+**Response — error**
+
+| HTTP | `error.code` | When |
+|------|--------------|------|
+| 400 | `invalid_request` | Missing `refreshToken` / malformed body |
+| 401 | `auth_failed` | Unknown, expired, spent, or revoked token (reuse revokes the family) |
+| 429 | `rate_limited` | Per-IP cap exceeded |
+
+#### 7.10.3 `POST /api/auth/revoke`
+
+Revoke the refresh-token family a token belongs to (sign-out on this device lineage).
+
+**Request** — `{ "refreshToken": "<opaque>" }`
+
+**Response — 204 No Content** — always, for a well-formed request, whether or not the token existed (no existence oracle). `400 invalid_request` for a missing field; `429 rate_limited` on cap breach.
+
+#### 7.10.4 `GET /api/auth/.well-known/jwks.json`
+
+Public JSON Web Key Set (RFC 7517) of the ES256 verification keys. Public, cacheable (`Cache-Control: public, max-age=3600`). Consumers resolve an access token's `kid` header to a key here to verify the signature.
+
+**Response — 200 OK**
+
+```json
+{ "keys": [ { "kty": "EC", "crv": "P-256", "x": "<b64url>", "y": "<b64url>", "use": "sig", "alg": "ES256", "kid": "<thumbprint>" } ] }
+```
+
+All JWKS fields are P0 (public by definition). The `kid` is the RFC 7638 thumbprint of the key.
 
 ---
 

--- a/internal/auth/dual_alg.go
+++ b/internal/auth/dual_alg.go
@@ -1,0 +1,72 @@
+package auth
+
+import (
+	"crypto/ecdsa"
+	"fmt"
+
+	"github.com/golang-jwt/jwt/v5"
+)
+
+// ES256KeyResolver resolves an ES256 verification public key by its `kid`
+// header. It is the consumer-site view of the identity module's keystore
+// (identity.Keystore.PublicKey satisfies it). Injected into the
+// JWTAuthenticator so the single validator can verify BOTH legacy HS256
+// (shared-secret) tokens AND new ES256 (locally-minted) tokens — the
+// dual-algorithm validation of ADR-001 §3.
+type ES256KeyResolver interface {
+	PublicKey(kid string) (*ecdsa.PublicKey, bool)
+}
+
+// Option configures a JWTAuthenticator at construction.
+type Option func(*JWTAuthenticator)
+
+// WithES256Resolver enables ES256 verification against the given resolver.
+// When unset, the validator remains HS256-only and rejects ES256 tokens.
+func WithES256Resolver(r ES256KeyResolver) Option {
+	return func(a *JWTAuthenticator) { a.es256 = r }
+}
+
+// validMethods returns the algorithm allowlist for this authenticator. HS256
+// is always allowed (legacy shared-secret tokens); ES256 is added only when
+// an ES256 resolver is configured. `none` and every other alg are rejected
+// by jwt.WithValidMethods before the key callback runs.
+func (a *JWTAuthenticator) validMethods() []string {
+	if a.es256 != nil {
+		return []string{"HS256", "ES256"}
+	}
+	return []string{"HS256"}
+}
+
+// keyFunc is the type-driven jwt key callback that pins the key material to
+// the token's signing-method TYPE, making alg-confusion impossible:
+//
+//   - an HMAC-typed token gets the []byte shared secret and only that (an
+//     attacker who signs an HS256 token with the published ES256 public key
+//     as the HMAC key fails — this branch returns AUTH_SECRET, never a public
+//     key);
+//   - an ECDSA-typed token gets an *ecdsa.PublicKey resolved by `kid` and
+//     only that (an ES256 token can never be verified with the HMAC secret).
+func (a *JWTAuthenticator) keyFunc(t *jwt.Token) (any, error) {
+	switch t.Method.(type) {
+	case *jwt.SigningMethodHMAC:
+		return a.secret, nil
+	case *jwt.SigningMethodECDSA:
+		if a.es256 == nil {
+			return nil, fmt.Errorf("ES256 not enabled: %v", t.Header["alg"])
+		}
+		if t.Method.Alg() != "ES256" {
+			return nil, fmt.Errorf("unsupported ECDSA algorithm: %v", t.Method.Alg())
+		}
+		kid, _ := t.Header["kid"].(string)
+		if kid == "" {
+			return nil, fmt.Errorf("ES256 token missing kid header")
+		}
+		pub, ok := a.es256.PublicKey(kid)
+		if !ok {
+			return nil, fmt.Errorf("unknown kid: %s", kid)
+		}
+		return pub, nil
+	default:
+		return nil, fmt.Errorf("unexpected signing method: %v", t.Header["alg"])
+	}
+}

--- a/internal/auth/dual_alg_test.go
+++ b/internal/auth/dual_alg_test.go
@@ -1,0 +1,171 @@
+package auth
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"testing"
+	"time"
+
+	"github.com/golang-jwt/jwt/v5"
+)
+
+// fakeES256Resolver resolves a single kid to a public key.
+type fakeES256Resolver struct {
+	kid string
+	pub *ecdsa.PublicKey
+}
+
+func (f fakeES256Resolver) PublicKey(kid string) (*ecdsa.PublicKey, bool) {
+	if kid == f.kid {
+		return f.pub, true
+	}
+	return nil, false
+}
+
+// signES256 signs a token with the given ECDSA key and kid header.
+func signES256(t *testing.T, key *ecdsa.PrivateKey, kid string, claims jwt.MapClaims) string {
+	t.Helper()
+	tok := jwt.NewWithClaims(jwt.SigningMethodES256, claims)
+	if kid != "" {
+		tok.Header["kid"] = kid
+	}
+	signed, err := tok.SignedString(key)
+	if err != nil {
+		t.Fatalf("signES256: %v", err)
+	}
+	return signed
+}
+
+func es256Claims() jwt.MapClaims {
+	return jwt.MapClaims{
+		"sub": "cmmgr4b1p0005l104ifpctlg8",
+		"iss": "myrobotaxi",
+		"aud": "telemetry",
+		"iat": time.Now().Add(-time.Minute).Unix(),
+		"exp": time.Now().Add(time.Hour).Unix(),
+	}
+}
+
+// TestDualAlg_HS256StillWorks asserts legacy HS256 acceptance is unchanged
+// when an ES256 resolver is also configured.
+func TestDualAlg_HS256StillWorks(t *testing.T) {
+	key, _ := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	a := &JWTAuthenticator{
+		secret: []byte(testSecret),
+		issuer: "myrobotaxi", audience: "telemetry",
+		es256: fakeES256Resolver{kid: "k1", pub: &key.PublicKey},
+	}
+	token := signToken(t, testSecret, jwt.MapClaims{
+		"sub": "cuser", "iss": "myrobotaxi", "aud": "telemetry",
+		"exp": time.Now().Add(time.Hour).Unix(),
+	})
+	got, err := a.ValidateToken(context.Background(), token)
+	if err != nil {
+		t.Fatalf("HS256 rejected under dual-alg: %v", err)
+	}
+	if got != "cuser" {
+		t.Errorf("sub = %q", got)
+	}
+}
+
+// TestDualAlg_ES256Accepted asserts a valid ES256 token verifies via the kid
+// resolver.
+func TestDualAlg_ES256Accepted(t *testing.T) {
+	key, _ := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	a := &JWTAuthenticator{
+		secret: []byte(testSecret),
+		issuer: "myrobotaxi", audience: "telemetry",
+		es256: fakeES256Resolver{kid: "k1", pub: &key.PublicKey},
+	}
+	token := signES256(t, key, "k1", es256Claims())
+	got, err := a.ValidateToken(context.Background(), token)
+	if err != nil {
+		t.Fatalf("valid ES256 rejected: %v", err)
+	}
+	if got != "cmmgr4b1p0005l104ifpctlg8" {
+		t.Errorf("sub = %q", got)
+	}
+}
+
+// TestDualAlg_ES256RejectedWhenDisabled asserts that without a resolver, ES256
+// tokens are rejected (HS256-only legacy behaviour).
+func TestDualAlg_ES256RejectedWhenDisabled(t *testing.T) {
+	key, _ := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	a := &JWTAuthenticator{secret: []byte(testSecret), issuer: "myrobotaxi", audience: "telemetry"}
+	token := signES256(t, key, "k1", es256Claims())
+	if _, err := a.ValidateToken(context.Background(), token); err == nil {
+		t.Fatal("ES256 token accepted with no resolver configured")
+	}
+}
+
+// TestDualAlg_UnknownKidRejected asserts a valid ES256 signature with an
+// unknown kid is rejected.
+func TestDualAlg_UnknownKidRejected(t *testing.T) {
+	key, _ := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	a := &JWTAuthenticator{
+		secret: []byte(testSecret),
+		issuer: "myrobotaxi", audience: "telemetry",
+		es256: fakeES256Resolver{kid: "k1", pub: &key.PublicKey},
+	}
+	token := signES256(t, key, "k-other", es256Claims())
+	if _, err := a.ValidateToken(context.Background(), token); err == nil {
+		t.Fatal("token with unknown kid accepted")
+	}
+}
+
+// TestDualAlg_MissingKidRejected asserts an ES256 token with no kid header is
+// rejected (we require kid to select the verification key).
+func TestDualAlg_MissingKidRejected(t *testing.T) {
+	key, _ := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	a := &JWTAuthenticator{
+		secret: []byte(testSecret),
+		issuer: "myrobotaxi", audience: "telemetry",
+		es256: fakeES256Resolver{kid: "k1", pub: &key.PublicKey},
+	}
+	token := signES256(t, key, "", es256Claims())
+	if _, err := a.ValidateToken(context.Background(), token); err == nil {
+		t.Fatal("ES256 token without kid accepted")
+	}
+}
+
+// TestDualAlg_AlgConfusion_PublicKeyAsHMAC is the core security assertion: an
+// attacker takes the published ES256 public key and forges an HS256 token
+// using the key's marshaled bytes as the HMAC secret. It MUST be rejected —
+// the HMAC branch returns the real AUTH_SECRET, never the public key.
+func TestDualAlg_AlgConfusion_PublicKeyAsHMAC(t *testing.T) {
+	key, _ := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	a := &JWTAuthenticator{
+		secret: []byte(testSecret),
+		issuer: "myrobotaxi", audience: "telemetry",
+		es256: fakeES256Resolver{kid: "k1", pub: &key.PublicKey},
+	}
+	// Forge HS256 using the public key's X bytes as the HMAC key.
+	forged := signToken(t, string(key.X.Bytes()), jwt.MapClaims{
+		"sub": "attacker", "iss": "myrobotaxi", "aud": "telemetry",
+		"exp": time.Now().Add(time.Hour).Unix(),
+	})
+	if _, err := a.ValidateToken(context.Background(), forged); err == nil {
+		t.Fatal("alg-confusion (public key as HMAC secret) was accepted")
+	}
+}
+
+// TestDualAlg_NoneRejected asserts the "none" algorithm is rejected under the
+// method allowlist.
+func TestDualAlg_NoneRejected(t *testing.T) {
+	key, _ := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	a := &JWTAuthenticator{
+		secret: []byte(testSecret),
+		issuer: "myrobotaxi", audience: "telemetry",
+		es256: fakeES256Resolver{kid: "k1", pub: &key.PublicKey},
+	}
+	tok := jwt.NewWithClaims(jwt.SigningMethodNone, es256Claims())
+	unsigned, err := tok.SignedString(jwt.UnsafeAllowNoneSignatureType)
+	if err != nil {
+		t.Fatalf("build none token: %v", err)
+	}
+	if _, err := a.ValidateToken(context.Background(), unsigned); err == nil {
+		t.Fatal("none-alg token accepted")
+	}
+}

--- a/internal/auth/jwt_auth.go
+++ b/internal/auth/jwt_auth.go
@@ -27,12 +27,15 @@ var (
 // the Prisma-owned "Vehicle" table.
 const queryUserVehicleIDs = `SELECT "id" FROM "Vehicle" WHERE "userId" = $1`
 
-// queryUserExists is a slim row-existence probe against the
-// Prisma-owned "User" table, used by the FR-10.1 fail-closed JWT
-// existence check (data-lifecycle.md §3.5, MYR-73). SELECT 1 + LIMIT
-// 1 lets Postgres short-circuit on the primary-key index without
-// pulling any data columns.
-const queryUserExists = `SELECT 1 FROM "User" WHERE "id" = $1 LIMIT 1`
+// queryUserExists is a slim row-existence probe used by the FR-10.1
+// fail-closed JWT existence check (data-lifecycle.md §3.5, MYR-73). A user
+// is "live" if a row exists in EITHER the Prisma-owned "User" table (web /
+// Google users) OR the Go-owned go_users table (Apple-native users minted by
+// the identity module, MYR-193 — they have no legacy Prisma row). Both EXISTS
+// sub-probes hit a primary-key index, so this stays a microsecond lookup.
+// The query returns one row when the user exists and zero rows otherwise, so
+// UserExists's pgx.ErrNoRows handling is unchanged.
+const queryUserExists = `SELECT 1 WHERE EXISTS (SELECT 1 FROM "User" WHERE "id" = $1) OR EXISTS (SELECT 1 FROM go_users WHERE "id" = $1)`
 
 // queryVehicleOwnerByID fetches the owning user ID for a vehicle. Used
 // by ResolveRole to determine whether the caller is the owner of the
@@ -44,12 +47,15 @@ const queryVehicleOwnerByID = `SELECT "userId" FROM "Vehicle" WHERE "id" = $1`
 // user's vehicle IDs from the database. It caches vehicle lookups to
 // avoid hitting the DB on every WebSocket reconnect.
 type JWTAuthenticator struct {
-	secret           []byte
-	issuer           string
-	audience         string
-	cache            *vehicleCache
-	ownerLookup      vehicleOwnerLookup
-	userExistsCache  *userExistenceCache
+	secret          []byte
+	issuer          string
+	audience        string
+	cache           *vehicleCache
+	ownerLookup     vehicleOwnerLookup
+	userExistsCache *userExistenceCache
+	// es256 optionally verifies ES256 tokens minted by the identity module
+	// (ADR-001 §3). Nil => HS256-only (legacy behaviour, unchanged).
+	es256 ES256KeyResolver
 }
 
 // Compile-time interface check.
@@ -71,13 +77,15 @@ type vehicleOwnerLookup interface {
 	GetVehicleOwnerByID(ctx context.Context, vehicleID string) (ownerID string, err error)
 }
 
-// NewJWTAuthenticator creates an authenticator that verifies HS256 JWTs
-// using the given secret and queries the pool for vehicle ownership.
-// Issuer and audience are validated if non-empty.
-func NewJWTAuthenticator(secret, issuer, audience string, pool *pgxpool.Pool) *JWTAuthenticator {
+// NewJWTAuthenticator creates an authenticator that verifies JWTs using the
+// given HS256 secret and queries the pool for vehicle ownership. Issuer and
+// audience are validated if non-empty. Pass WithES256Resolver to additionally
+// accept ES256 tokens minted by the identity module (ADR-001 §3); without it
+// the validator is HS256-only and unchanged.
+func NewJWTAuthenticator(secret, issuer, audience string, pool *pgxpool.Pool, opts ...Option) *JWTAuthenticator {
 	querier := &pgVehicleQuerier{pool: pool}
 	existenceQuerier := &pgUserExistenceQuerier{pool: pool}
-	return &JWTAuthenticator{
+	a := &JWTAuthenticator{
 		secret:          []byte(secret),
 		issuer:          issuer,
 		audience:        audience,
@@ -85,16 +93,22 @@ func NewJWTAuthenticator(secret, issuer, audience string, pool *pgxpool.Pool) *J
 		ownerLookup:     querier,
 		userExistsCache: newUserExistenceCache(existenceQuerier, userExistenceTTL),
 	}
+	for _, opt := range opts {
+		opt(a)
+	}
+	return a
 }
 
-// ValidateToken parses and verifies an HS256 JWT, checks expiration, and
-// returns the user ID from the "sub" claim.
+// ValidateToken parses and verifies a JWT — legacy HS256 (shared secret) or,
+// when an ES256 resolver is configured, ES256 (identity-module keypair,
+// resolved by `kid`) — with the algorithm pinned per token (ADR-001 §3). It
+// checks issuer/audience/expiry and returns the user ID from the "sub" claim.
 func (a *JWTAuthenticator) ValidateToken(ctx context.Context, token string) (string, error) {
 	if token == "" {
 		return "", fmt.Errorf("auth.ValidateToken: %w", ErrInvalidToken)
 	}
 
-	opts := []jwt.ParserOption{jwt.WithValidMethods([]string{"HS256"})}
+	opts := []jwt.ParserOption{jwt.WithValidMethods(a.validMethods())}
 	if a.issuer != "" {
 		opts = append(opts, jwt.WithIssuer(a.issuer))
 	}
@@ -102,12 +116,7 @@ func (a *JWTAuthenticator) ValidateToken(ctx context.Context, token string) (str
 		opts = append(opts, jwt.WithAudience(a.audience))
 	}
 
-	parsed, err := jwt.Parse(token, func(t *jwt.Token) (any, error) {
-		if _, ok := t.Method.(*jwt.SigningMethodHMAC); !ok {
-			return nil, fmt.Errorf("unexpected signing method: %v", t.Header["alg"])
-		}
-		return a.secret, nil
-	}, opts...)
+	parsed, err := jwt.Parse(token, a.keyFunc, opts...)
 
 	if err != nil {
 		return "", fmt.Errorf("auth.ValidateToken: %w: %w", ErrInvalidToken, err)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -16,6 +16,7 @@ type Config struct {
 	drives         DrivesConfig
 	websocket      WebSocketConfig
 	auth           AuthConfig
+	identity       IdentityConfig
 	proxy          ProxyConfig
 	teslaOAuth     TeslaOAuthConfig
 	monitoring     MonitoringConfig
@@ -103,6 +104,43 @@ type AuthConfig struct {
 	TokenAudience string
 }
 
+// IdentityConfig holds settings for the internal/identity module (MYR-193,
+// ADR-001): native Sign in with Apple, ES256 access-token minting, and
+// rotating refresh tokens. Secrets (the ES256 private key) come from the
+// environment; the operational knobs (TTLs, rate limit) come from the JSON
+// file. The module is ENABLED at wiring time when an ES256 signing key is
+// available (a config key in prod, or an ephemeral dev key) AND an Apple
+// client id is configured.
+type IdentityConfig struct {
+	// ES256PrivateKeyPEM is the PKCS#8 PEM of the P-256 private key used to
+	// sign access tokens. Secret — from AUTH_ES256_PRIVATE_KEY(_B64). Empty
+	// means "no static key"; in --dev the wiring generates an ephemeral one.
+	ES256PrivateKeyPEM string
+
+	// AppleClientID is the expected `aud` on Apple identity tokens — the
+	// native app's Service/Bundle id (APPLE_NATIVE_CLIENT_ID,
+	// e.g. app.myrobotaxi.ios). Empty disables the Apple sign-in endpoint.
+	AppleClientID string
+
+	// BootstrapEmailToCUID is a config-seeded first-sign-in override
+	// (AUTH_APPLE_BOOTSTRAP) mapping a verified email to an existing user
+	// CUID, so a known user's first Apple sign-in binds to the right CUID
+	// even if email-match would miss (e.g. Apple private-relay address).
+	BootstrapEmailToCUID map[string]string
+
+	// AccessTokenTTL is the lifetime of a minted ES256 access token (~1h).
+	AccessTokenTTL time.Duration
+
+	// RefreshTokenTTL is the sliding refresh-family lifetime (~90d): each
+	// rotation issues a refresh token expiring now + RefreshTokenTTL.
+	RefreshTokenTTL time.Duration
+
+	// AuthRateLimitPerMinute is the per-IP request cap on the /api/auth/*
+	// endpoints (brute-force protection). Burst is AuthRateLimitBurst.
+	AuthRateLimitPerMinute int
+	AuthRateLimitBurst     int
+}
+
 // ProxyConfig holds settings for the Tesla Fleet API proxy (tesla-http-proxy).
 // All fields are optional — when URL is empty, the fleet config push endpoint
 // is disabled.
@@ -143,6 +181,9 @@ func (c *Config) WebSocket() WebSocketConfig { return c.websocket }
 
 // Auth returns the authentication configuration.
 func (c *Config) Auth() AuthConfig { return c.auth }
+
+// Identity returns the identity-module configuration (MYR-193, ADR-001).
+func (c *Config) Identity() IdentityConfig { return c.identity }
 
 // Proxy returns the Tesla Fleet API proxy configuration. When URL is empty,
 // the fleet config push feature is unavailable.

--- a/internal/config/defaults.go
+++ b/internal/config/defaults.go
@@ -95,6 +95,27 @@ func applyAuthDefaults(a *fileAuthConfig) {
 	}
 }
 
+func applyIdentityDefaults(i *fileIdentityConfig) {
+	if i.AccessTokenTTL.Dur() == 0 {
+		// 1h access-token lifetime (ADR-001 §5, MYR-193). Short enough that a
+		// leaked access token is bounded; the refresh token (sliding 90d)
+		// carries the long-lived session.
+		i.AccessTokenTTL = Duration{d: time.Hour}
+	}
+	if i.RefreshTokenTTL.Dur() == 0 {
+		// 90d sliding refresh-family life — each rotation re-anchors it.
+		i.RefreshTokenTTL = Duration{d: 90 * 24 * time.Hour}
+	}
+	if i.AuthRateLimitPerMinute == 0 {
+		// Per-IP cap on /api/auth/*: brute-force protection on the
+		// pre-authentication surface. 30/min ≈ 0.5 req/s sustained.
+		i.AuthRateLimitPerMinute = 30
+	}
+	if i.AuthRateLimitBurst == 0 {
+		i.AuthRateLimitBurst = 10
+	}
+}
+
 func applyProxyDefaults(p *fileProxyConfig) {
 	if p.FleetTelemetryPort == 0 {
 		p.FleetTelemetryPort = 443

--- a/internal/config/identity_test.go
+++ b/internal/config/identity_test.go
@@ -1,0 +1,97 @@
+package config
+
+import (
+	"encoding/base64"
+	"testing"
+	"time"
+)
+
+func TestLoad_IdentityDefaults(t *testing.T) {
+	dir := t.TempDir()
+	path := writeTestConfig(t, dir, nil)
+	setRequiredEnv(t)
+
+	cfg, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	id := cfg.Identity()
+	if id.AccessTokenTTL != time.Hour {
+		t.Errorf("AccessTokenTTL = %v, want 1h", id.AccessTokenTTL)
+	}
+	if id.RefreshTokenTTL != 90*24*time.Hour {
+		t.Errorf("RefreshTokenTTL = %v, want 90d", id.RefreshTokenTTL)
+	}
+	if id.AuthRateLimitPerMinute != 30 || id.AuthRateLimitBurst != 10 {
+		t.Errorf("rate limit defaults = %d/%d, want 30/10", id.AuthRateLimitPerMinute, id.AuthRateLimitBurst)
+	}
+	// Absent secrets => module disabled.
+	if id.ES256PrivateKeyPEM != "" || id.AppleClientID != "" || id.BootstrapEmailToCUID != nil {
+		t.Errorf("expected empty identity secrets by default: %+v", id)
+	}
+}
+
+func TestLoad_IdentityEnv(t *testing.T) {
+	dir := t.TempDir()
+	path := writeTestConfig(t, dir, nil)
+	setRequiredEnv(t)
+	t.Setenv("AUTH_ES256_PRIVATE_KEY", "-----BEGIN PRIVATE KEY-----\nabc\n-----END PRIVATE KEY-----")
+	t.Setenv("APPLE_NATIVE_CLIENT_ID", "app.myrobotaxi.ios")
+	t.Setenv("AUTH_APPLE_BOOTSTRAP", "Owner@Example.com=cmmgr4b1p0005l104ifpctlg8, junk , =bad")
+
+	cfg, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	id := cfg.Identity()
+	if id.AppleClientID != "app.myrobotaxi.ios" {
+		t.Errorf("AppleClientID = %q", id.AppleClientID)
+	}
+	if id.ES256PrivateKeyPEM == "" {
+		t.Error("ES256PrivateKeyPEM not read from env")
+	}
+	if got := id.BootstrapEmailToCUID["owner@example.com"]; got != "cmmgr4b1p0005l104ifpctlg8" {
+		t.Errorf("bootstrap map = %v, want lower-cased key -> cuid", id.BootstrapEmailToCUID)
+	}
+	if len(id.BootstrapEmailToCUID) != 1 {
+		t.Errorf("malformed bootstrap entries not dropped: %v", id.BootstrapEmailToCUID)
+	}
+}
+
+func TestLoad_IdentityKeyB64(t *testing.T) {
+	dir := t.TempDir()
+	path := writeTestConfig(t, dir, nil)
+	setRequiredEnv(t)
+	pem := "-----BEGIN PRIVATE KEY-----\nxyz\n-----END PRIVATE KEY-----"
+	t.Setenv("AUTH_ES256_PRIVATE_KEY_B64", base64.StdEncoding.EncodeToString([]byte(pem)))
+
+	cfg, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if cfg.Identity().ES256PrivateKeyPEM != pem {
+		t.Errorf("B64 key not decoded: %q", cfg.Identity().ES256PrivateKeyPEM)
+	}
+}
+
+func TestLoad_IdentityBadB64(t *testing.T) {
+	dir := t.TempDir()
+	path := writeTestConfig(t, dir, nil)
+	setRequiredEnv(t)
+	t.Setenv("AUTH_ES256_PRIVATE_KEY_B64", "!!!not base64!!!")
+	if _, err := Load(path); err == nil {
+		t.Fatal("expected error for invalid base64 key")
+	}
+}
+
+func TestValidateIdentity_RejectsBadTTL(t *testing.T) {
+	errs := validateIdentity(IdentityConfig{
+		AccessTokenTTL:         2 * time.Hour,
+		RefreshTokenTTL:        time.Hour, // refresh < access
+		AuthRateLimitPerMinute: 0,
+		AuthRateLimitBurst:     0,
+	})
+	if len(errs) == 0 {
+		t.Fatal("expected validation errors for bad identity config")
+	}
+}

--- a/internal/config/load.go
+++ b/internal/config/load.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -17,6 +18,7 @@ type fileConfig struct {
 	Drives    fileDrivesConfig    `json:"drives"`
 	WebSocket fileWebSocketConfig `json:"websocket"`
 	Auth      fileAuthConfig      `json:"auth"`
+	Identity  fileIdentityConfig  `json:"identity"`
 	Proxy     fileProxyConfig     `json:"proxy"`
 
 	// Populated from environment, not JSON.
@@ -28,6 +30,11 @@ type fileConfig struct {
 	teslaClientID        string
 	teslaClientSec       string
 	certMonitorEndpoints []string
+
+	// Identity module secrets/identifiers (env, not JSON).
+	es256PrivateKeyPEM string
+	appleClientID      string
+	appleBootstrap     map[string]string
 }
 
 type fileServerConfig struct {
@@ -77,6 +84,13 @@ type fileAuthConfig struct {
 	TokenAudience string `json:"token_audience"`
 }
 
+type fileIdentityConfig struct {
+	AccessTokenTTL         Duration `json:"access_token_ttl"`
+	RefreshTokenTTL        Duration `json:"refresh_token_ttl"`
+	AuthRateLimitPerMinute int      `json:"auth_rate_limit_per_minute"`
+	AuthRateLimitBurst     int      `json:"auth_rate_limit_burst"`
+}
+
 type fileProxyConfig struct {
 	URL                    string `json:"url"`
 	FleetTelemetryHostname string `json:"fleet_telemetry_hostname"`
@@ -106,6 +120,7 @@ func applyDefaults(fc *fileConfig) {
 	applyDrivesDefaults(&fc.Drives)
 	applyWebSocketDefaults(&fc.WebSocket)
 	applyAuthDefaults(&fc.Auth)
+	applyIdentityDefaults(&fc.Identity)
 	applyProxyDefaults(&fc.Proxy)
 }
 
@@ -129,6 +144,16 @@ func applyEnvOverrides(fc *fileConfig) error {
 	fc.fleetTelemetryCA = os.Getenv("FLEET_TELEMETRY_CA") // optional: PEM CA cert
 	fc.teslaClientID = os.Getenv("AUTH_TESLA_ID")         // optional: enables token refresh
 	fc.teslaClientSec = os.Getenv("AUTH_TESLA_SECRET")    // optional: enables token refresh
+
+	// Identity module (MYR-193, ADR-001). All optional: absent = module
+	// disabled (the server stays a pure token VALIDATOR, HS256-only).
+	keyPEM, err := readES256KeyEnv()
+	if err != nil {
+		return err
+	}
+	fc.es256PrivateKeyPEM = keyPEM
+	fc.appleClientID = os.Getenv("APPLE_NATIVE_CLIENT_ID")   // expected aud on Apple id tokens
+	fc.appleBootstrap = parseKVMap(os.Getenv("AUTH_APPLE_BOOTSTRAP")) // email=cuid[,email=cuid]
 
 	// Database env var overrides.
 	if v := os.Getenv("DATABASE_DISABLE_PREPARED_STATEMENTS"); v == "true" || v == "1" {
@@ -174,6 +199,50 @@ func applyEnvOverrides(fc *fileConfig) error {
 		return fmt.Errorf("config.Load: %w: %v", ErrMissingRequired, missing)
 	}
 	return nil
+}
+
+// readES256KeyEnv reads the identity module's ES256 private key from the
+// environment. AUTH_ES256_PRIVATE_KEY holds the raw PKCS#8 PEM;
+// AUTH_ES256_PRIVATE_KEY_B64 holds the same PEM base64-encoded (the Fly /
+// container convention — a single env line with no embedded newlines). The
+// raw form wins if both are set. Returns "" (no key) when neither is set.
+func readES256KeyEnv() (string, error) {
+	if raw := os.Getenv("AUTH_ES256_PRIVATE_KEY"); raw != "" {
+		return raw, nil
+	}
+	b64 := os.Getenv("AUTH_ES256_PRIVATE_KEY_B64")
+	if b64 == "" {
+		return "", nil
+	}
+	decoded, err := base64.StdEncoding.DecodeString(strings.TrimSpace(b64))
+	if err != nil {
+		return "", fmt.Errorf("config.Load: decode AUTH_ES256_PRIVATE_KEY_B64: %w: %w", ErrInvalidValue, err)
+	}
+	return string(decoded), nil
+}
+
+// parseKVMap parses a "k=v,k=v" list into a map. Whitespace around keys and
+// values is trimmed; empty or malformed (no "=") entries are dropped. Keys
+// are lower-cased so email lookups are case-insensitive. Returns nil for an
+// empty input so an unset var yields a nil (disabled) map.
+func parseKVMap(raw string) map[string]string {
+	if strings.TrimSpace(raw) == "" {
+		return nil
+	}
+	out := make(map[string]string)
+	for _, pair := range strings.Split(raw, ",") {
+		k, v, ok := strings.Cut(pair, "=")
+		k = strings.ToLower(strings.TrimSpace(k))
+		v = strings.TrimSpace(v)
+		if !ok || k == "" || v == "" {
+			continue
+		}
+		out[k] = v
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
 }
 
 // parseOriginList splits a comma-separated origin pattern list, trims
@@ -234,6 +303,15 @@ func buildConfig(fc *fileConfig) *Config {
 			Secret:        fc.authSecret,
 			TokenIssuer:   fc.Auth.TokenIssuer,
 			TokenAudience: fc.Auth.TokenAudience,
+		},
+		identity: IdentityConfig{
+			ES256PrivateKeyPEM:     fc.es256PrivateKeyPEM,
+			AppleClientID:          fc.appleClientID,
+			BootstrapEmailToCUID:   fc.appleBootstrap,
+			AccessTokenTTL:         fc.Identity.AccessTokenTTL.Dur(),
+			RefreshTokenTTL:        fc.Identity.RefreshTokenTTL.Dur(),
+			AuthRateLimitPerMinute: fc.Identity.AuthRateLimitPerMinute,
+			AuthRateLimitBurst:     fc.Identity.AuthRateLimitBurst,
 		},
 		proxy: ProxyConfig{
 			URL:                    fc.Proxy.URL,

--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -17,6 +17,7 @@ func validate(cfg *Config) error {
 	errs = append(errs, validateDrives(cfg.drives)...)
 	errs = append(errs, validateWebSocket(cfg.websocket)...)
 	errs = append(errs, validateAuth(cfg.auth)...)
+	errs = append(errs, validateIdentity(cfg.identity)...)
 
 	if len(errs) > 0 {
 		return fmt.Errorf("config.Validate: %w:\n  %s",
@@ -135,6 +136,30 @@ func validateAuth(a AuthConfig) []string {
 	}
 	if a.TokenAudience == "" {
 		errs = append(errs, "auth.token_audience: must not be empty")
+	}
+	return errs
+}
+
+// validateIdentity checks the identity-module operational knobs. The secrets
+// (ES256 key, Apple client id) are optional — an absent key simply disables
+// the module — so they are NOT required here; the keystore validates the PEM
+// at load time. Only the always-defaulted numeric knobs are range-checked.
+func validateIdentity(i IdentityConfig) []string {
+	var errs []string
+	if i.AccessTokenTTL <= 0 {
+		errs = append(errs, "identity.access_token_ttl: must be positive")
+	}
+	if i.RefreshTokenTTL <= 0 {
+		errs = append(errs, "identity.refresh_token_ttl: must be positive")
+	}
+	if i.RefreshTokenTTL <= i.AccessTokenTTL {
+		errs = append(errs, "identity.refresh_token_ttl: must exceed identity.access_token_ttl")
+	}
+	if i.AuthRateLimitPerMinute < 1 {
+		errs = append(errs, fmt.Sprintf("identity.auth_rate_limit_per_minute: %d must be >= 1", i.AuthRateLimitPerMinute))
+	}
+	if i.AuthRateLimitBurst < 1 {
+		errs = append(errs, fmt.Sprintf("identity.auth_rate_limit_burst: %d must be >= 1", i.AuthRateLimitBurst))
 	}
 	return errs
 }

--- a/internal/identity/apple.go
+++ b/internal/identity/apple.go
@@ -1,0 +1,110 @@
+package identity
+
+import (
+	"context"
+	"crypto/rsa"
+	"fmt"
+	"net/http"
+
+	"github.com/golang-jwt/jwt/v5"
+)
+
+// AppleIssuer is the required `iss` on a Sign in with Apple identity token.
+const AppleIssuer = "https://appleid.apple.com"
+
+// AppleClaims is the validated subset of an Apple identity token this module
+// consumes. Email/name are P1 (PII) and must never be logged.
+type AppleClaims struct {
+	Sub            string // Apple's stable per-user subject — the linkage key
+	Email          string // may be empty (user hid it) or a private-relay address
+	EmailVerified  bool   // Apple asserts the email is verified
+	IsPrivateEmail bool   // the email is an Apple private-relay address
+	Nonce          string // echoed nonce, if the client supplied one
+}
+
+// AppleValidator verifies Apple identity tokens: RS256 signature against
+// Apple's rotating JWKS, plus issuer, audience (the native client id), and
+// expiry/issued-at. It never contacts Apple beyond the JWKS fetch — there is
+// no code-exchange step for the native identity-token flow.
+type AppleValidator struct {
+	keys     appleKeyResolver
+	issuer   string
+	audience string
+}
+
+// NewAppleValidator builds a validator whose `aud` check is clientID
+// (APPLE_NATIVE_CLIENT_ID). keysURL/httpClient configure the JWKS cache; pass
+// "" / nil for production defaults (Apple's endpoint, a 5s-timeout client).
+func NewAppleValidator(clientID, keysURL string, httpClient *http.Client) *AppleValidator {
+	return &AppleValidator{
+		keys:     newAppleKeyCache(keysURL, httpClient),
+		issuer:   AppleIssuer,
+		audience: clientID,
+	}
+}
+
+// Validate verifies the identity token and returns the accepted claims.
+// expectedNonce, when non-empty, MUST match the token's nonce (the token's
+// nonce is otherwise optional). Any failure returns ErrInvalidAppleToken.
+func (v *AppleValidator) Validate(ctx context.Context, idToken, expectedNonce string) (AppleClaims, error) {
+	parser := jwt.NewParser(
+		jwt.WithValidMethods([]string{"RS256"}),
+		jwt.WithIssuer(v.issuer),
+		jwt.WithAudience(v.audience),
+		jwt.WithExpirationRequired(),
+	)
+
+	claims := jwt.MapClaims{}
+	_, err := parser.ParseWithClaims(idToken, claims, func(t *jwt.Token) (any, error) {
+		kid, _ := t.Header["kid"].(string)
+		if kid == "" {
+			return nil, fmt.Errorf("apple token missing kid")
+		}
+		return v.appleKey(ctx, kid)
+	})
+	if err != nil {
+		return AppleClaims{}, fmt.Errorf("identity.AppleValidator.Validate: %w: %w", ErrInvalidAppleToken, err)
+	}
+
+	sub, _ := claims["sub"].(string)
+	if sub == "" {
+		return AppleClaims{}, fmt.Errorf("identity.AppleValidator.Validate: %w: missing sub", ErrInvalidAppleToken)
+	}
+
+	out := AppleClaims{
+		Sub:            sub,
+		Email:          stringClaim(claims["email"]),
+		EmailVerified:  boolClaim(claims["email_verified"]),
+		IsPrivateEmail: boolClaim(claims["is_private_email"]),
+		Nonce:          stringClaim(claims["nonce"]),
+	}
+
+	if expectedNonce != "" && out.Nonce != expectedNonce {
+		return AppleClaims{}, fmt.Errorf("identity.AppleValidator.Validate: %w: nonce mismatch", ErrInvalidAppleToken)
+	}
+	return out, nil
+}
+
+// appleKey adapts the resolver to the jwt keyfunc return type.
+func (v *AppleValidator) appleKey(ctx context.Context, kid string) (*rsa.PublicKey, error) {
+	return v.keys.key(ctx, kid)
+}
+
+// stringClaim coerces a JSON claim to string ("" if absent/wrong type).
+func stringClaim(v any) string {
+	s, _ := v.(string)
+	return s
+}
+
+// boolClaim coerces an Apple claim to bool. Apple encodes email_verified /
+// is_private_email as either a JSON bool or the strings "true"/"false".
+func boolClaim(v any) bool {
+	switch t := v.(type) {
+	case bool:
+		return t
+	case string:
+		return t == "true"
+	default:
+		return false
+	}
+}

--- a/internal/identity/apple_test.go
+++ b/internal/identity/apple_test.go
@@ -1,0 +1,231 @@
+package identity
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"encoding/base64"
+	"encoding/json"
+	"math/big"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/golang-jwt/jwt/v5"
+)
+
+// appleRSAKey generates a test RSA key.
+func appleRSAKey(t *testing.T) *rsa.PrivateKey {
+	t.Helper()
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("generate rsa: %v", err)
+	}
+	return key
+}
+
+// jwksServer serves a JWKS document for the given kid->public-key set.
+func jwksServer(t *testing.T, keys map[string]*rsa.PublicKey) *httptest.Server {
+	t.Helper()
+	type jwk struct {
+		Kty, Kid, N, E, Use, Alg string
+	}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		var out struct {
+			Keys []jwk `json:"keys"`
+		}
+		for kid, pub := range keys {
+			out.Keys = append(out.Keys, jwk{
+				Kty: "RSA", Kid: kid, Use: "sig", Alg: "RS256",
+				N: base64.RawURLEncoding.EncodeToString(pub.N.Bytes()),
+				E: base64.RawURLEncoding.EncodeToString(big.NewInt(int64(pub.E)).Bytes()),
+			})
+		}
+		_ = json.NewEncoder(w).Encode(out)
+	}))
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+// signApple signs an Apple-style identity token with RS256 and a kid header.
+func signApple(t *testing.T, key *rsa.PrivateKey, kid string, claims jwt.MapClaims) string {
+	t.Helper()
+	tok := jwt.NewWithClaims(jwt.SigningMethodRS256, claims)
+	tok.Header["kid"] = kid
+	signed, err := tok.SignedString(key)
+	if err != nil {
+		t.Fatalf("sign apple token: %v", err)
+	}
+	return signed
+}
+
+const testClientID = "app.myrobotaxi.ios"
+
+func baseAppleClaims() jwt.MapClaims {
+	now := time.Now()
+	return jwt.MapClaims{
+		"iss":            AppleIssuer,
+		"aud":            testClientID,
+		"sub":            "000123.apple.subject",
+		"iat":            now.Add(-time.Minute).Unix(),
+		"exp":            now.Add(time.Hour).Unix(),
+		"email":          "owner@example.com",
+		"email_verified": true,
+	}
+}
+
+func TestAppleValidator_Valid(t *testing.T) {
+	key := appleRSAKey(t)
+	srv := jwksServer(t, map[string]*rsa.PublicKey{"k1": &key.PublicKey})
+	v := NewAppleValidator(testClientID, srv.URL, nil)
+
+	token := signApple(t, key, "k1", baseAppleClaims())
+	claims, err := v.Validate(context.Background(), token, "")
+	if err != nil {
+		t.Fatalf("Validate: %v", err)
+	}
+	if claims.Sub != "000123.apple.subject" {
+		t.Errorf("sub = %q", claims.Sub)
+	}
+	if claims.Email != "owner@example.com" || !claims.EmailVerified {
+		t.Errorf("email claims = %q verified=%v", claims.Email, claims.EmailVerified)
+	}
+}
+
+func TestAppleValidator_Matrix(t *testing.T) {
+	key := appleRSAKey(t)
+	srv := jwksServer(t, map[string]*rsa.PublicKey{"k1": &key.PublicKey})
+	v := NewAppleValidator(testClientID, srv.URL, nil)
+
+	tests := []struct {
+		name   string
+		mutate func(jwt.MapClaims)
+		kid    string
+		method jwt.SigningMethod
+	}{
+		{"bad issuer", func(c jwt.MapClaims) { c["iss"] = "https://evil.example.com" }, "k1", nil},
+		{"bad audience", func(c jwt.MapClaims) { c["aud"] = "app.someone.else" }, "k1", nil},
+		{"expired", func(c jwt.MapClaims) { c["exp"] = time.Now().Add(-time.Hour).Unix() }, "k1", nil},
+		{"missing sub", func(c jwt.MapClaims) { delete(c, "sub") }, "k1", nil},
+		{"unknown kid", func(jwt.MapClaims) {}, "k-unknown", nil},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			claims := baseAppleClaims()
+			tt.mutate(claims)
+			token := signApple(t, key, tt.kid, claims)
+			if _, err := v.Validate(context.Background(), token, ""); err == nil {
+				t.Fatalf("expected rejection for %s", tt.name)
+			}
+		})
+	}
+}
+
+// TestAppleValidator_AlgConfusion asserts a non-RS256 signing algorithm is
+// rejected before the key callback runs (WithValidMethods allowlist).
+func TestAppleValidator_AlgConfusion(t *testing.T) {
+	key := appleRSAKey(t)
+	srv := jwksServer(t, map[string]*rsa.PublicKey{"k1": &key.PublicKey})
+	v := NewAppleValidator(testClientID, srv.URL, nil)
+
+	// HS256 token forged with the (public) modulus bytes as the HMAC secret —
+	// the classic RSA/HMAC confusion. Must be rejected by the method allowlist.
+	tok := jwt.NewWithClaims(jwt.SigningMethodHS256, baseAppleClaims())
+	tok.Header["kid"] = "k1"
+	forged, err := tok.SignedString(key.N.Bytes())
+	if err != nil {
+		t.Fatalf("sign forged: %v", err)
+	}
+	if _, err := v.Validate(context.Background(), forged, ""); err == nil {
+		t.Fatal("alg-confusion token was accepted")
+	}
+}
+
+func TestAppleValidator_Nonce(t *testing.T) {
+	key := appleRSAKey(t)
+	srv := jwksServer(t, map[string]*rsa.PublicKey{"k1": &key.PublicKey})
+	v := NewAppleValidator(testClientID, srv.URL, nil)
+
+	claims := baseAppleClaims()
+	claims["nonce"] = "abc123"
+	token := signApple(t, key, "k1", claims)
+
+	if _, err := v.Validate(context.Background(), token, "abc123"); err != nil {
+		t.Fatalf("matching nonce rejected: %v", err)
+	}
+	if _, err := v.Validate(context.Background(), token, "wrong"); err == nil {
+		t.Fatal("mismatched nonce accepted")
+	}
+	// Absent expected nonce -> token nonce is optional, accepted.
+	if _, err := v.Validate(context.Background(), token, ""); err != nil {
+		t.Fatalf("optional nonce rejected: %v", err)
+	}
+}
+
+func TestAppleValidator_EmailVerifiedStringForm(t *testing.T) {
+	key := appleRSAKey(t)
+	srv := jwksServer(t, map[string]*rsa.PublicKey{"k1": &key.PublicKey})
+	v := NewAppleValidator(testClientID, srv.URL, nil)
+
+	claims := baseAppleClaims()
+	claims["email_verified"] = "true" // Apple sometimes stringifies booleans
+	claims["is_private_email"] = "true"
+	token := signApple(t, key, "k1", claims)
+
+	got, err := v.Validate(context.Background(), token, "")
+	if err != nil {
+		t.Fatalf("Validate: %v", err)
+	}
+	if !got.EmailVerified {
+		t.Error("string 'true' email_verified not parsed as true")
+	}
+	if !got.IsPrivateEmail {
+		t.Error("string 'true' is_private_email not parsed as true")
+	}
+}
+
+// TestAppleKeyCache_Rotation asserts a previously-unseen kid triggers a
+// re-fetch (Apple key rotation), exercised directly on the cache with the
+// miss backoff disabled.
+func TestAppleKeyCache_Rotation(t *testing.T) {
+	key1 := appleRSAKey(t)
+	key2 := appleRSAKey(t)
+	served := map[string]*rsa.PublicKey{"k1": &key1.PublicKey}
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		type jwk struct{ Kty, Kid, N, E string }
+		var out struct {
+			Keys []jwk `json:"keys"`
+		}
+		for kid, pub := range served {
+			out.Keys = append(out.Keys, jwk{
+				Kty: "RSA", Kid: kid,
+				N: base64.RawURLEncoding.EncodeToString(pub.N.Bytes()),
+				E: base64.RawURLEncoding.EncodeToString(big.NewInt(int64(pub.E)).Bytes()),
+			})
+		}
+		_ = json.NewEncoder(w).Encode(out)
+	}))
+	t.Cleanup(srv.Close)
+
+	cache := newAppleKeyCache(srv.URL, nil)
+	cache.missBackfx = 0 // allow immediate miss-triggered refetch
+
+	ctx := context.Background()
+	if _, err := cache.key(ctx, "k1"); err != nil {
+		t.Fatalf("k1: %v", err)
+	}
+	// Rotate: server now serves k2 as well; a request for k2 must refetch.
+	served["k2"] = &key2.PublicKey
+	if _, err := cache.key(ctx, "k2"); err != nil {
+		t.Fatalf("k2 after rotation: %v", err)
+	}
+}
+
+// sanity: ensure the JWK exponent decode rejects nonsense.
+func TestRSAPublicFromJWK_BadExponent(t *testing.T) {
+	if _, err := rsaPublicFromJWK(base64.RawURLEncoding.EncodeToString([]byte{1, 2, 3}), ""); err == nil {
+		t.Fatal("expected error for empty exponent")
+	}
+}

--- a/internal/identity/applekeys.go
+++ b/internal/identity/applekeys.go
@@ -1,0 +1,155 @@
+package identity
+
+import (
+	"context"
+	"crypto/rsa"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"math/big"
+	"net/http"
+	"sync"
+	"time"
+)
+
+// AppleKeysURL is Apple's public JWKS endpoint for Sign in with Apple.
+const AppleKeysURL = "https://appleid.apple.com/auth/keys"
+
+// appleKeyResolver resolves an Apple signing key by `kid`. Defined at the
+// consumer site (the token validator) so tests can supply a stub without a
+// live network.
+type appleKeyResolver interface {
+	key(ctx context.Context, kid string) (*rsa.PublicKey, error)
+}
+
+// appleKeyCache fetches and caches Apple's JWKS. Apple rotates its signing
+// keys, so on a cache miss (a `kid` we have not seen) the cache re-fetches —
+// rate-limited to avoid hammering Apple when presented an unknown kid — and
+// it proactively re-fetches once the cache is older than maxAge.
+type appleKeyCache struct {
+	url        string
+	httpClient *http.Client
+	maxAge     time.Duration // force refresh when cache is older than this
+	missBackfx time.Duration // min interval between miss-triggered refreshes
+	now        func() time.Time
+
+	mu        sync.Mutex
+	keys      map[string]*rsa.PublicKey
+	fetchedAt time.Time
+}
+
+// newAppleKeyCache builds an Apple JWKS cache. url defaults to AppleKeysURL;
+// httpClient defaults to a client with a short timeout.
+func newAppleKeyCache(url string, httpClient *http.Client) *appleKeyCache {
+	if url == "" {
+		url = AppleKeysURL
+	}
+	if httpClient == nil {
+		httpClient = &http.Client{Timeout: 5 * time.Second}
+	}
+	return &appleKeyCache{
+		url:        url,
+		httpClient: httpClient,
+		maxAge:     6 * time.Hour,
+		missBackfx: 1 * time.Minute,
+		now:        time.Now,
+	}
+}
+
+// key returns the RSA public key for kid, refreshing the cache if the key is
+// absent (Apple key rotation) or the cache is stale.
+func (c *appleKeyCache) key(ctx context.Context, kid string) (*rsa.PublicKey, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if k := c.keys[kid]; k != nil && c.now().Sub(c.fetchedAt) < c.maxAge {
+		return k, nil
+	}
+
+	// Refresh on a stale cache or an unknown kid, but rate-limit the
+	// miss-triggered path so an attacker spraying unknown kids can't force a
+	// fetch per request.
+	stale := c.keys == nil || c.now().Sub(c.fetchedAt) >= c.maxAge
+	missAllowed := c.now().Sub(c.fetchedAt) >= c.missBackfx
+	if stale || missAllowed {
+		if err := c.refreshLocked(ctx); err != nil {
+			// Serve a still-valid cached key on a refresh failure if we have
+			// one; otherwise surface the error.
+			if k := c.keys[kid]; k != nil {
+				return k, nil
+			}
+			return nil, err
+		}
+	}
+
+	if k := c.keys[kid]; k != nil {
+		return k, nil
+	}
+	return nil, fmt.Errorf("identity: apple key %q not found: %w", kid, ErrUnknownKID)
+}
+
+// refreshLocked fetches the JWKS and replaces the cache. Caller holds c.mu.
+func (c *appleKeyCache) refreshLocked(ctx context.Context) error {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.url, http.NoBody)
+	if err != nil {
+		return fmt.Errorf("identity: build apple jwks request: %w", err)
+	}
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("identity: fetch apple jwks: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("identity: apple jwks status %d", resp.StatusCode)
+	}
+
+	var doc struct {
+		Keys []struct {
+			Kty string `json:"kty"`
+			Kid string `json:"kid"`
+			N   string `json:"n"`
+			E   string `json:"e"`
+		} `json:"keys"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&doc); err != nil {
+		return fmt.Errorf("identity: decode apple jwks: %w", err)
+	}
+
+	keys := make(map[string]*rsa.PublicKey, len(doc.Keys))
+	for _, k := range doc.Keys {
+		if k.Kty != "RSA" || k.Kid == "" {
+			continue
+		}
+		pub, err := rsaPublicFromJWK(k.N, k.E)
+		if err != nil {
+			continue // skip a malformed key rather than fail the whole set
+		}
+		keys[k.Kid] = pub
+	}
+	if len(keys) == 0 {
+		return fmt.Errorf("identity: apple jwks contained no usable RSA keys")
+	}
+	c.keys = keys
+	c.fetchedAt = c.now()
+	return nil
+}
+
+// rsaPublicFromJWK reconstructs an RSA public key from base64url JWK n/e.
+func rsaPublicFromJWK(nB64, eB64 string) (*rsa.PublicKey, error) {
+	nBytes, err := base64.RawURLEncoding.DecodeString(nB64)
+	if err != nil {
+		return nil, fmt.Errorf("decode n: %w", err)
+	}
+	eBytes, err := base64.RawURLEncoding.DecodeString(eB64)
+	if err != nil {
+		return nil, fmt.Errorf("decode e: %w", err)
+	}
+	e := new(big.Int).SetBytes(eBytes)
+	if !e.IsInt64() || e.Int64() < 2 {
+		return nil, fmt.Errorf("invalid RSA exponent")
+	}
+	return &rsa.PublicKey{
+		N: new(big.Int).SetBytes(nBytes),
+		E: int(e.Int64()),
+	}, nil
+}

--- a/internal/identity/audit.go
+++ b/internal/identity/audit.go
@@ -1,0 +1,54 @@
+package identity
+
+import "log/slog"
+
+// auditLogger emits the identity module's auth audit trail as structured slog
+// records (ADR-001 §6). It records the event and the opaque user/family ids
+// only — never PII (no email, name, raw token, or token hash). This trail
+// stays inside the module rather than touching the Prisma-owned "AuditLog"
+// enum (which is contract-restricted to three system actions).
+type auditLogger struct {
+	log *slog.Logger
+}
+
+func newAuditLogger(log *slog.Logger) *auditLogger {
+	if log == nil {
+		log = slog.Default()
+	}
+	return &auditLogger{log: log.With(slog.String("audit", "identity"))}
+}
+
+// signIn records a successful Apple sign-in. newUser distinguishes a freshly
+// minted account from a returning/linked one.
+func (a *auditLogger) signIn(userID string, newUser bool) {
+	a.log.Info("auth.sign_in",
+		slog.String("event", "sign_in"),
+		slog.String("user_id", userID),
+		slog.Bool("new_user", newUser),
+	)
+}
+
+// refresh records a successful refresh-token rotation.
+func (a *auditLogger) refresh(userID string) {
+	a.log.Info("auth.refresh",
+		slog.String("event", "refresh"),
+		slog.String("user_id", userID),
+	)
+}
+
+// reuseDetected records a refresh-token reuse (theft) that revoked a family.
+func (a *auditLogger) reuseDetected(userID, familyID string) {
+	a.log.Warn("auth.reuse_detected",
+		slog.String("event", "reuse_detected"),
+		slog.String("user_id", userID),
+		slog.String("family_id", familyID),
+	)
+}
+
+// revoke records an explicit sign-out (family revocation).
+func (a *auditLogger) revoke(userID string) {
+	a.log.Info("auth.revoke",
+		slog.String("event", "revoke"),
+		slog.String("user_id", userID),
+	)
+}

--- a/internal/identity/errors.go
+++ b/internal/identity/errors.go
@@ -1,0 +1,38 @@
+// Package identity is the telemetry server's bounded identity module
+// (MYR-193, docs/architecture/adr-001-identity-module.md). It owns native
+// Sign in with Apple, ES256 access-token minting with a published JWKS, and
+// rotating refresh tokens with family reuse-detection. The rest of the app
+// consumes only the validated user identity (a user CUID) via the shared
+// auth.JWTAuthenticator; nothing outside this package touches the signing
+// key, the Apple validation, or the refresh-token store.
+package identity
+
+import "errors"
+
+// Domain errors. Handlers map these to typed REST error envelopes; the raw
+// errors never carry PII (an email or token) — only opaque ids.
+var (
+	// ErrInvalidAppleToken indicates the Apple identity token failed
+	// validation (signature, issuer, audience, expiry, or claim shape).
+	ErrInvalidAppleToken = errors.New("invalid apple identity token")
+
+	// ErrEmailNotVerified indicates the Apple token carried an email that
+	// Apple did not assert as verified, so it cannot be used for linkage.
+	ErrEmailNotVerified = errors.New("apple email not verified")
+
+	// ErrInvalidRefreshToken indicates the presented refresh token is
+	// unknown, malformed, or naturally expired (benign — no family revoke).
+	ErrInvalidRefreshToken = errors.New("invalid refresh token")
+
+	// ErrRefreshReuseDetected indicates a spent or revoked refresh token was
+	// presented — treated as theft. The whole family is revoked.
+	ErrRefreshReuseDetected = errors.New("refresh token reuse detected")
+
+	// ErrNoSigningKey indicates the keystore has no ES256 signing key, so no
+	// access token can be minted (misconfiguration — module should be off).
+	ErrNoSigningKey = errors.New("no ES256 signing key configured")
+
+	// ErrUnknownKID indicates a token's `kid` did not resolve to a known
+	// public key in the keystore.
+	ErrUnknownKID = errors.New("unknown key id")
+)

--- a/internal/identity/handlers.go
+++ b/internal/identity/handlers.go
@@ -1,0 +1,219 @@
+package identity
+
+import (
+	"encoding/json"
+	"errors"
+	"log/slog"
+	"net"
+	"net/http"
+	"strings"
+
+	"github.com/myrobotaxi/telemetry/internal/wserrors"
+)
+
+// Handler serves the /api/auth/* REST surface. It follows the repo's
+// per-handler pattern (no shared auth middleware): strict JSON decoding,
+// per-IP pre-auth rate limiting, and typed error envelopes via wserrors.
+type Handler struct {
+	svc      *Service
+	keystore *Keystore
+	limiter  *ipRateLimiter
+	logger   *slog.Logger
+	// appleEnabled is false when no Apple client id is configured — the sign
+	// -in endpoint then 404s so it is not a half-configured foot-gun.
+	appleEnabled bool
+}
+
+// HandlerConfig bundles the auth handler's construction inputs.
+type HandlerConfig struct {
+	Service      *Service
+	Keystore     *Keystore
+	AppleEnabled bool
+	// RateLimitPerMinute / RateLimitBurst configure the per-IP pre-auth cap.
+	RateLimitPerMinute int
+	RateLimitBurst     int
+	Logger             *slog.Logger
+}
+
+// NewHandler builds the auth HTTP handler, constructing its per-IP rate
+// limiter internally.
+func NewHandler(cfg HandlerConfig) *Handler {
+	logger := cfg.Logger
+	if logger == nil {
+		logger = slog.Default()
+	}
+	return &Handler{
+		svc:          cfg.Service,
+		keystore:     cfg.Keystore,
+		limiter:      newIPRateLimiter(cfg.RateLimitPerMinute, cfg.RateLimitBurst),
+		appleEnabled: cfg.AppleEnabled,
+		logger:       logger,
+	}
+}
+
+type appleSignInRequest struct {
+	IdentityToken string `json:"identityToken"`
+	FullName      string `json:"fullName,omitempty"`
+	Email         string `json:"email,omitempty"`
+	Nonce         string `json:"nonce,omitempty"`
+}
+
+type refreshRequest struct {
+	RefreshToken string `json:"refreshToken"`
+}
+
+type revokeRequest struct {
+	RefreshToken string `json:"refreshToken"`
+}
+
+type authResponse struct {
+	AccessToken  string   `json:"accessToken"`
+	ExpiresIn    int      `json:"expiresIn"`
+	RefreshToken string   `json:"refreshToken"`
+	User         UserInfo `json:"user"`
+}
+
+// ServeApple handles POST /api/auth/apple.
+func (h *Handler) ServeApple(w http.ResponseWriter, r *http.Request) {
+	if !h.appleEnabled {
+		h.writeError(w, http.StatusNotFound, wserrors.ErrCodeNotFound, "sign in with apple is not enabled")
+		return
+	}
+	if !h.allow(w, r) {
+		return
+	}
+	var body appleSignInRequest
+	if !decodeJSON(w, r, &body, h) {
+		return
+	}
+	if strings.TrimSpace(body.IdentityToken) == "" {
+		h.writeError(w, http.StatusBadRequest, wserrors.ErrCodeInvalidRequest, "identityToken is required")
+		return
+	}
+
+	res, err := h.svc.SignInWithApple(r.Context(), AppleSignInInput(body))
+	if err != nil {
+		h.mapAuthError(w, "apple sign-in", err)
+		return
+	}
+	h.writeJSON(w, http.StatusOK, toResponse(res))
+}
+
+// ServeRefresh handles POST /api/auth/refresh.
+func (h *Handler) ServeRefresh(w http.ResponseWriter, r *http.Request) {
+	if !h.allow(w, r) {
+		return
+	}
+	var body refreshRequest
+	if !decodeJSON(w, r, &body, h) {
+		return
+	}
+	if strings.TrimSpace(body.RefreshToken) == "" {
+		h.writeError(w, http.StatusBadRequest, wserrors.ErrCodeInvalidRequest, "refreshToken is required")
+		return
+	}
+	res, err := h.svc.Refresh(r.Context(), body.RefreshToken)
+	if err != nil {
+		h.mapAuthError(w, "refresh", err)
+		return
+	}
+	h.writeJSON(w, http.StatusOK, toResponse(res))
+}
+
+// ServeRevoke handles POST /api/auth/revoke. Always 204 on a well-formed
+// request (no existence oracle) unless the store fails.
+func (h *Handler) ServeRevoke(w http.ResponseWriter, r *http.Request) {
+	if !h.allow(w, r) {
+		return
+	}
+	var body revokeRequest
+	if !decodeJSON(w, r, &body, h) {
+		return
+	}
+	if strings.TrimSpace(body.RefreshToken) == "" {
+		h.writeError(w, http.StatusBadRequest, wserrors.ErrCodeInvalidRequest, "refreshToken is required")
+		return
+	}
+	if err := h.svc.Revoke(r.Context(), body.RefreshToken); err != nil {
+		h.logger.Error("revoke failed", slog.String("error", err.Error()))
+		h.writeError(w, http.StatusInternalServerError, wserrors.ErrCodeInternalError, "internal error")
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
+// ServeJWKS handles GET /api/auth/.well-known/jwks.json — the public keys.
+func (h *Handler) ServeJWKS(w http.ResponseWriter, _ *http.Request) {
+	w.Header().Set("Content-Type", "application/json; charset=utf-8")
+	w.Header().Set("Cache-Control", "public, max-age=3600")
+	if err := json.NewEncoder(w).Encode(h.keystore.JWKS()); err != nil {
+		h.logger.Error("jwks encode failed", slog.String("error", err.Error()))
+	}
+}
+
+// allow enforces the per-IP rate limit; on breach it writes 429 and returns
+// false.
+func (h *Handler) allow(w http.ResponseWriter, r *http.Request) bool {
+	if h.limiter == nil || h.limiter.allow(clientIP(r)) {
+		return true
+	}
+	w.Header().Set("Retry-After", "1")
+	h.writeError(w, http.StatusTooManyRequests, wserrors.ErrCodeRateLimited, "too many requests")
+	return false
+}
+
+// mapAuthError maps a service error to a typed REST envelope. Auth failures
+// collapse to 401 auth_failed with a generic message (no reuse/linkage
+// oracle, no PII); everything else is a 500.
+func (h *Handler) mapAuthError(w http.ResponseWriter, op string, err error) {
+	switch {
+	case errors.Is(err, ErrInvalidAppleToken), errors.Is(err, ErrEmailNotVerified),
+		errors.Is(err, ErrInvalidRefreshToken), errors.Is(err, ErrRefreshReuseDetected):
+		h.writeError(w, http.StatusUnauthorized, wserrors.ErrCodeAuthFailed, "authentication failed")
+	default:
+		h.logger.Error(op+" failed", slog.String("error", err.Error()))
+		h.writeError(w, http.StatusInternalServerError, wserrors.ErrCodeInternalError, "internal error")
+	}
+}
+
+func toResponse(res AuthResult) authResponse {
+	return authResponse(res)
+}
+
+// decodeJSON strictly decodes the request body (unknown fields -> 400).
+func decodeJSON(w http.ResponseWriter, r *http.Request, dst any, h *Handler) bool {
+	dec := json.NewDecoder(r.Body)
+	dec.DisallowUnknownFields()
+	if err := dec.Decode(dst); err != nil {
+		h.writeError(w, http.StatusBadRequest, wserrors.ErrCodeInvalidRequest, "malformed request body")
+		return false
+	}
+	return true
+}
+
+func (h *Handler) writeJSON(w http.ResponseWriter, status int, v any) {
+	w.Header().Set("Content-Type", "application/json; charset=utf-8")
+	w.WriteHeader(status)
+	if err := json.NewEncoder(w).Encode(v); err != nil {
+		h.logger.Error("writeJSON encode failed", slog.String("error", err.Error()))
+	}
+}
+
+func (h *Handler) writeError(w http.ResponseWriter, status int, code wserrors.ErrorCode, msg string) {
+	wserrors.WriteErrorEnvelope(w, h.logger, status, code, msg)
+}
+
+// clientIP resolves the caller IP for rate-limit keying: the leftmost
+// X-Forwarded-For entry (the edge appends), else RemoteAddr's host.
+func clientIP(r *http.Request) string {
+	if xff := r.Header.Get("X-Forwarded-For"); xff != "" {
+		if first := strings.TrimSpace(strings.SplitN(xff, ",", 2)[0]); first != "" {
+			return first
+		}
+	}
+	host, _, err := net.SplitHostPort(r.RemoteAddr)
+	if err != nil {
+		return r.RemoteAddr
+	}
+	return host
+}

--- a/internal/identity/handlers_test.go
+++ b/internal/identity/handlers_test.go
@@ -1,0 +1,174 @@
+package identity
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+func newTestHandler(t *testing.T, store Store, apple appleTokenValidator, appleEnabled bool, perMin int) *Handler {
+	t.Helper()
+	ks, err := NewKeystoreFromPEM(testKeyPEM(t))
+	if err != nil {
+		t.Fatalf("keystore: %v", err)
+	}
+	svc := NewService(ServiceConfig{
+		Store:      store,
+		Apple:      apple,
+		Minter:     NewTokenMinter(ks, "myrobotaxi", "telemetry", time.Hour),
+		RefreshTTL: 90 * 24 * time.Hour,
+	})
+	return NewHandler(HandlerConfig{
+		Service:            svc,
+		Keystore:           ks,
+		AppleEnabled:       appleEnabled,
+		RateLimitPerMinute: perMin,
+		RateLimitBurst:     perMin,
+	})
+}
+
+func postJSON(t *testing.T, h http.HandlerFunc, path, body string) *httptest.ResponseRecorder {
+	t.Helper()
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodPost, path, strings.NewReader(body))
+	req.RemoteAddr = "203.0.113.7:5555"
+	rec := httptest.NewRecorder()
+	h(rec, req)
+	return rec
+}
+
+func TestServeApple_Success(t *testing.T) {
+	store := newFakeStore()
+	store.prismaByEmail["owner@example.com"] = "cprismauser"
+	h := newTestHandler(t, store, fakeApple{claims: AppleClaims{Sub: "s1", Email: "owner@example.com", EmailVerified: true}}, true, 100)
+
+	rec := postJSON(t, h.ServeApple, "/api/auth/apple", `{"identityToken":"tok"}`)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", rec.Code, rec.Body.String())
+	}
+	var resp authResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if resp.AccessToken == "" || resp.RefreshToken == "" || resp.ExpiresIn != 3600 {
+		t.Errorf("bad response: %+v", resp)
+	}
+	if resp.User.ID != "cprismauser" {
+		t.Errorf("user id = %q", resp.User.ID)
+	}
+}
+
+func TestServeApple_Disabled404(t *testing.T) {
+	h := newTestHandler(t, newFakeStore(), fakeApple{}, false, 100)
+	rec := postJSON(t, h.ServeApple, "/api/auth/apple", `{"identityToken":"tok"}`)
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("status = %d, want 404", rec.Code)
+	}
+}
+
+func TestServeApple_InvalidTokenIs401(t *testing.T) {
+	h := newTestHandler(t, newFakeStore(), fakeApple{err: ErrInvalidAppleToken}, true, 100)
+	rec := postJSON(t, h.ServeApple, "/api/auth/apple", `{"identityToken":"tok"}`)
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("status = %d, want 401", rec.Code)
+	}
+}
+
+func TestServeApple_BadBody(t *testing.T) {
+	h := newTestHandler(t, newFakeStore(), fakeApple{}, true, 100)
+	// Malformed JSON.
+	if rec := postJSON(t, h.ServeApple, "/api/auth/apple", `{`); rec.Code != http.StatusBadRequest {
+		t.Errorf("malformed body status = %d, want 400", rec.Code)
+	}
+	// Missing required field.
+	if rec := postJSON(t, h.ServeApple, "/api/auth/apple", `{}`); rec.Code != http.StatusBadRequest {
+		t.Errorf("missing identityToken status = %d, want 400", rec.Code)
+	}
+	// Unknown field (strict decoding).
+	if rec := postJSON(t, h.ServeApple, "/api/auth/apple", `{"identityToken":"x","evil":1}`); rec.Code != http.StatusBadRequest {
+		t.Errorf("unknown field status = %d, want 400", rec.Code)
+	}
+}
+
+func TestServeRefresh(t *testing.T) {
+	store := newFakeStore()
+	store.rotateResult = RotateResult{Outcome: RotateRotated, UserID: "cuser"}
+	h := newTestHandler(t, store, fakeApple{}, true, 100)
+
+	rec := postJSON(t, h.ServeRefresh, "/api/auth/refresh", `{"refreshToken":"abc"}`)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, body=%s", rec.Code, rec.Body.String())
+	}
+
+	store.rotateResult = RotateResult{Outcome: RotateReuse, UserID: "cuser", FamilyID: "f"}
+	if rec := postJSON(t, h.ServeRefresh, "/api/auth/refresh", `{"refreshToken":"abc"}`); rec.Code != http.StatusUnauthorized {
+		t.Errorf("reuse status = %d, want 401", rec.Code)
+	}
+	if rec := postJSON(t, h.ServeRefresh, "/api/auth/refresh", `{}`); rec.Code != http.StatusBadRequest {
+		t.Errorf("missing token status = %d, want 400", rec.Code)
+	}
+}
+
+func TestServeRevoke_204(t *testing.T) {
+	store := newFakeStore()
+	store.revokeFound = true
+	store.revokeUserID = "cuser"
+	h := newTestHandler(t, store, fakeApple{}, true, 100)
+	rec := postJSON(t, h.ServeRevoke, "/api/auth/revoke", `{"refreshToken":"abc"}`)
+	if rec.Code != http.StatusNoContent {
+		t.Fatalf("status = %d, want 204", rec.Code)
+	}
+}
+
+func TestServeJWKS(t *testing.T) {
+	h := newTestHandler(t, newFakeStore(), fakeApple{}, true, 100)
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/api/auth/.well-known/jwks.json", http.NoBody)
+	rec := httptest.NewRecorder()
+	h.ServeJWKS(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d", rec.Code)
+	}
+	var jwks JWKS
+	if err := json.Unmarshal(rec.Body.Bytes(), &jwks); err != nil {
+		t.Fatalf("decode jwks: %v", err)
+	}
+	if len(jwks.Keys) != 1 || jwks.Keys[0].Kty != "EC" {
+		t.Errorf("unexpected jwks: %+v", jwks)
+	}
+}
+
+func TestServeRefresh_RateLimited(t *testing.T) {
+	store := newFakeStore()
+	store.rotateResult = RotateResult{Outcome: RotateRotated, UserID: "cuser"}
+	h := newTestHandler(t, store, fakeApple{}, true, 1) // 1/min, burst 1
+
+	// First request from the IP is allowed; the second is throttled.
+	if rec := postJSON(t, h.ServeRefresh, "/api/auth/refresh", `{"refreshToken":"a"}`); rec.Code != http.StatusOK {
+		t.Fatalf("first status = %d, want 200", rec.Code)
+	}
+	rec := postJSON(t, h.ServeRefresh, "/api/auth/refresh", `{"refreshToken":"a"}`)
+	if rec.Code != http.StatusTooManyRequests {
+		t.Fatalf("second status = %d, want 429", rec.Code)
+	}
+	if rec.Header().Get("Retry-After") == "" {
+		t.Error("missing Retry-After header on 429")
+	}
+}
+
+// clientIP unit coverage for the XFF path.
+func TestClientIP(t *testing.T) {
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodPost, "/", http.NoBody)
+	req.RemoteAddr = "10.0.0.1:1234"
+	req.Header.Set("X-Forwarded-For", "198.51.100.9, 10.0.0.1")
+	if got := clientIP(req); got != "198.51.100.9" {
+		t.Errorf("clientIP = %q, want leftmost XFF", got)
+	}
+	req2 := httptest.NewRequestWithContext(context.Background(), http.MethodPost, "/", http.NoBody)
+	req2.RemoteAddr = "10.0.0.2:9999"
+	if got := clientIP(req2); got != "10.0.0.2" {
+		t.Errorf("clientIP = %q, want RemoteAddr host", got)
+	}
+}

--- a/internal/identity/jwks.go
+++ b/internal/identity/jwks.go
@@ -1,0 +1,22 @@
+package identity
+
+// JWKS is a JSON Web Key Set — the public-key document served at
+// GET /api/auth/.well-known/jwks.json (RFC 7517). Consumers (and the
+// server's own dual-alg validator) resolve an access token's `kid` header to
+// one of these keys to verify the ES256 signature.
+type JWKS struct {
+	Keys []JWK `json:"keys"`
+}
+
+// JWK is a single public JSON Web Key. Only the public EC parameters are
+// emitted here — the private scalar `d` is never serialized. All fields are
+// P0 (public by definition).
+type JWK struct {
+	Kty string `json:"kty"`           // key type — always "EC" for ES256
+	Crv string `json:"crv"`           // curve — always "P-256"
+	X   string `json:"x"`             // base64url big-endian x coordinate
+	Y   string `json:"y"`             // base64url big-endian y coordinate
+	Use string `json:"use,omitempty"` // "sig"
+	Alg string `json:"alg,omitempty"` // "ES256"
+	Kid string `json:"kid"`           // RFC 7638 thumbprint
+}

--- a/internal/identity/keystore.go
+++ b/internal/identity/keystore.go
@@ -1,0 +1,149 @@
+package identity
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/sha256"
+	"crypto/x509"
+	"encoding/base64"
+	"encoding/pem"
+	"errors"
+	"fmt"
+	"math/big"
+)
+
+// Keystore holds the identity module's ES256 signing material. It owns
+// exactly one active signing key (used to mint access tokens) and a set of
+// verification public keys keyed by `kid` (the active key plus any retired
+// keys still trusted during a rotation window). The private key never leaves
+// this struct — callers get only a Sign method and the public JWKS.
+//
+// The `kid` is the RFC 7638 JWK SHA-256 thumbprint of the public key, so it
+// is stable, collision-resistant, and derivable from the key alone (no
+// separate key-id bookkeeping).
+type Keystore struct {
+	signingKey *ecdsa.PrivateKey
+	signingKID string
+	verifiers  map[string]*ecdsa.PublicKey
+	ephemeral  bool
+}
+
+// NewKeystoreFromPEM builds a Keystore from a PKCS#8 or SEC1 EC private-key
+// PEM. The key MUST be on the P-256 curve (ES256). The returned keystore
+// trusts exactly this one key for both signing and verification.
+func NewKeystoreFromPEM(pemStr string) (*Keystore, error) {
+	key, err := parseECPrivateKeyPEM(pemStr)
+	if err != nil {
+		return nil, fmt.Errorf("identity.NewKeystoreFromPEM: %w", err)
+	}
+	return newKeystore(key, false)
+}
+
+// NewEphemeralKeystore generates a throwaway P-256 key for local development
+// (--dev). Tokens signed with it do not survive a restart. Callers MUST log
+// loudly that an ephemeral key is in use; production requires a static key.
+func NewEphemeralKeystore() (*Keystore, error) {
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		return nil, fmt.Errorf("identity.NewEphemeralKeystore: generate: %w", err)
+	}
+	return newKeystore(key, true)
+}
+
+func newKeystore(key *ecdsa.PrivateKey, ephemeral bool) (*Keystore, error) {
+	if key.Curve != elliptic.P256() {
+		return nil, fmt.Errorf("identity: signing key must be P-256 (ES256), got %s", key.Curve.Params().Name)
+	}
+	kid := jwkThumbprint(&key.PublicKey)
+	return &Keystore{
+		signingKey: key,
+		signingKID: kid,
+		verifiers:  map[string]*ecdsa.PublicKey{kid: &key.PublicKey},
+		ephemeral:  ephemeral,
+	}, nil
+}
+
+// SigningKID returns the `kid` of the active signing key.
+func (k *Keystore) SigningKID() string { return k.signingKID }
+
+// Ephemeral reports whether this keystore uses a throwaway dev key.
+func (k *Keystore) Ephemeral() bool { return k.ephemeral }
+
+// PrivateKey returns the active ES256 signing key. Kept unexported-in-spirit:
+// only the in-package token signer calls it.
+func (k *Keystore) privateKey() *ecdsa.PrivateKey { return k.signingKey }
+
+// PublicKey resolves a verification key by `kid`. It satisfies the
+// auth.ES256KeyResolver consumer interface so the shared JWT validator can
+// verify ES256 tokens minted here. The bool is false for an unknown kid.
+func (k *Keystore) PublicKey(kid string) (*ecdsa.PublicKey, bool) {
+	pub, ok := k.verifiers[kid]
+	return pub, ok
+}
+
+// JWKS returns the public JSON Web Key Set for GET /.well-known/jwks.json.
+// Only public parameters are emitted; the private scalar never appears.
+func (k *Keystore) JWKS() JWKS {
+	keys := make([]JWK, 0, len(k.verifiers))
+	for kid, pub := range k.verifiers {
+		keys = append(keys, ecPublicJWK(pub, kid))
+	}
+	return JWKS{Keys: keys}
+}
+
+// parseECPrivateKeyPEM decodes a PEM block into an ECDSA private key,
+// accepting both PKCS#8 ("PRIVATE KEY") and SEC1 ("EC PRIVATE KEY") encodings.
+func parseECPrivateKeyPEM(pemStr string) (*ecdsa.PrivateKey, error) {
+	block, _ := pem.Decode([]byte(pemStr))
+	if block == nil {
+		return nil, errors.New("no PEM block found (expected an EC PRIVATE KEY / PRIVATE KEY block)")
+	}
+	// SEC1.
+	if key, err := x509.ParseECPrivateKey(block.Bytes); err == nil {
+		return key, nil
+	}
+	// PKCS#8.
+	parsed, err := x509.ParsePKCS8PrivateKey(block.Bytes)
+	if err != nil {
+		return nil, fmt.Errorf("parse EC private key (tried SEC1 and PKCS#8): %w", err)
+	}
+	ecKey, ok := parsed.(*ecdsa.PrivateKey)
+	if !ok {
+		return nil, fmt.Errorf("PKCS#8 key is %T, not *ecdsa.PrivateKey", parsed)
+	}
+	return ecKey, nil
+}
+
+// jwkThumbprint computes the RFC 7638 SHA-256 thumbprint of an EC public key,
+// base64url-encoded (no padding). The JSON is the required members in
+// lexicographic order with no whitespace: {"crv","kty","x","y"}.
+func jwkThumbprint(pub *ecdsa.PublicKey) string {
+	x := coordBase64(pub.X)
+	y := coordBase64(pub.Y)
+	canonical := fmt.Sprintf(`{"crv":"P-256","kty":"EC","x":%q,"y":%q}`, x, y)
+	sum := sha256.Sum256([]byte(canonical))
+	return base64.RawURLEncoding.EncodeToString(sum[:])
+}
+
+// coordBase64 encodes an EC coordinate as a fixed-width 32-byte big-endian
+// value, base64url without padding (JWK "x"/"y" convention).
+func coordBase64(coord *big.Int) string {
+	const p256CoordBytes = 32
+	buf := make([]byte, p256CoordBytes)
+	coord.FillBytes(buf) // left-pads with zeros to exactly 32 bytes
+	return base64.RawURLEncoding.EncodeToString(buf)
+}
+
+// ecPublicJWK builds the public JWK for an EC public key.
+func ecPublicJWK(pub *ecdsa.PublicKey, kid string) JWK {
+	return JWK{
+		Kty: "EC",
+		Crv: "P-256",
+		X:   coordBase64(pub.X),
+		Y:   coordBase64(pub.Y),
+		Use: "sig",
+		Alg: "ES256",
+		Kid: kid,
+	}
+}

--- a/internal/identity/keystore_test.go
+++ b/internal/identity/keystore_test.go
@@ -1,0 +1,128 @@
+package identity
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"encoding/pem"
+	"testing"
+)
+
+// testKeyPEM generates a P-256 PKCS#8 PEM for tests.
+func testKeyPEM(t *testing.T) string {
+	t.Helper()
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("generate key: %v", err)
+	}
+	der, err := x509.MarshalPKCS8PrivateKey(key)
+	if err != nil {
+		t.Fatalf("marshal pkcs8: %v", err)
+	}
+	return string(pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: der}))
+}
+
+func TestNewKeystoreFromPEM_RoundTrip(t *testing.T) {
+	ks, err := NewKeystoreFromPEM(testKeyPEM(t))
+	if err != nil {
+		t.Fatalf("NewKeystoreFromPEM: %v", err)
+	}
+	if ks.SigningKID() == "" {
+		t.Fatal("empty kid")
+	}
+	if ks.Ephemeral() {
+		t.Fatal("static key reported ephemeral")
+	}
+	// The signing kid resolves to a public key.
+	pub, ok := ks.PublicKey(ks.SigningKID())
+	if !ok || pub == nil {
+		t.Fatal("signing kid did not resolve to a public key")
+	}
+	// An unknown kid does not.
+	if _, ok := ks.PublicKey("nope"); ok {
+		t.Fatal("unknown kid resolved")
+	}
+}
+
+func TestKeystore_SEC1PEMAccepted(t *testing.T) {
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("generate: %v", err)
+	}
+	der, err := x509.MarshalECPrivateKey(key) // SEC1 "EC PRIVATE KEY"
+	if err != nil {
+		t.Fatalf("marshal sec1: %v", err)
+	}
+	sec1 := string(pem.EncodeToMemory(&pem.Block{Type: "EC PRIVATE KEY", Bytes: der}))
+	if _, err := NewKeystoreFromPEM(sec1); err != nil {
+		t.Fatalf("SEC1 PEM rejected: %v", err)
+	}
+}
+
+func TestKeystore_RejectsNonP256(t *testing.T) {
+	key, err := ecdsa.GenerateKey(elliptic.P384(), rand.Reader)
+	if err != nil {
+		t.Fatalf("generate p384: %v", err)
+	}
+	der, _ := x509.MarshalPKCS8PrivateKey(key)
+	p384 := string(pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: der}))
+	if _, err := NewKeystoreFromPEM(p384); err == nil {
+		t.Fatal("expected P-384 key to be rejected")
+	}
+}
+
+func TestKeystore_RejectsGarbage(t *testing.T) {
+	if _, err := NewKeystoreFromPEM("not a pem"); err == nil {
+		t.Fatal("expected error for non-PEM input")
+	}
+}
+
+func TestEphemeralKeystore(t *testing.T) {
+	ks, err := NewEphemeralKeystore()
+	if err != nil {
+		t.Fatalf("NewEphemeralKeystore: %v", err)
+	}
+	if !ks.Ephemeral() {
+		t.Fatal("ephemeral keystore not flagged ephemeral")
+	}
+	if ks.SigningKID() == "" {
+		t.Fatal("empty kid")
+	}
+}
+
+func TestKeystore_JWKSShape(t *testing.T) {
+	ks, err := NewKeystoreFromPEM(testKeyPEM(t))
+	if err != nil {
+		t.Fatalf("keystore: %v", err)
+	}
+	jwks := ks.JWKS()
+	if len(jwks.Keys) != 1 {
+		t.Fatalf("expected 1 key, got %d", len(jwks.Keys))
+	}
+	k := jwks.Keys[0]
+	if k.Kty != "EC" || k.Crv != "P-256" || k.Alg != "ES256" || k.Use != "sig" {
+		t.Errorf("unexpected JWK metadata: %+v", k)
+	}
+	if k.Kid != ks.SigningKID() {
+		t.Errorf("JWK kid %q != signing kid %q", k.Kid, ks.SigningKID())
+	}
+	if k.X == "" || k.Y == "" {
+		t.Error("JWK missing coordinates")
+	}
+}
+
+func TestJWKThumbprint_Deterministic(t *testing.T) {
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("generate: %v", err)
+	}
+	a := jwkThumbprint(&key.PublicKey)
+	b := jwkThumbprint(&key.PublicKey)
+	if a != b {
+		t.Errorf("thumbprint not deterministic: %q != %q", a, b)
+	}
+	if a == "" {
+		t.Error("empty thumbprint")
+	}
+}

--- a/internal/identity/linkage.go
+++ b/internal/identity/linkage.go
@@ -1,0 +1,101 @@
+package identity
+
+import (
+	"context"
+	"fmt"
+	"strings"
+)
+
+// resolveUser maps an Apple sign-in to a user CUID, binding it in
+// go_identity_apple on first sign-in. It returns the user id, the best-known
+// name/email for the client projection, and whether a brand-new user was
+// minted.
+//
+// Precedence (ADR-001 §4, same-DB topology):
+//  1. An existing apple_sub binding wins outright — the binding is reused
+//     verbatim so a later email change can never re-point an Apple account.
+//  2. First sign-in: config bootstrap override (verified email -> CUID).
+//  3. First sign-in: verified-email match against the Prisma "User" table.
+//  4. First sign-in: mint a fresh Apple-native user in go_users.
+func (s *Service) resolveUser(ctx context.Context, claims AppleClaims, in AppleSignInInput) (userID, name, email string, newUser bool, err error) {
+	// The email used for linkage MUST be the verified claim (never the
+	// client-supplied advisory field). Empty when Apple asserts no verified
+	// email (hidden-email / relay without verification).
+	verifiedEmail := ""
+	if claims.EmailVerified {
+		verifiedEmail = strings.TrimSpace(claims.Email)
+	}
+	// Name is captured from the client on first authorization (Apple returns
+	// it only once, outside the token). Email for the projection prefers the
+	// verified claim, then the client-supplied advisory value.
+	name = strings.TrimSpace(in.FullName)
+	projEmail := verifiedEmail
+	if projEmail == "" {
+		projEmail = strings.TrimSpace(in.Email)
+	}
+
+	// (1) Existing binding.
+	if existing, found, gErr := s.store.GetAppleIdentity(ctx, claims.Sub); gErr != nil {
+		return "", "", "", false, fmt.Errorf("identity.resolveUser: get binding: %w", gErr)
+	} else if found {
+		// Backfill name/email if we learned them now and lacked them before.
+		if tErr := s.store.TouchAppleLogin(ctx, claims.Sub, verifiedEmail, name); tErr != nil {
+			return "", "", "", false, fmt.Errorf("identity.resolveUser: touch: %w", tErr)
+		}
+		return existing.UserID, firstNonEmpty(name, existing.Name), firstNonEmpty(projEmail, existing.Email), false, nil
+	}
+
+	// First sign-in — resolve the CUID.
+	resolvedID, isNew, rErr := s.resolveFirstSignIn(ctx, verifiedEmail)
+	if rErr != nil {
+		return "", "", "", false, rErr
+	}
+
+	// Bind apple_sub -> user_id, persisting first-sign-in name/email.
+	if iErr := s.store.InsertAppleIdentity(ctx, AppleIdentity{
+		AppleSub: claims.Sub,
+		UserID:   resolvedID,
+		Email:    verifiedEmail,
+		Name:     name,
+	}); iErr != nil {
+		return "", "", "", false, fmt.Errorf("identity.resolveUser: bind: %w", iErr)
+	}
+	return resolvedID, name, projEmail, isNew, nil
+}
+
+// resolveFirstSignIn applies the bootstrap-override then email-match then
+// fresh-mint precedence and returns the CUID plus whether it is a new user.
+func (s *Service) resolveFirstSignIn(ctx context.Context, verifiedEmail string) (userID string, newUser bool, err error) {
+	// (2) Bootstrap override — binds a known user even if email-match misses.
+	if verifiedEmail != "" && s.bootstrap != nil {
+		if cuid, ok := s.bootstrap[strings.ToLower(verifiedEmail)]; ok {
+			return cuid, false, nil
+		}
+	}
+
+	// (3) Verified-email match against the Prisma "User" table (read-only).
+	if verifiedEmail != "" {
+		if id, found, fErr := s.store.FindPrismaUserIDByEmail(ctx, verifiedEmail); fErr != nil {
+			return "", false, fmt.Errorf("identity.resolveFirstSignIn: email match: %w", fErr)
+		} else if found {
+			return id, false, nil
+		}
+	}
+
+	// (4) Fresh mint — a genuinely new user with no legacy row.
+	id := newID()
+	if cErr := s.store.CreateGoUser(ctx, id, verifiedEmail, ""); cErr != nil {
+		return "", false, fmt.Errorf("identity.resolveFirstSignIn: mint: %w", cErr)
+	}
+	return id, true, nil
+}
+
+// firstNonEmpty returns the first non-empty of its arguments.
+func firstNonEmpty(vals ...string) string {
+	for _, v := range vals {
+		if v != "" {
+			return v
+		}
+	}
+	return ""
+}

--- a/internal/identity/pgstore.go
+++ b/internal/identity/pgstore.go
@@ -1,0 +1,137 @@
+package identity
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+// AppleIdentity is a persisted apple_sub -> user_id binding row.
+type AppleIdentity struct {
+	AppleSub string
+	UserID   string
+	Email    string // P1
+	Name     string // P1
+}
+
+// RotateOutcome classifies the result of a refresh-token rotation attempt.
+type RotateOutcome int
+
+const (
+	// RotateInvalid: the presented token hash is unknown.
+	RotateInvalid RotateOutcome = iota
+	// RotateExpired: the token is known and unspent but naturally expired
+	// (benign — no family revoke).
+	RotateExpired
+	// RotateReuse: a spent or revoked token was presented — theft; the whole
+	// family has been revoked.
+	RotateReuse
+	// RotateRotated: the token was valid and has been rotated to a new one.
+	RotateRotated
+)
+
+// RotateResult carries the locked old-row identity fields the service needs
+// to mint the new access token.
+type RotateResult struct {
+	Outcome  RotateOutcome
+	UserID   string
+	FamilyID string
+}
+
+// PgStore is the identity module's pgx-backed persistence. It owns the
+// go_identity_apple / go_users / go_refresh_tokens tables and holds READ-ONLY
+// access to the Prisma "User" table for first-sign-in email linkage (CG-DL-9:
+// never writes a Prisma table).
+type PgStore struct {
+	pool *pgxpool.Pool
+}
+
+// NewPgStore constructs the store.
+func NewPgStore(pool *pgxpool.Pool) *PgStore { return &PgStore{pool: pool} }
+
+const queryGetAppleIdentity = `
+SELECT apple_sub, user_id, COALESCE(email, ''), COALESCE(name, '')
+FROM go_identity_apple WHERE apple_sub = $1`
+
+// GetAppleIdentity returns the binding for an Apple subject, if present.
+func (s *PgStore) GetAppleIdentity(ctx context.Context, appleSub string) (AppleIdentity, bool, error) {
+	var ai AppleIdentity
+	err := s.pool.QueryRow(ctx, queryGetAppleIdentity, appleSub).
+		Scan(&ai.AppleSub, &ai.UserID, &ai.Email, &ai.Name)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return AppleIdentity{}, false, nil
+	}
+	if err != nil {
+		return AppleIdentity{}, false, fmt.Errorf("identity.GetAppleIdentity: %w", err)
+	}
+	return ai, true, nil
+}
+
+const queryInsertAppleIdentity = `
+INSERT INTO go_identity_apple (apple_sub, user_id, email, name)
+VALUES ($1, $2, NULLIF($3, ''), NULLIF($4, ''))`
+
+// InsertAppleIdentity persists a first-sign-in binding. The caller has
+// already resolved user_id via the LINKAGE precedence.
+func (s *PgStore) InsertAppleIdentity(ctx context.Context, ai AppleIdentity) error {
+	_, err := s.pool.Exec(ctx, queryInsertAppleIdentity, ai.AppleSub, ai.UserID, ai.Email, ai.Name)
+	if err != nil {
+		return fmt.Errorf("identity.InsertAppleIdentity: %w", err)
+	}
+	return nil
+}
+
+const queryTouchAppleLogin = `
+UPDATE go_identity_apple
+SET last_login_at = NOW(),
+    email = COALESCE(email, NULLIF($2, '')),
+    name  = COALESCE(name,  NULLIF($3, ''))
+WHERE apple_sub = $1`
+
+// TouchAppleLogin updates last_login_at on a returning sign-in and backfills
+// email/name if Apple supplied them and we did not have them yet. The
+// user_id binding is deliberately never updated (ADR-001 §4).
+func (s *PgStore) TouchAppleLogin(ctx context.Context, appleSub, email, name string) error {
+	_, err := s.pool.Exec(ctx, queryTouchAppleLogin, appleSub, email, name)
+	if err != nil {
+		return fmt.Errorf("identity.TouchAppleLogin: %w", err)
+	}
+	return nil
+}
+
+// queryFindPrismaUserByEmail reads the Prisma-owned "User" table READ-ONLY
+// (CG-DL-9 permits reads, forbids writes). Case-insensitive email match.
+const queryFindPrismaUserByEmail = `
+SELECT "id" FROM "User" WHERE lower("email") = lower($1) LIMIT 1`
+
+// FindPrismaUserIDByEmail resolves an existing web user's CUID by email. Used
+// only on first Apple sign-in when Apple asserts the email is verified.
+func (s *PgStore) FindPrismaUserIDByEmail(ctx context.Context, email string) (userID string, found bool, err error) {
+	if email == "" {
+		return "", false, nil
+	}
+	err = s.pool.QueryRow(ctx, queryFindPrismaUserByEmail, email).Scan(&userID)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return "", false, nil
+	}
+	if err != nil {
+		return "", false, fmt.Errorf("identity.FindPrismaUserIDByEmail: %w", err)
+	}
+	return userID, true, nil
+}
+
+const queryCreateGoUser = `
+INSERT INTO go_users (id, email, name) VALUES ($1, NULLIF($2, ''), NULLIF($3, ''))`
+
+// CreateGoUser mints a brand-new Apple-native user row (no legacy Prisma
+// "User" exists for them). id is a caller-generated cuid.
+func (s *PgStore) CreateGoUser(ctx context.Context, id, email, name string) error {
+	_, err := s.pool.Exec(ctx, queryCreateGoUser, id, email, name)
+	if err != nil {
+		return fmt.Errorf("identity.CreateGoUser: %w", err)
+	}
+	return nil
+}

--- a/internal/identity/pgstore_integration_test.go
+++ b/internal/identity/pgstore_integration_test.go
@@ -1,0 +1,336 @@
+package identity_test
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"encoding/pem"
+	"fmt"
+	"log/slog"
+	"os"
+	"os/exec"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/testcontainers/testcontainers-go"
+	"github.com/testcontainers/testcontainers-go/modules/postgres"
+	"github.com/testcontainers/testcontainers-go/wait"
+
+	"github.com/myrobotaxi/telemetry/internal/auth"
+	"github.com/myrobotaxi/telemetry/internal/identity"
+	"github.com/myrobotaxi/telemetry/internal/store"
+)
+
+var (
+	testPool        *pgxpool.Pool
+	testConnStr     string
+	dockerAvailable bool
+)
+
+func TestMain(m *testing.M) {
+	// The unit tests in package identity share this binary but need no DB, so
+	// a missing Docker daemon must NOT abort the run — it only skips the
+	// integration tests below.
+	if !dockerRunning() {
+		fmt.Fprintln(os.Stderr, "Docker not available — identity integration tests will skip")
+		os.Exit(m.Run())
+	}
+	ctx := context.Background()
+	c, err := postgres.Run(ctx, "postgres:16-alpine",
+		postgres.WithDatabase("testdb"),
+		postgres.WithUsername("testuser"),
+		postgres.WithPassword("testpass"),
+		testcontainers.WithWaitStrategy(
+			wait.ForLog("database system is ready to accept connections").
+				WithOccurrence(2).WithStartupTimeout(60*time.Second)),
+	)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "start postgres: %v\n", err)
+		os.Exit(1)
+	}
+	testConnStr, err = c.ConnectionString(ctx, "sslmode=disable")
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "conn str: %v\n", err)
+		os.Exit(1)
+	}
+	testPool, err = pgxpool.New(ctx, testConnStr)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "pool: %v\n", err)
+		os.Exit(1)
+	}
+	// The Prisma-owned "User" table (minimal shape) for the email-linkage +
+	// existence queries; the go_ tables arrive via our migrations.
+	if _, err := testPool.Exec(ctx, `CREATE TABLE "User" (
+		"id" TEXT PRIMARY KEY, "email" TEXT UNIQUE, "emailVerified" TIMESTAMPTZ)`); err != nil {
+		fmt.Fprintf(os.Stderr, "create User: %v\n", err)
+		os.Exit(1)
+	}
+	if err := store.RunMigrations(ctx, testConnStr, discardLogger()); err != nil {
+		fmt.Fprintf(os.Stderr, "migrations: %v\n", err)
+		os.Exit(1)
+	}
+	dockerAvailable = true
+
+	code := m.Run()
+	testPool.Close()
+	_ = c.Terminate(ctx)
+	os.Exit(code)
+}
+
+func discardLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(discardWriter{}, &slog.HandlerOptions{Level: slog.LevelError}))
+}
+
+type discardWriter struct{}
+
+func (discardWriter) Write(p []byte) (int, error) { return len(p), nil }
+
+func dockerRunning() bool {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	return exec.CommandContext(ctx, "docker", "info").Run() == nil //nolint:gosec // fixed command
+}
+
+func requireDocker(t *testing.T) {
+	t.Helper()
+	if !dockerAvailable {
+		t.Skip("Docker not available — skipping identity integration test")
+	}
+}
+
+func cleanIdentityTables(t *testing.T) {
+	t.Helper()
+	ctx := context.Background()
+	for _, tbl := range []string{"go_refresh_tokens", "go_identity_apple", "go_users", `"User"`} {
+		if _, err := testPool.Exec(ctx, "DELETE FROM "+tbl); err != nil {
+			t.Fatalf("clean %s: %v", tbl, err)
+		}
+	}
+}
+
+func TestPgStore_AppleIdentityRoundTrip(t *testing.T) {
+	requireDocker(t)
+	cleanIdentityTables(t)
+	ctx := context.Background()
+	s := identity.NewPgStore(testPool)
+
+	if _, found, err := s.GetAppleIdentity(ctx, "sub-x"); err != nil || found {
+		t.Fatalf("expected miss, found=%v err=%v", found, err)
+	}
+	if err := s.InsertAppleIdentity(ctx, identity.AppleIdentity{
+		AppleSub: "sub-x", UserID: "cuser1", Email: "a@example.com", Name: "Ada",
+	}); err != nil {
+		t.Fatalf("insert: %v", err)
+	}
+	got, found, err := s.GetAppleIdentity(ctx, "sub-x")
+	if err != nil || !found {
+		t.Fatalf("get: found=%v err=%v", found, err)
+	}
+	if got.UserID != "cuser1" || got.Email != "a@example.com" || got.Name != "Ada" {
+		t.Errorf("round-trip mismatch: %+v", got)
+	}
+	// Touch backfills nothing new but must not error or change user_id.
+	if err := s.TouchAppleLogin(ctx, "sub-x", "a@example.com", "Ada"); err != nil {
+		t.Fatalf("touch: %v", err)
+	}
+}
+
+func TestPgStore_EmailLinkageAndGoUser(t *testing.T) {
+	requireDocker(t)
+	cleanIdentityTables(t)
+	ctx := context.Background()
+	s := identity.NewPgStore(testPool)
+
+	if _, err := testPool.Exec(ctx,
+		`INSERT INTO "User" ("id","email","emailVerified") VALUES ('cprisma','Owner@Example.com', NOW())`); err != nil {
+		t.Fatalf("seed User: %v", err)
+	}
+	// Case-insensitive match.
+	id, found, err := s.FindPrismaUserIDByEmail(ctx, "owner@example.com")
+	if err != nil || !found || id != "cprisma" {
+		t.Fatalf("email match: id=%q found=%v err=%v", id, found, err)
+	}
+	if _, found, _ := s.FindPrismaUserIDByEmail(ctx, "nobody@example.com"); found {
+		t.Error("unexpected match for unknown email")
+	}
+	// Mint an Apple-native user.
+	if err := s.CreateGoUser(ctx, "cgo1", "new@example.com", "New User"); err != nil {
+		t.Fatalf("CreateGoUser: %v", err)
+	}
+}
+
+func TestPgStore_RefreshRotationAndReuse(t *testing.T) {
+	requireDocker(t)
+	cleanIdentityTables(t)
+	ctx := context.Background()
+	s := identity.NewPgStore(testPool)
+
+	root := "hash-root"
+	future := time.Now().Add(90 * 24 * time.Hour)
+	if err := s.InsertRefreshRoot(ctx, root, "fam1", "cuser", future); err != nil {
+		t.Fatalf("insert root: %v", err)
+	}
+	// Rotate root -> t2.
+	res, err := s.RotateRefreshToken(ctx, root, "hash-t2", future)
+	if err != nil {
+		t.Fatalf("rotate: %v", err)
+	}
+	if res.Outcome != identity.RotateRotated || res.UserID != "cuser" {
+		t.Fatalf("rotate outcome = %v user=%q", res.Outcome, res.UserID)
+	}
+	// Present the spent root again -> reuse, family revoked.
+	res, err = s.RotateRefreshToken(ctx, root, "hash-t3", future)
+	if err != nil {
+		t.Fatalf("reuse rotate: %v", err)
+	}
+	if res.Outcome != identity.RotateReuse {
+		t.Fatalf("expected RotateReuse, got %v", res.Outcome)
+	}
+	// t2 is now part of a revoked family -> presenting it is reuse too.
+	res, err = s.RotateRefreshToken(ctx, "hash-t2", "hash-t4", future)
+	if err != nil {
+		t.Fatalf("rotate t2: %v", err)
+	}
+	if res.Outcome != identity.RotateReuse {
+		t.Fatalf("expected revoked-family token to be RotateReuse, got %v", res.Outcome)
+	}
+}
+
+func TestPgStore_RefreshExpiredAndInvalid(t *testing.T) {
+	requireDocker(t)
+	cleanIdentityTables(t)
+	ctx := context.Background()
+	s := identity.NewPgStore(testPool)
+
+	// Unknown token.
+	if res, _ := s.RotateRefreshToken(ctx, "nope", "x", time.Now().Add(time.Hour)); res.Outcome != identity.RotateInvalid {
+		t.Fatalf("unknown token outcome = %v, want RotateInvalid", res.Outcome)
+	}
+	// Expired token (past expiry).
+	if err := s.InsertRefreshRoot(ctx, "hash-old", "fam2", "cuser", time.Now().Add(-time.Hour)); err != nil {
+		t.Fatalf("insert old: %v", err)
+	}
+	if res, _ := s.RotateRefreshToken(ctx, "hash-old", "x", time.Now().Add(time.Hour)); res.Outcome != identity.RotateExpired {
+		t.Fatalf("expired token outcome = %v, want RotateExpired", res.Outcome)
+	}
+}
+
+func TestPgStore_RevokeFamilyByToken(t *testing.T) {
+	requireDocker(t)
+	cleanIdentityTables(t)
+	ctx := context.Background()
+	s := identity.NewPgStore(testPool)
+
+	future := time.Now().Add(24 * time.Hour)
+	_ = s.InsertRefreshRoot(ctx, "hash-r", "fam3", "cuser", future)
+	uid, found, err := s.RevokeFamilyByToken(ctx, "hash-r")
+	if err != nil || !found || uid != "cuser" {
+		t.Fatalf("revoke: uid=%q found=%v err=%v", uid, found, err)
+	}
+	// Now the token is revoked -> rotation is reuse.
+	if res, _ := s.RotateRefreshToken(ctx, "hash-r", "x", future); res.Outcome != identity.RotateReuse {
+		t.Fatalf("revoked token rotate = %v, want RotateReuse", res.Outcome)
+	}
+	// Unknown token -> not found, no error.
+	if _, found, err := s.RevokeFamilyByToken(ctx, "unknown"); err != nil || found {
+		t.Fatalf("revoke unknown: found=%v err=%v", found, err)
+	}
+}
+
+// TestPgStore_ConcurrentRotate asserts the FOR UPDATE lock makes exactly one
+// of two concurrent rotations win; the other is treated as reuse.
+func TestPgStore_ConcurrentRotate(t *testing.T) {
+	requireDocker(t)
+	cleanIdentityTables(t)
+	ctx := context.Background()
+	s := identity.NewPgStore(testPool)
+	future := time.Now().Add(24 * time.Hour)
+	_ = s.InsertRefreshRoot(ctx, "hash-c", "famc", "cuser", future)
+
+	var wg sync.WaitGroup
+	outcomes := make([]identity.RotateOutcome, 2)
+	for i := 0; i < 2; i++ {
+		wg.Add(1)
+		go func(idx int) {
+			defer wg.Done()
+			res, err := s.RotateRefreshToken(ctx, "hash-c", fmt.Sprintf("hash-c-next-%d", idx), future)
+			if err != nil {
+				t.Errorf("rotate %d: %v", idx, err)
+				return
+			}
+			outcomes[idx] = res.Outcome
+		}(i)
+	}
+	wg.Wait()
+
+	rotated, reuse := 0, 0
+	for _, o := range outcomes {
+		switch o {
+		case identity.RotateRotated:
+			rotated++
+		case identity.RotateReuse:
+			reuse++
+		}
+	}
+	if rotated != 1 || reuse != 1 {
+		t.Fatalf("concurrent rotate: rotated=%d reuse=%d (want 1/1); outcomes=%v", rotated, reuse, outcomes)
+	}
+}
+
+// TestE2E_DualAlgWithGoUsersExistence mints an ES256 token for an
+// Apple-native go_users user and validates it through the real
+// JWTAuthenticator (dual-alg + fail-closed existence). A CUID present in
+// neither "User" nor go_users is rejected.
+func TestE2E_DualAlgWithGoUsersExistence(t *testing.T) {
+	requireDocker(t)
+	cleanIdentityTables(t)
+	ctx := context.Background()
+	s := identity.NewPgStore(testPool)
+
+	if err := s.CreateGoUser(ctx, "capple1", "apple@example.com", "Apple User"); err != nil {
+		t.Fatalf("create go user: %v", err)
+	}
+	ks, err := identity.NewKeystoreFromPEM(genP256PEM(t))
+	if err != nil {
+		t.Fatalf("keystore: %v", err)
+	}
+	minter := identity.NewTokenMinter(ks, "myrobotaxi", "telemetry", time.Hour)
+
+	validator := auth.NewJWTAuthenticator("hs-secret", "myrobotaxi", "telemetry", testPool, auth.WithES256Resolver(ks))
+
+	token, _, err := minter.MintAccessToken("capple1")
+	if err != nil {
+		t.Fatalf("mint: %v", err)
+	}
+	uid, err := validator.ValidateToken(ctx, token)
+	if err != nil {
+		t.Fatalf("validate go_users token: %v", err)
+	}
+	if uid != "capple1" {
+		t.Errorf("uid = %q, want capple1", uid)
+	}
+
+	// A token for a nonexistent user is rejected by the existence check.
+	ghost, _, _ := minter.MintAccessToken("cghost-nonexistent")
+	if _, err := validator.ValidateToken(ctx, ghost); err == nil {
+		t.Fatal("token for nonexistent user was accepted")
+	}
+}
+
+// genP256PEM is a local PKCS#8 P-256 PEM generator for the integration file.
+func genP256PEM(t *testing.T) string {
+	t.Helper()
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("gen key: %v", err)
+	}
+	der, err := x509.MarshalPKCS8PrivateKey(key)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	return string(pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: der}))
+}

--- a/internal/identity/pgstore_refresh.go
+++ b/internal/identity/pgstore_refresh.go
@@ -1,0 +1,129 @@
+package identity
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+)
+
+const queryInsertRefreshRoot = `
+INSERT INTO go_refresh_tokens (token_hash, family_id, user_id, expires_at, rotated_from)
+VALUES ($1, $2, $3, $4, NULL)`
+
+// InsertRefreshRoot persists the first refresh token of a new family (issued
+// at sign-in). newID() supplies the family_id at the call site.
+func (s *PgStore) InsertRefreshRoot(ctx context.Context, tokenHash, familyID, userID string, expiresAt time.Time) error {
+	_, err := s.pool.Exec(ctx, queryInsertRefreshRoot, tokenHash, familyID, userID, expiresAt)
+	if err != nil {
+		return fmt.Errorf("identity.InsertRefreshRoot: %w", err)
+	}
+	return nil
+}
+
+// RotateRefreshToken atomically consumes oldHash and issues newHash in the
+// same family. It locks the old row (SELECT ... FOR UPDATE) so two concurrent
+// refreshes cannot both succeed: the first rotates; the second observes a
+// spent row and is treated as reuse (the family is revoked). Outcomes:
+//
+//   - RotateInvalid : oldHash unknown.
+//   - RotateExpired : oldHash known, unspent, but past expiry (no revoke).
+//   - RotateReuse   : oldHash already spent or revoked -> family revoked.
+//   - RotateRotated : success; new row inserted, old row marked spent.
+func (s *PgStore) RotateRefreshToken(ctx context.Context, oldHash, newHash string, newExpiresAt time.Time) (RotateResult, error) {
+	tx, err := s.pool.Begin(ctx)
+	if err != nil {
+		return RotateResult{}, fmt.Errorf("identity.RotateRefreshToken: begin: %w", err)
+	}
+	defer func() { _ = tx.Rollback(ctx) }() // no-op after commit
+
+	var (
+		familyID  string
+		userID    string
+		expiresAt time.Time
+		rotatedTo *string
+		revoked   bool
+	)
+	const selectForUpdate = `
+SELECT family_id, user_id, expires_at, rotated_to, revoked
+FROM go_refresh_tokens WHERE token_hash = $1 FOR UPDATE`
+	err = tx.QueryRow(ctx, selectForUpdate, oldHash).Scan(&familyID, &userID, &expiresAt, &rotatedTo, &revoked)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return RotateResult{Outcome: RotateInvalid}, nil
+	}
+	if err != nil {
+		return RotateResult{}, fmt.Errorf("identity.RotateRefreshToken: select: %w", err)
+	}
+
+	// Spent (already rotated) or explicitly revoked => reuse/theft.
+	if revoked || (rotatedTo != nil && *rotatedTo != "") {
+		if err := revokeFamilyTx(ctx, tx, familyID, "reuse_detected"); err != nil {
+			return RotateResult{}, err
+		}
+		if err := tx.Commit(ctx); err != nil {
+			return RotateResult{}, fmt.Errorf("identity.RotateRefreshToken: commit reuse: %w", err)
+		}
+		return RotateResult{Outcome: RotateReuse, UserID: userID, FamilyID: familyID}, nil
+	}
+
+	// Natural expiry — benign, not an attack. Leave the family intact.
+	if !expiresAt.After(time.Now().UTC()) {
+		return RotateResult{Outcome: RotateExpired, UserID: userID, FamilyID: familyID}, nil
+	}
+
+	const markSpent = `UPDATE go_refresh_tokens SET rotated_to = $2, reason = 'rotated' WHERE token_hash = $1`
+	if _, err := tx.Exec(ctx, markSpent, oldHash, newHash); err != nil {
+		return RotateResult{}, fmt.Errorf("identity.RotateRefreshToken: mark spent: %w", err)
+	}
+	const insertNext = `
+INSERT INTO go_refresh_tokens (token_hash, family_id, user_id, expires_at, rotated_from)
+VALUES ($1, $2, $3, $4, $5)`
+	if _, err := tx.Exec(ctx, insertNext, newHash, familyID, userID, newExpiresAt, oldHash); err != nil {
+		return RotateResult{}, fmt.Errorf("identity.RotateRefreshToken: insert next: %w", err)
+	}
+	if err := tx.Commit(ctx); err != nil {
+		return RotateResult{}, fmt.Errorf("identity.RotateRefreshToken: commit: %w", err)
+	}
+	return RotateResult{Outcome: RotateRotated, UserID: userID, FamilyID: familyID}, nil
+}
+
+// RevokeFamilyByToken revokes the whole family the given token belongs to
+// (explicit sign-out via /api/auth/revoke). Returns found=false when the
+// token is unknown so the handler can respond without leaking existence.
+func (s *PgStore) RevokeFamilyByToken(ctx context.Context, tokenHash string) (userID string, found bool, err error) {
+	const selectFamily = `SELECT family_id, user_id FROM go_refresh_tokens WHERE token_hash = $1`
+	var familyID string
+	err = s.pool.QueryRow(ctx, selectFamily, tokenHash).Scan(&familyID, &userID)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return "", false, nil
+	}
+	if err != nil {
+		return "", false, fmt.Errorf("identity.RevokeFamilyByToken: select: %w", err)
+	}
+	tx, err := s.pool.Begin(ctx)
+	if err != nil {
+		return "", false, fmt.Errorf("identity.RevokeFamilyByToken: begin: %w", err)
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+	if err := revokeFamilyTx(ctx, tx, familyID, "revoked"); err != nil {
+		return "", false, err
+	}
+	if err := tx.Commit(ctx); err != nil {
+		return "", false, fmt.Errorf("identity.RevokeFamilyByToken: commit: %w", err)
+	}
+	return userID, true, nil
+}
+
+// revokeFamilyTx marks every not-yet-revoked token in a family revoked.
+func revokeFamilyTx(ctx context.Context, tx pgx.Tx, familyID, reason string) error {
+	const q = `
+UPDATE go_refresh_tokens
+SET revoked = TRUE, revoked_at = NOW(), reason = $2
+WHERE family_id = $1 AND revoked = FALSE`
+	if _, err := tx.Exec(ctx, q, familyID, reason); err != nil {
+		return fmt.Errorf("identity.revokeFamily(%s): %w", reason, err)
+	}
+	return nil
+}

--- a/internal/identity/ratelimit.go
+++ b/internal/identity/ratelimit.go
@@ -1,0 +1,71 @@
+package identity
+
+import (
+	"sync"
+	"time"
+
+	"golang.org/x/time/rate"
+)
+
+// ipRateLimiter is a per-client-IP token-bucket limiter guarding the
+// pre-authentication /api/auth/* surface against brute-force / credential
+// spraying. It follows the in-repo precedent of golang.org/x/time/rate
+// (internal/geocode). Idle IP entries are evicted to bound memory.
+type ipRateLimiter struct {
+	mu       sync.Mutex
+	limiters map[string]*ipEntry
+	limit    rate.Limit
+	burst    int
+	ttl      time.Duration
+	now      func() time.Time
+}
+
+type ipEntry struct {
+	limiter  *rate.Limiter
+	lastSeen time.Time
+}
+
+// newIPRateLimiter builds a limiter allowing perMinute sustained requests per
+// IP with the given burst. perMinute<=0 disables limiting (allow always).
+func newIPRateLimiter(perMinute, burst int) *ipRateLimiter {
+	if burst < 1 {
+		burst = 1
+	}
+	return &ipRateLimiter{
+		limiters: make(map[string]*ipEntry),
+		limit:    rate.Limit(float64(perMinute) / 60.0),
+		burst:    burst,
+		ttl:      10 * time.Minute,
+		now:      time.Now,
+	}
+}
+
+// allow reports whether a request from ip may proceed. A disabled limiter
+// (non-positive rate) always allows.
+func (l *ipRateLimiter) allow(ip string) bool {
+	if l.limit <= 0 {
+		return true
+	}
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	now := l.now()
+	e, ok := l.limiters[ip]
+	if !ok {
+		e = &ipEntry{limiter: rate.NewLimiter(l.limit, l.burst)}
+		l.limiters[ip] = e
+	}
+	e.lastSeen = now
+	l.evictLocked(now)
+	return e.limiter.AllowN(now, 1)
+}
+
+// evictLocked drops entries idle longer than ttl. Called under l.mu; cheap
+// because the pre-auth IP set is small at v1 scale.
+func (l *ipRateLimiter) evictLocked(now time.Time) {
+	for ip, e := range l.limiters {
+		if now.Sub(e.lastSeen) > l.ttl {
+			delete(l.limiters, ip)
+		}
+	}
+}

--- a/internal/identity/ratelimit_test.go
+++ b/internal/identity/ratelimit_test.go
@@ -1,0 +1,57 @@
+package identity
+
+import (
+	"testing"
+	"time"
+)
+
+func TestIPRateLimiter_BurstThenThrottle(t *testing.T) {
+	l := newIPRateLimiter(60, 2) // 1/sec, burst 2
+	base := time.Unix(1_000_000, 0)
+	l.now = func() time.Time { return base }
+
+	if !l.allow("1.1.1.1") {
+		t.Fatal("first request in burst should be allowed")
+	}
+	if !l.allow("1.1.1.1") {
+		t.Fatal("second request in burst should be allowed")
+	}
+	if l.allow("1.1.1.1") {
+		t.Fatal("third immediate request should be throttled")
+	}
+	// A different IP has its own bucket.
+	if !l.allow("2.2.2.2") {
+		t.Fatal("distinct IP should be allowed")
+	}
+	// After time passes, the bucket refills.
+	l.now = func() time.Time { return base.Add(2 * time.Second) }
+	if !l.allow("1.1.1.1") {
+		t.Fatal("bucket should refill after 2s")
+	}
+}
+
+func TestIPRateLimiter_DisabledAlwaysAllows(t *testing.T) {
+	l := newIPRateLimiter(0, 0) // disabled
+	for i := 0; i < 100; i++ {
+		if !l.allow("9.9.9.9") {
+			t.Fatal("disabled limiter must always allow")
+		}
+	}
+}
+
+func TestIPRateLimiter_Eviction(t *testing.T) {
+	l := newIPRateLimiter(60, 1)
+	base := time.Unix(2_000_000, 0)
+	l.now = func() time.Time { return base }
+	l.allow("a")
+	l.allow("b")
+	// Advance beyond ttl; a new request prunes idle entries.
+	l.now = func() time.Time { return base.Add(l.ttl + time.Minute) }
+	l.allow("c")
+	l.mu.Lock()
+	_, aStill := l.limiters["a"]
+	l.mu.Unlock()
+	if aStill {
+		t.Error("idle entry should have been evicted")
+	}
+}

--- a/internal/identity/service.go
+++ b/internal/identity/service.go
@@ -1,0 +1,187 @@
+package identity
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"time"
+)
+
+// Store is the persistence surface the Service depends on (consumer-site
+// interface; PgStore is the production implementation, and tests supply a
+// fake). It spans the three Go-owned tables plus the read-only Prisma "User"
+// email lookup used for first-sign-in linkage.
+type Store interface {
+	GetAppleIdentity(ctx context.Context, appleSub string) (AppleIdentity, bool, error)
+	InsertAppleIdentity(ctx context.Context, ai AppleIdentity) error
+	TouchAppleLogin(ctx context.Context, appleSub, email, name string) error
+	FindPrismaUserIDByEmail(ctx context.Context, email string) (string, bool, error)
+	CreateGoUser(ctx context.Context, id, email, name string) error
+
+	InsertRefreshRoot(ctx context.Context, tokenHash, familyID, userID string, expiresAt time.Time) error
+	RotateRefreshToken(ctx context.Context, oldHash, newHash string, newExpiresAt time.Time) (RotateResult, error)
+	RevokeFamilyByToken(ctx context.Context, tokenHash string) (userID string, found bool, err error)
+}
+
+// appleTokenValidator is the consumer-site view of AppleValidator.
+type appleTokenValidator interface {
+	Validate(ctx context.Context, idToken, expectedNonce string) (AppleClaims, error)
+}
+
+// Service is the identity module's application core: it validates Apple
+// tokens, resolves/binds the user, and mints the access + refresh pair.
+type Service struct {
+	store      Store
+	apple      appleTokenValidator
+	minter     *TokenMinter
+	audit      *auditLogger
+	bootstrap  map[string]string // lower-email -> existing user CUID
+	refreshTTL time.Duration
+	now        func() time.Time
+}
+
+// ServiceConfig bundles the Service's construction inputs. Apple is the
+// consumer-site interface so tests can inject a fake validator; the composition
+// root passes a *AppleValidator (which satisfies it).
+type ServiceConfig struct {
+	Store             Store
+	Apple             appleTokenValidator
+	Minter            *TokenMinter
+	BootstrapEmailMap map[string]string
+	RefreshTTL        time.Duration
+	Logger            *slog.Logger
+}
+
+// NewService constructs the identity service. The auth audit logger is built
+// internally from Logger so callers never touch the module's audit surface.
+func NewService(cfg ServiceConfig) *Service {
+	return &Service{
+		store:      cfg.Store,
+		apple:      cfg.Apple,
+		minter:     cfg.Minter,
+		audit:      newAuditLogger(cfg.Logger),
+		bootstrap:  cfg.BootstrapEmailMap,
+		refreshTTL: cfg.RefreshTTL,
+		now:        time.Now,
+	}
+}
+
+// AppleSignInInput is the validated POST /api/auth/apple request.
+type AppleSignInInput struct {
+	IdentityToken string // Apple identity token (JWT)
+	FullName      string // optional; Apple returns the name only on first authorization
+	Email         string // optional client-supplied email (advisory only)
+	Nonce         string // optional; matched against the token nonce when present
+}
+
+// UserInfo is the public user projection returned to the client.
+type UserInfo struct {
+	ID    string `json:"id"`
+	Name  string `json:"name,omitempty"`
+	Email string `json:"email,omitempty"`
+}
+
+// AuthResult is the token pair + user returned by sign-in and refresh.
+type AuthResult struct {
+	AccessToken  string
+	ExpiresIn    int
+	RefreshToken string
+	User         UserInfo
+}
+
+// SignInWithApple validates the Apple identity token, resolves the user (see
+// resolveUser), and issues a fresh access + refresh-family pair.
+func (s *Service) SignInWithApple(ctx context.Context, in AppleSignInInput) (AuthResult, error) {
+	claims, err := s.apple.Validate(ctx, in.IdentityToken, in.Nonce)
+	if err != nil {
+		return AuthResult{}, fmt.Errorf("identity.SignInWithApple: %w", err) // chain preserves ErrInvalidAppleToken
+	}
+
+	userID, name, email, newUser, err := s.resolveUser(ctx, claims, in)
+	if err != nil {
+		return AuthResult{}, err
+	}
+
+	pair, err := s.issuePair(ctx, userID)
+	if err != nil {
+		return AuthResult{}, err
+	}
+	s.audit.signIn(userID, newUser)
+
+	pair.User = UserInfo{ID: userID, Name: name, Email: email}
+	return pair, nil
+}
+
+// Refresh performs single-use rotation with family reuse-detection.
+func (s *Service) Refresh(ctx context.Context, rawRefresh string) (AuthResult, error) {
+	if rawRefresh == "" {
+		return AuthResult{}, ErrInvalidRefreshToken
+	}
+	oldHash := hashRefreshToken(rawRefresh)
+	newRaw, newHash, err := newRefreshToken()
+	if err != nil {
+		return AuthResult{}, fmt.Errorf("identity.Refresh: %w", err)
+	}
+	newExpiry := s.now().UTC().Add(s.refreshTTL)
+
+	res, err := s.store.RotateRefreshToken(ctx, oldHash, newHash, newExpiry)
+	if err != nil {
+		return AuthResult{}, fmt.Errorf("identity.Refresh: %w", err)
+	}
+	switch res.Outcome {
+	case RotateReuse:
+		s.audit.reuseDetected(res.UserID, res.FamilyID)
+		return AuthResult{}, ErrRefreshReuseDetected
+	case RotateInvalid, RotateExpired:
+		return AuthResult{}, ErrInvalidRefreshToken
+	case RotateRotated:
+		access, expiresIn, err := s.minter.MintAccessToken(res.UserID)
+		if err != nil {
+			return AuthResult{}, fmt.Errorf("identity.Refresh: mint: %w", err)
+		}
+		s.audit.refresh(res.UserID)
+		return AuthResult{
+			AccessToken:  access,
+			ExpiresIn:    expiresIn,
+			RefreshToken: newRaw,
+			User:         UserInfo{ID: res.UserID},
+		}, nil
+	default:
+		return AuthResult{}, ErrInvalidRefreshToken
+	}
+}
+
+// Revoke revokes the whole refresh-token family a token belongs to. It is
+// intentionally non-committal about whether the token existed (no oracle):
+// an unknown token is a silent success.
+func (s *Service) Revoke(ctx context.Context, rawRefresh string) error {
+	if rawRefresh == "" {
+		return nil
+	}
+	userID, found, err := s.store.RevokeFamilyByToken(ctx, hashRefreshToken(rawRefresh))
+	if err != nil {
+		return fmt.Errorf("identity.Revoke: %w", err)
+	}
+	if found {
+		s.audit.revoke(userID)
+	}
+	return nil
+}
+
+// issuePair mints an access token and a new refresh-token family for userID.
+func (s *Service) issuePair(ctx context.Context, userID string) (AuthResult, error) {
+	access, expiresIn, err := s.minter.MintAccessToken(userID)
+	if err != nil {
+		return AuthResult{}, fmt.Errorf("identity.issuePair: mint access: %w", err)
+	}
+	rawRefresh, refreshHash, err := newRefreshToken()
+	if err != nil {
+		return AuthResult{}, fmt.Errorf("identity.issuePair: %w", err)
+	}
+	familyID := newID()
+	expiry := s.now().UTC().Add(s.refreshTTL)
+	if err := s.store.InsertRefreshRoot(ctx, refreshHash, familyID, userID, expiry); err != nil {
+		return AuthResult{}, fmt.Errorf("identity.issuePair: persist refresh: %w", err)
+	}
+	return AuthResult{AccessToken: access, ExpiresIn: expiresIn, RefreshToken: rawRefresh}, nil
+}

--- a/internal/identity/service_test.go
+++ b/internal/identity/service_test.go
@@ -1,0 +1,269 @@
+package identity
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+)
+
+// fakeApple is an injectable Apple token validator.
+type fakeApple struct {
+	claims AppleClaims
+	err    error
+}
+
+func (f fakeApple) Validate(context.Context, string, string) (AppleClaims, error) {
+	return f.claims, f.err
+}
+
+// fakeStore is an in-memory Store for service/linkage/handler tests.
+type fakeStore struct {
+	apple         map[string]AppleIdentity // apple_sub -> binding
+	prismaByEmail map[string]string        // lower-email -> Prisma User CUID
+	goUsers       map[string]string        // id -> email
+
+	inserted   []AppleIdentity
+	touched    []string
+	createdIDs []string
+
+	rotateResult RotateResult
+	rotateErr    error
+	rootInserts  int
+
+	revokeUserID string
+	revokeFound  bool
+}
+
+func newFakeStore() *fakeStore {
+	return &fakeStore{
+		apple:         map[string]AppleIdentity{},
+		prismaByEmail: map[string]string{},
+		goUsers:       map[string]string{},
+	}
+}
+
+func (s *fakeStore) GetAppleIdentity(_ context.Context, sub string) (AppleIdentity, bool, error) {
+	ai, ok := s.apple[sub]
+	return ai, ok, nil
+}
+
+func (s *fakeStore) InsertAppleIdentity(_ context.Context, ai AppleIdentity) error {
+	s.apple[ai.AppleSub] = ai
+	s.inserted = append(s.inserted, ai)
+	return nil
+}
+
+func (s *fakeStore) TouchAppleLogin(_ context.Context, sub, _, _ string) error {
+	s.touched = append(s.touched, sub)
+	return nil
+}
+
+func (s *fakeStore) FindPrismaUserIDByEmail(_ context.Context, email string) (string, bool, error) {
+	id, ok := s.prismaByEmail[email]
+	return id, ok, nil
+}
+
+func (s *fakeStore) CreateGoUser(_ context.Context, id, email, _ string) error {
+	s.goUsers[id] = email
+	s.createdIDs = append(s.createdIDs, id)
+	return nil
+}
+
+func (s *fakeStore) InsertRefreshRoot(context.Context, string, string, string, time.Time) error {
+	s.rootInserts++
+	return nil
+}
+
+func (s *fakeStore) RotateRefreshToken(context.Context, string, string, time.Time) (RotateResult, error) {
+	return s.rotateResult, s.rotateErr
+}
+
+func (s *fakeStore) RevokeFamilyByToken(context.Context, string) (string, bool, error) {
+	return s.revokeUserID, s.revokeFound, nil
+}
+
+func newTestService(t *testing.T, store Store, apple appleTokenValidator, bootstrap map[string]string) *Service {
+	t.Helper()
+	ks, err := NewKeystoreFromPEM(testKeyPEM(t))
+	if err != nil {
+		t.Fatalf("keystore: %v", err)
+	}
+	return NewService(ServiceConfig{
+		Store:             store,
+		Apple:             apple,
+		Minter:            NewTokenMinter(ks, "myrobotaxi", "telemetry", time.Hour),
+		BootstrapEmailMap: bootstrap,
+		RefreshTTL:        90 * 24 * time.Hour,
+		Logger:            nil,
+	})
+}
+
+func TestSignIn_ExistingBindingReused(t *testing.T) {
+	store := newFakeStore()
+	store.apple["apple-sub-1"] = AppleIdentity{AppleSub: "apple-sub-1", UserID: "cexisting", Name: "Old", Email: "old@example.com"}
+	svc := newTestService(t, store, fakeApple{claims: AppleClaims{Sub: "apple-sub-1", Email: "new@example.com", EmailVerified: true}}, nil)
+
+	res, err := svc.SignInWithApple(context.Background(), AppleSignInInput{IdentityToken: "x"})
+	if err != nil {
+		t.Fatalf("SignIn: %v", err)
+	}
+	if res.User.ID != "cexisting" {
+		t.Errorf("user id = %q, want cexisting (binding reused, never re-pointed)", res.User.ID)
+	}
+	if len(store.touched) != 1 {
+		t.Errorf("expected last-login touch, got %d", len(store.touched))
+	}
+	if res.AccessToken == "" || res.RefreshToken == "" {
+		t.Error("missing tokens")
+	}
+}
+
+func TestSignIn_BootstrapOverride(t *testing.T) {
+	store := newFakeStore()
+	// Email-match would MISS (no prisma row), but the bootstrap binds the CUID.
+	svc := newTestService(t, store,
+		fakeApple{claims: AppleClaims{Sub: "apple-new", Email: "Owner@Example.com", EmailVerified: true}},
+		map[string]string{"owner@example.com": "cmmgr4b1p0005l104ifpctlg8"})
+
+	res, err := svc.SignInWithApple(context.Background(), AppleSignInInput{IdentityToken: "x"})
+	if err != nil {
+		t.Fatalf("SignIn: %v", err)
+	}
+	if res.User.ID != "cmmgr4b1p0005l104ifpctlg8" {
+		t.Errorf("user id = %q, want bootstrap CUID", res.User.ID)
+	}
+	if len(store.inserted) != 1 || store.inserted[0].UserID != "cmmgr4b1p0005l104ifpctlg8" {
+		t.Error("apple binding not persisted to bootstrap CUID")
+	}
+	if len(store.createdIDs) != 0 {
+		t.Error("bootstrap override should not mint a go_users row")
+	}
+}
+
+func TestSignIn_EmailMatch(t *testing.T) {
+	store := newFakeStore()
+	store.prismaByEmail["owner@example.com"] = "cprismauser"
+	svc := newTestService(t, store,
+		fakeApple{claims: AppleClaims{Sub: "apple-new", Email: "owner@example.com", EmailVerified: true}}, nil)
+
+	res, err := svc.SignInWithApple(context.Background(), AppleSignInInput{IdentityToken: "x"})
+	if err != nil {
+		t.Fatalf("SignIn: %v", err)
+	}
+	if res.User.ID != "cprismauser" {
+		t.Errorf("user id = %q, want cprismauser (email-matched)", res.User.ID)
+	}
+	if len(store.createdIDs) != 0 {
+		t.Error("email-match should not mint a go_users row")
+	}
+}
+
+func TestSignIn_UnverifiedEmailDoesNotMatch(t *testing.T) {
+	store := newFakeStore()
+	store.prismaByEmail["owner@example.com"] = "cprismauser"
+	// email present but NOT verified -> must NOT link by email; mints fresh.
+	svc := newTestService(t, store,
+		fakeApple{claims: AppleClaims{Sub: "apple-new", Email: "owner@example.com", EmailVerified: false}}, nil)
+
+	res, err := svc.SignInWithApple(context.Background(), AppleSignInInput{IdentityToken: "x"})
+	if err != nil {
+		t.Fatalf("SignIn: %v", err)
+	}
+	if res.User.ID == "cprismauser" {
+		t.Error("unverified email must not link to the Prisma user")
+	}
+	if len(store.createdIDs) != 1 {
+		t.Errorf("expected a fresh go_users mint, got %d", len(store.createdIDs))
+	}
+}
+
+func TestSignIn_FreshMint(t *testing.T) {
+	store := newFakeStore()
+	svc := newTestService(t, store,
+		fakeApple{claims: AppleClaims{Sub: "apple-brand-new", Email: "new@example.com", EmailVerified: true}}, nil)
+
+	res, err := svc.SignInWithApple(context.Background(), AppleSignInInput{IdentityToken: "x", FullName: "Ada Lovelace"})
+	if err != nil {
+		t.Fatalf("SignIn: %v", err)
+	}
+	if len(store.createdIDs) != 1 {
+		t.Fatalf("expected 1 minted user, got %d", len(store.createdIDs))
+	}
+	if res.User.ID != store.createdIDs[0] {
+		t.Errorf("returned id %q != minted id %q", res.User.ID, store.createdIDs[0])
+	}
+	if res.User.Name != "Ada Lovelace" {
+		t.Errorf("name = %q, want first-sign-in FullName", res.User.Name)
+	}
+}
+
+func TestSignIn_InvalidAppleToken(t *testing.T) {
+	svc := newTestService(t, newFakeStore(), fakeApple{err: ErrInvalidAppleToken}, nil)
+	if _, err := svc.SignInWithApple(context.Background(), AppleSignInInput{IdentityToken: "x"}); !errors.Is(err, ErrInvalidAppleToken) {
+		t.Fatalf("err = %v, want ErrInvalidAppleToken", err)
+	}
+}
+
+func TestRefresh_Rotated(t *testing.T) {
+	store := newFakeStore()
+	store.rotateResult = RotateResult{Outcome: RotateRotated, UserID: "cuser", FamilyID: "fam1"}
+	svc := newTestService(t, store, fakeApple{}, nil)
+
+	res, err := svc.Refresh(context.Background(), "some-refresh-token")
+	if err != nil {
+		t.Fatalf("Refresh: %v", err)
+	}
+	if res.AccessToken == "" || res.RefreshToken == "" {
+		t.Error("rotated refresh missing tokens")
+	}
+	if res.User.ID != "cuser" {
+		t.Errorf("user id = %q", res.User.ID)
+	}
+}
+
+func TestRefresh_ReuseDetected(t *testing.T) {
+	store := newFakeStore()
+	store.rotateResult = RotateResult{Outcome: RotateReuse, UserID: "cuser", FamilyID: "fam1"}
+	svc := newTestService(t, store, fakeApple{}, nil)
+
+	if _, err := svc.Refresh(context.Background(), "spent-token"); !errors.Is(err, ErrRefreshReuseDetected) {
+		t.Fatalf("err = %v, want ErrRefreshReuseDetected", err)
+	}
+}
+
+func TestRefresh_InvalidAndExpired(t *testing.T) {
+	for _, outcome := range []RotateOutcome{RotateInvalid, RotateExpired} {
+		store := newFakeStore()
+		store.rotateResult = RotateResult{Outcome: outcome}
+		svc := newTestService(t, store, fakeApple{}, nil)
+		if _, err := svc.Refresh(context.Background(), "tok"); !errors.Is(err, ErrInvalidRefreshToken) {
+			t.Errorf("outcome %v: err = %v, want ErrInvalidRefreshToken", outcome, err)
+		}
+	}
+}
+
+func TestRefresh_EmptyToken(t *testing.T) {
+	svc := newTestService(t, newFakeStore(), fakeApple{}, nil)
+	if _, err := svc.Refresh(context.Background(), ""); !errors.Is(err, ErrInvalidRefreshToken) {
+		t.Fatalf("err = %v, want ErrInvalidRefreshToken", err)
+	}
+}
+
+func TestRevoke(t *testing.T) {
+	store := newFakeStore()
+	store.revokeFound = true
+	store.revokeUserID = "cuser"
+	svc := newTestService(t, store, fakeApple{}, nil)
+	if err := svc.Revoke(context.Background(), "tok"); err != nil {
+		t.Fatalf("Revoke: %v", err)
+	}
+	// Unknown token: still a silent success (no oracle).
+	store.revokeFound = false
+	if err := svc.Revoke(context.Background(), "unknown"); err != nil {
+		t.Fatalf("Revoke unknown: %v", err)
+	}
+	if err := svc.Revoke(context.Background(), ""); err != nil {
+		t.Fatalf("Revoke empty: %v", err)
+	}
+}

--- a/internal/identity/token.go
+++ b/internal/identity/token.go
@@ -1,0 +1,59 @@
+package identity
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/golang-jwt/jwt/v5"
+)
+
+// TokenMinter mints ES256 access tokens signed by the Keystore's active key.
+// The tokens are validated by the shared auth.JWTAuthenticator (dual-alg),
+// which resolves the `kid` header to the public key via the Keystore.
+type TokenMinter struct {
+	keystore *Keystore
+	issuer   string
+	audience string
+	ttl      time.Duration
+	now      func() time.Time // injectable clock for tests
+}
+
+// NewTokenMinter builds a minter. issuer/audience MUST match the values the
+// dual-alg validator checks (config auth.token_issuer / auth.token_audience —
+// "myrobotaxi" / "telemetry") so ES256 and legacy HS256 tokens validate
+// identically. ttl is the access-token lifetime (~1h).
+func NewTokenMinter(keystore *Keystore, issuer, audience string, ttl time.Duration) *TokenMinter {
+	return &TokenMinter{
+		keystore: keystore,
+		issuer:   issuer,
+		audience: audience,
+		ttl:      ttl,
+		now:      time.Now,
+	}
+}
+
+// MintAccessToken signs a fresh ES256 access token for userID (a user CUID).
+// It returns the compact JWT and the lifetime in whole seconds (the
+// `expiresIn` the iOS client uses to schedule a proactive refresh).
+func (m *TokenMinter) MintAccessToken(userID string) (token string, expiresIn int, err error) {
+	if m.keystore == nil || m.keystore.privateKey() == nil {
+		return "", 0, fmt.Errorf("identity.MintAccessToken: %w", ErrNoSigningKey)
+	}
+	now := m.now().UTC()
+	claims := jwt.RegisteredClaims{
+		Subject:   userID,
+		Issuer:    m.issuer,
+		Audience:  jwt.ClaimStrings{m.audience},
+		IssuedAt:  jwt.NewNumericDate(now),
+		NotBefore: jwt.NewNumericDate(now),
+		ExpiresAt: jwt.NewNumericDate(now.Add(m.ttl)),
+	}
+	jwtToken := jwt.NewWithClaims(jwt.SigningMethodES256, claims)
+	jwtToken.Header["kid"] = m.keystore.SigningKID()
+
+	signed, err := jwtToken.SignedString(m.keystore.privateKey())
+	if err != nil {
+		return "", 0, fmt.Errorf("identity.MintAccessToken: sign: %w", err)
+	}
+	return signed, int(m.ttl.Seconds()), nil
+}

--- a/internal/identity/token_test.go
+++ b/internal/identity/token_test.go
@@ -1,0 +1,71 @@
+package identity
+
+import (
+	"testing"
+	"time"
+
+	"github.com/golang-jwt/jwt/v5"
+)
+
+func TestMintAccessToken_ClaimsAndHeader(t *testing.T) {
+	ks, err := NewKeystoreFromPEM(testKeyPEM(t))
+	if err != nil {
+		t.Fatalf("keystore: %v", err)
+	}
+	minter := NewTokenMinter(ks, "myrobotaxi", "telemetry", time.Hour)
+	fixed := time.Date(2030, 7, 10, 12, 0, 0, 0, time.UTC)
+	minter.now = func() time.Time { return fixed }
+
+	token, expiresIn, err := minter.MintAccessToken("cmmgr4b1p0005l104ifpctlg8")
+	if err != nil {
+		t.Fatalf("MintAccessToken: %v", err)
+	}
+	if expiresIn != 3600 {
+		t.Errorf("expiresIn = %d, want 3600", expiresIn)
+	}
+
+	// Verify via the keystore's own public key resolver.
+	parsed, err := jwt.Parse(token, func(tok *jwt.Token) (any, error) {
+		if tok.Method.Alg() != "ES256" {
+			t.Fatalf("alg = %s, want ES256", tok.Method.Alg())
+		}
+		kid, _ := tok.Header["kid"].(string)
+		if kid != ks.SigningKID() {
+			t.Fatalf("kid header = %q, want %q", kid, ks.SigningKID())
+		}
+		pub, ok := ks.PublicKey(kid)
+		if !ok {
+			t.Fatalf("kid did not resolve")
+		}
+		return pub, nil
+	}, jwt.WithValidMethods([]string{"ES256"}), jwt.WithTimeFunc(func() time.Time { return fixed }))
+	if err != nil {
+		t.Fatalf("parse minted token: %v", err)
+	}
+
+	claims, ok := parsed.Claims.(jwt.MapClaims)
+	if !ok {
+		t.Fatal("claims not MapClaims")
+	}
+	if claims["sub"] != "cmmgr4b1p0005l104ifpctlg8" {
+		t.Errorf("sub = %v", claims["sub"])
+	}
+	if claims["iss"] != "myrobotaxi" {
+		t.Errorf("iss = %v", claims["iss"])
+	}
+	// aud is an array in the token.
+	if aud, _ := parsed.Claims.GetAudience(); len(aud) != 1 || aud[0] != "telemetry" {
+		t.Errorf("aud = %v", aud)
+	}
+	exp, _ := parsed.Claims.GetExpirationTime()
+	if !exp.Equal(fixed.Add(time.Hour)) {
+		t.Errorf("exp = %v, want %v", exp.Time, fixed.Add(time.Hour))
+	}
+}
+
+func TestMintAccessToken_NoSigningKey(t *testing.T) {
+	minter := NewTokenMinter(&Keystore{}, "iss", "aud", time.Hour)
+	if _, _, err := minter.MintAccessToken("u"); err == nil {
+		t.Fatal("expected ErrNoSigningKey")
+	}
+}

--- a/internal/identity/tokens_random.go
+++ b/internal/identity/tokens_random.go
@@ -1,0 +1,48 @@
+package identity
+
+import (
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/hex"
+	"fmt"
+	"time"
+)
+
+// refreshTokenBytes sizes the opaque refresh token: 32 bytes = 256 bits of
+// entropy, base64url-encoded to the client. Only its SHA-256 hash is stored.
+const refreshTokenBytes = 32
+
+// idRandomBytes sizes the random suffix of a cuid-shaped id (16 bytes -> 32
+// hex chars + "c" prefix), matching the platform convention (see
+// store.newRideRequestID / mask.newAuditID).
+const idRandomBytes = 16
+
+// newRefreshToken returns a fresh opaque refresh token and its SHA-256 hex
+// digest. The raw token is returned to the client exactly once; the server
+// persists only the hash (go_refresh_tokens.token_hash).
+func newRefreshToken() (raw, hash string, err error) {
+	b := make([]byte, refreshTokenBytes)
+	if _, err := rand.Read(b); err != nil {
+		return "", "", fmt.Errorf("identity.newRefreshToken: read entropy: %w", err)
+	}
+	raw = base64.RawURLEncoding.EncodeToString(b)
+	return raw, hashRefreshToken(raw), nil
+}
+
+// hashRefreshToken returns the lowercase SHA-256 hex digest of a raw refresh
+// token — the value stored and looked up in go_refresh_tokens.
+func hashRefreshToken(raw string) string {
+	sum := sha256.Sum256([]byte(raw))
+	return hex.EncodeToString(sum[:])
+}
+
+// newID generates a cuid-shaped identifier for a Go-owned row (a go_users id
+// or a refresh-token family_id). Mirrors store.newRideRequestID.
+func newID() string {
+	b := make([]byte, idRandomBytes)
+	if _, err := rand.Read(b); err != nil {
+		return fmt.Sprintf("c%x", time.Now().UnixNano())
+	}
+	return "c" + hex.EncodeToString(b)
+}

--- a/internal/store/migrations/0003_identity.down.sql
+++ b/internal/store/migrations/0003_identity.down.sql
@@ -1,0 +1,8 @@
+-- 0003_identity.down.sql
+--
+-- Reverts MYR-193: drops the Go-owned identity tables (indexes drop with
+-- them). Order is irrelevant — there are no foreign keys (CG-DL-9).
+
+DROP TABLE IF EXISTS go_refresh_tokens;
+DROP TABLE IF EXISTS go_identity_apple;
+DROP TABLE IF EXISTS go_users;

--- a/internal/store/migrations/0003_identity.up.sql
+++ b/internal/store/migrations/0003_identity.up.sql
@@ -1,0 +1,77 @@
+-- 0003_identity.up.sql
+--
+-- MYR-193: the identity module's own tables (ADR-001,
+-- docs/architecture/adr-001-identity-module.md). Native Sign in with Apple
+-- resolves to a user CUID; ES256 access tokens + rotating refresh tokens are
+-- minted by internal/identity.
+--
+-- Naming convention (CG-DL-9): all three are Go-owned, "go_" prefix, and
+-- reference user cuids WITHOUT foreign keys — CG-DL-9 forbids Go migration
+-- SQL from referencing tables owned by the Next.js app's Prisma schema (the
+-- linkage to the Prisma "User" row is resolved at RUNTIME by a read-only
+-- SELECT in internal/identity, never by a DB constraint here).
+--
+-- Classification (docs/contracts/data-classification.md §1.10–§1.12): email
+-- and name are P1 (PII, never logged); apple_sub / user_id / family_id /
+-- token_hash are P0 opaque identifiers; the raw refresh token is NEVER
+-- stored — only its SHA-256 hex digest (token_hash).
+
+-- go_users: Apple-native users with no legacy Prisma "User" row. A user who
+-- signed up through the old web app already has a Prisma "User" cuid and is
+-- linked by email-match instead (their id lives in "User", not here). Only
+-- genuinely-new Apple users get a row here. The validator's user-existence
+-- check accepts a CUID present in EITHER "User" OR go_users.
+CREATE TABLE IF NOT EXISTS go_users (
+    id          TEXT PRIMARY KEY,             -- cuid-shaped, Go-generated
+    email       TEXT,                          -- P1; verified email at creation (nullable: Apple hidden-email)
+    name        TEXT,                          -- P1; display name from first sign-in (nullable)
+    created_at  TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at  TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+-- Partial unique index on email: at most one go_users row per non-null email,
+-- so a repeat mint can't fork a second Apple-native account for one address.
+CREATE UNIQUE INDEX IF NOT EXISTS idx_go_users_email
+    ON go_users (email) WHERE email IS NOT NULL;
+
+-- go_identity_apple: the authoritative apple_sub -> user_id binding. Written
+-- once on first sign-in (LINKAGE precedence in ADR-001 §4); reused verbatim
+-- afterwards so a later email change can never re-point an Apple account.
+CREATE TABLE IF NOT EXISTS go_identity_apple (
+    apple_sub     TEXT PRIMARY KEY,           -- Apple's stable subject ("sub" claim)
+    user_id       TEXT NOT NULL,              -- resolved CUID: a Prisma "User".id OR a go_users.id (no FK, CG-DL-9)
+    email         TEXT,                        -- P1; email captured at first sign-in (nullable)
+    name          TEXT,                        -- P1; name captured at first sign-in (nullable)
+    created_at    TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    last_login_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+-- Reverse lookup: all Apple identities bound to a user (rare, but keeps the
+-- user_id -> apple_sub direction indexed for ops/debug).
+CREATE INDEX IF NOT EXISTS idx_go_identity_apple_user
+    ON go_identity_apple (user_id);
+
+-- go_refresh_tokens: hash-only refresh-token store with single-use rotation
+-- and family reuse-detection (ADR-001 §5). The raw token is never persisted.
+CREATE TABLE IF NOT EXISTS go_refresh_tokens (
+    token_hash   TEXT PRIMARY KEY,            -- SHA-256 hex of the opaque refresh token
+    family_id    TEXT NOT NULL,               -- rotation lineage; reuse-detection revokes the whole family
+    user_id      TEXT NOT NULL,               -- owning user cuid (no FK, CG-DL-9)
+    issued_at    TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    expires_at   TIMESTAMPTZ NOT NULL,        -- sliding 90d: each rotation sets now + 90d
+    rotated_from TEXT,                          -- token_hash this one replaced (NULL for the family root)
+    rotated_to   TEXT,                          -- token_hash that replaced this one (set on rotation; non-NULL => spent)
+    revoked      BOOLEAN NOT NULL DEFAULT FALSE,
+    revoked_at   TIMESTAMPTZ,
+    reason       TEXT                           -- 'rotated' | 'revoked' | 'reuse_detected' (opaque enum, P0)
+);
+
+-- Family revocation touches every row in a family_id.
+CREATE INDEX IF NOT EXISTS idx_go_refresh_tokens_family
+    ON go_refresh_tokens (family_id);
+
+-- Per-user session enumeration + the background expiry sweep.
+CREATE INDEX IF NOT EXISTS idx_go_refresh_tokens_user
+    ON go_refresh_tokens (user_id);
+CREATE INDEX IF NOT EXISTS idx_go_refresh_tokens_expires
+    ON go_refresh_tokens (expires_at);


### PR DESCRIPTION
## Summary

Adds native **Sign in with Apple** to the Go telemetry server as a strictly-bounded **identity module** (`internal/identity`), plus asymmetric **ES256** access tokens with a published JWKS and **rotating refresh tokens** with family reuse-detection. Architecture-reviewed with the client (2026-07-10); design recorded as **ADR-001**.

## ADR summary (`docs/architecture/adr-001-identity-module.md`)

- **Modular-monolith IAM.** Identity is a bounded module, not a new service: its own `go_*` tables, its own ES256 signing-key secret class, its own `/api/auth/*` endpoints. The rest of the app consumes only the validated user CUID. Split triggers documented; the **Tesla command signer** (already isolated in the `tesla-http-proxy` sidecar, MYR-180) is the first candidate for further isolation — not IAM.
- **Asymmetric ES256 access tokens** (P-256), `kid` in the header, public keys at `GET /api/auth/.well-known/jwks.json`. The module alone holds the private key.
- **One validator, dual-algorithm.** The existing JWT validation now accepts **both** legacy HS256 (shared secret, unchanged — the live app depends on it) **and** ES256, algorithm pinned per token by `alg`+`kid` with strict allowlists.

## Topology finding — SAME shared DB (evidence)

The Go server and the Next.js app share **one Supabase Postgres**:
- `CLAUDE.md` ("Same Supabase PostgreSQL as MyRoboTaxi Next.js app");
- `internal/auth/jwt_auth.go` reads the Prisma-owned `"User"`/`"Vehicle"` tables directly;
- `sdk-testbench`'s `/api/backend-token` resolves identity via the shared `"Account"` table over the same `DATABASE_URL`;
- `react-frontend/prisma/schema.prisma` `User` has `email String? @unique` + `emailVerified DateTime?`.

So linkage uses **read-only email-match** (chosen path). The client's CUID `cmmgr4b1p0005l104ifpctlg8` resolves via the precedence below; **we never write to Prisma tables** (CG-DL-9).

## Linkage mechanics (first sign-in for an unknown `apple_sub`)

1. **Bootstrap override** (`AUTH_APPLE_BOOTSTRAP` email→CUID) — a defensive safety net so the client's first sign-in binds to his CUID even if his Apple relay email differs from his DB email.
2. **Verified-email match** against `"User"` (read-only, verified-claim only).
3. **Fresh mint** into Go-owned `go_users` (new users with no legacy row).

The `apple_sub → user_id` binding is written once and reused verbatim (a later email change cannot re-point an account). The fail-closed existence check now accepts a `sub` in **either** `"User"` or `go_users`.

## Dual-alg validator design

Valid methods allowlisted to exactly `{HS256, ES256}`; the key callback is **type-driven** — an HMAC-typed token only ever gets the shared secret, an ECDSA-typed token only ever gets an EC public key resolved by `kid`. Alg-confusion (forging HS256 with the published public key as the HMAC secret) and `none` are rejected. Same `iss=myrobotaxi`/`aud=telemetry`/`exp` checks for both algs.

## Refresh rotation

Opaque 256-bit tokens, **SHA-256 hash-only** storage, family ids, **single-use** rotation via a transactional `SELECT … FOR UPDATE` (concurrent double-refresh → one rotates, the other is reuse). Presenting a spent/revoked token **revokes the whole family**. Sliding 90-day family life. `/api/auth/revoke` revokes the family.

## Endpoints (rest-api.md §7.10; contract-guard docs updated)

- `POST /api/auth/apple` → `{accessToken, expiresIn, refreshToken, user{id,name,email}}`
- `POST /api/auth/refresh` → new pair (single-use rotation)
- `POST /api/auth/revoke` → 204 (family revoke, no existence oracle)
- `GET /api/auth/.well-known/jwks.json` → public ES256 keys

Auth events (sign-in / refresh / reuse / revoke) are audit-logged via an in-module `slog` trail (user/family ids only, **no PII**) — deliberately not the Prisma `AuditLog` enum (contract-restricted). Per-IP rate limiting on the pre-auth surface.

## Key runbook (env)

- `AUTH_ES256_PRIVATE_KEY` (PKCS#8 PEM) or `AUTH_ES256_PRIVATE_KEY_B64` (base64) — **enables** the module. Generate:
  ```
  openssl ecparam -genkey -name prime256v1 -noout -out ec-private.pem
  openssl pkcs8 -topk8 -nocrypt -in ec-private.pem -out ec-private-pkcs8.pem
  base64 -i ec-private-pkcs8.pem | tr -d '\n'   # -> AUTH_ES256_PRIVATE_KEY_B64
  ```
  No generate-if-absent in prod (fail-fast); `--dev` generates an ephemeral key with a loud warning.
- `APPLE_NATIVE_CLIENT_ID=app.myrobotaxi.ios` — expected `aud`; unset → `/api/auth/apple` 404s.
- `AUTH_APPLE_BOOTSTRAP=email=cuid[,…]` — optional first-sign-in override.

## Migrations

- `0003_identity.up/down.sql`: `go_users`, `go_identity_apple`, `go_refresh_tokens` (CG-DL-9 `go_` namespace, no FK to Prisma tables).

## iOS half (recommended AuthSession/Kit contract)

- **Sign-in:** `POST /api/auth/apple` with `{identityToken, fullName?, nonce?}` from `ASAuthorizationAppleIDCredential`. Store `accessToken` (memory) + `refreshToken` (Keychain).
- **AuthSession:** schedule a proactive refresh at `expiresIn − 60s`; on any `401 auth_failed` from a Bearer call, `POST /api/auth/refresh` once, then retry (FR-6.2). A second 401 → interactive re-sign-in.
- **Kit token provider:** the `getToken()` callback returns the current `accessToken`; refresh is owned by AuthSession. Sign-out → `POST /api/auth/revoke` + clear Keychain.

## Test coverage

Unit (no live Apple — faked JWKS + injected clocks + fake store): keystore/JWKS/thumbprint, ES256 mint+verify, Apple validation matrix (bad iss/aud/exp/sub/kid, alg-confusion, nonce, string-vs-bool `email_verified`, JWKS rotation), linkage precedence (existing/bootstrap/email-match/unverified/mint), refresh outcomes, handlers (success/401/400/404/429/JWKS), rate limiter, dual-alg validator (HS256 pass, ES256 pass, alg-confusion/none/unknown-kid/missing-kid fail, ES256-disabled rejects), config. Integration (testcontainers): real Apple-identity round-trip, email linkage, refresh rotation+reuse+family-revoke, concurrent double-rotate, and **end-to-end dual-alg validation of a `go_users` token**.

`go build ./...`, `go vet ./...`, `golangci-lint run ./...` (0 issues), and full `go test ./...` (colima) all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)