### PR TITLE
MYR-242 Request re-consent for missing scopes in ops auth link

### DIFF
--- a/cmd/ops/auth_oauth.go
+++ b/cmd/ops/auth_oauth.go
@@ -67,6 +67,10 @@ func buildAuthorizeURL(clientID, redirectURI, scopes, state, codeChallenge strin
 	q.Set("state", state)
 	q.Set("code_challenge", codeChallenge)
 	q.Set("code_challenge_method", "S256")
+	// Without this, Tesla silently re-issues the previously consented scope
+	// set for an already-linked account and never shows the consent screen
+	// for newly requested scopes (observed MYR-242: vehicle_cmds dropped).
+	q.Set("prompt_missing_scopes", "true")
 	return teslaOAuthAuthorizeURL + "?" + q.Encode()
 }
 


### PR DESCRIPTION
## Root cause (MYR-242)

Ride dispatch failed with `permission_denied` because the owner's stored Tesla token lacked the `vehicle_cmds` scope. Re-linking via `ops auth link` did not help: Tesla's authorize endpoint silently re-issues the previously consented scope set for an already-linked account and never shows the consent screen for newly requested scopes.

## Fix

Send `prompt_missing_scopes=true` on the authorize URL — Tesla then prompts for any requested-but-not-yet-granted scopes. Verified live: the re-link consent screen showed the missing scopes and the new token's `scp` claim now contains `vehicle_cmds`.

No server behavior changes — ops CLI only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)