### PR TITLE
MYR-193 fix: restore contract conformance on main

### DIFF
--- a/tests/contract/contract_test.go
+++ b/tests/contract/contract_test.go
@@ -152,6 +152,16 @@ func createContractSchema(ctx context.Context, pool *pgxpool.Pool) error {
 		"id" TEXT PRIMARY KEY
 	);
 
+	-- go_users: the Go-owned identity table (migration 0003, MYR-193).
+	-- The JWTAuthenticator's FR-10.1 existence check probes a sub in
+	-- EITHER "User" OR go_users (Apple-native users have no Prisma row),
+	-- so the harness MUST provision both tables or every authenticated
+	-- request fails closed when the go_users EXISTS sub-probe hits a
+	-- missing relation. Minimal shape — the check only reads "id".
+	CREATE TABLE go_users (
+		"id" TEXT PRIMARY KEY
+	);
+
 	CREATE TABLE "Vehicle" (
 		"id"               TEXT PRIMARY KEY,
 		"userId"           TEXT NOT NULL,
@@ -470,6 +480,9 @@ func cleanTables(t *testing.T, pool *pgxpool.Pool) {
 	}
 	if _, err := pool.Exec(ctx, `DELETE FROM "User"`); err != nil {
 		t.Fatalf("clean User: %v", err)
+	}
+	if _, err := pool.Exec(ctx, `DELETE FROM go_users`); err != nil {
+		t.Fatalf("clean go_users: %v", err)
 	}
 }
 


### PR DESCRIPTION
## Summary

`main` went red after squash-merging #292 (MYR-193 identity module). The `Contract conformance` CI job (`go test -tags=contract ./tests/contract/...`) failed with **every** subtest of `TestContract_GETVehicles` / `GETVehicleSnapshot` / `GETVehicleDrives` returning `401 auth_failed` at once — empty-list, happy-path, 403, 404, and pagination all down together.

## Root cause (harness gap, not a validator bug)

#292 extended the JWT validator's fail-closed user-existence probe to accept a `sub` in **either** `"User"` **or** `go_users`:

```
internal/auth/jwt_auth.go:36 (queryUserExists)
  SELECT 1 WHERE EXISTS (SELECT 1 FROM "User"  WHERE "id" = $1)
              OR       EXISTS (SELECT 1 FROM go_users WHERE "id" = $1)
```

The contract harness `createContractSchema` (`tests/contract/contract_test.go`) provisions `User`, `Vehicle`, `Drive` — but never `go_users`. On main, every authenticated request errored inside the existence check with `relation "go_users" does not exist`; the existence cache propagated the error and `ValidateToken` fail-closed to `401 auth_failed`. Because the **shared auth path** was down, *all* endpoint subtests failed simultaneously — not any single endpoint's logic.

The dual-alg validator itself is correct: its production DB (migration `0003_identity.up.sql`) creates `go_users`, and the dual-table semantics are intended. This is purely the test harness lagging the new validator's read surface.

## Fix

- Provision a minimal `go_users` table (`id TEXT PRIMARY KEY` — the probe only reads `id`) in `createContractSchema`.
- Truncate `go_users` in `cleanTables` for isolation.
- **No change to the validator.** Alg allowlists, type-driven key selection, and the dual-table existence semantics are untouched. Legacy HS256 acceptance is unaffected (full suite green).

## Why PR CI passed but main went red

Classic **merge-interaction gap**. #292's own CI ran the contract job against the PR branch, where the new `go_users` EXISTS clause and the old harness schema were both present and consistent *within that branch's history at the time it was validated* — but the coupling only becomes wrong once the extended query and the un-extended harness coexist and are re-run on `main` under `-count=1` (cache-disabled, canonical schema). Two independently-green changes are incompatible only after they land together.

The author's local `go test ./...` was also green because the contract tests are behind the `contract` build tag and require Docker, so a default local run never exercises them.

## Regression prevention

The harness now mirrors the full set of tables the validator's existence probe reads. An inline comment on `go_users` flags the harness↔validator coupling so the next identity-table change updates the harness in lockstep.

## Gates

- `go test -tags=contract -count=1 ./tests/contract/...` — green
- full `go test ./...` — green
- `go vet ./...` and `go vet -tags=contract ./tests/contract/...` — clean
- `golangci-lint run` (incl. `--build-tags=contract`) — 0 issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)