### PR TITLE
MYR-241 Capture drive start charge level from last-known Soc

### DIFF
--- a/docs/contracts/data-lifecycle.md
+++ b/docs/contracts/data-lifecycle.md
@@ -99,7 +99,7 @@ Live drive events (start, route point, speed update) flow over the WebSocket in 
 | `avgSpeedMph` | DB | Go store (create) | Computed at completion |
 | `maxSpeedMph` | DB | Go store (create) | Computed at completion |
 | `energyUsedKwh` | DB | Go store (create) | Computed at completion |
-| `startChargeLevel` | DB | Go store (create) | Captured at drive start |
+| `startChargeLevel` | DB | Go store (complete) | SOC at drive start; the create-time insert defaults it to 0 (drive.started carries no charge), so it is persisted on the completion UPDATE from the detector's last-known/first-in-drive SOC (MYR-241) |
 | `endChargeLevel` | DB | Go store (create) | Captured at drive end |
 | `fsdMiles` | DB | Go store (create) | Accumulated during drive |
 | `fsdPercentage` | DB | Go store (create) | Computed at completion |

--- a/internal/drives/start_charge_sourcing_test.go
+++ b/internal/drives/start_charge_sourcing_test.go
@@ -1,0 +1,154 @@
+package drives
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/myrobotaxi/telemetry/internal/events"
+	"github.com/myrobotaxi/telemetry/internal/telemetry"
+)
+
+// runStartChargeScenario drives one full idle→drive→park sequence through a
+// real Detector + bus and returns the resulting DriveStats. Each SOC argument
+// is optional: a nil pointer means the corresponding frame carries no charge
+// atomic group, modelling the gear(1s)/charge(slow) cadence mismatch that made
+// the gear-change start frame arrive without SOC. The start frame itself never
+// carries SOC — that is the realistic worst case the sourcing logic guards.
+func runStartChargeScenario(t *testing.T, idleSOC, midSOC, endSOC *float64) events.DriveStats {
+	t.Helper()
+
+	bus := testBus()
+	defer bus.Close(context.Background())
+
+	cfg := testConfig()
+	cfg.EndDebounce = 20 * time.Millisecond
+	cfg.MinDuration = 0
+	cfg.MinDistanceMiles = 0
+
+	d := NewDetector(bus, cfg, testLogger(), NoopDetectorMetrics{}, nil)
+	if err := d.Start(context.Background()); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	defer func() { _ = d.Stop() }()
+
+	startedCh := subscribeTopic(t, bus, events.TopicDriveStarted)
+	endedCh := subscribeTopic(t, bus, events.TopicDriveEnded)
+
+	const vin = "VIN_MYR241"
+	now := time.Now()
+
+	// Optional pre-drive idle tick establishes the last-known charge while
+	// parked (gear=P, so no drive is started).
+	if idleSOC != nil {
+		publishTelemetry(t, bus, telemetryEvent(vin, now, map[string]events.TelemetryValue{
+			string(telemetry.FieldGear): {StringVal: ptr("P")},
+			string(telemetry.FieldSOC):  {FloatVal: idleSOC},
+		}))
+	}
+
+	// Drive start frame: gear flips to D but carries NO SOC.
+	publishTelemetry(t, bus, telemetryEvent(vin, now.Add(1*time.Second), map[string]events.TelemetryValue{
+		string(telemetry.FieldGear):     {StringVal: ptr("D")},
+		string(telemetry.FieldSpeed):    {FloatVal: ptr(0.0)},
+		string(telemetry.FieldLocation): {LocationVal: &events.Location{Latitude: 33.0, Longitude: -96.0}},
+	}))
+	if _, ok := waitForEvent(startedCh); !ok {
+		t.Fatal("timed out waiting for DriveStartedEvent")
+	}
+
+	// Mid-drive frame: movement plus an optional SOC sample.
+	midFields := map[string]events.TelemetryValue{
+		string(telemetry.FieldGear):     {StringVal: ptr("D")},
+		string(telemetry.FieldSpeed):    {FloatVal: ptr(55.0)},
+		string(telemetry.FieldLocation): {LocationVal: &events.Location{Latitude: 33.2, Longitude: -96.2}},
+	}
+	if midSOC != nil {
+		midFields[string(telemetry.FieldSOC)] = events.TelemetryValue{FloatVal: midSOC}
+	}
+	publishTelemetry(t, bus, telemetryEvent(vin, now.Add(61*time.Second), midFields))
+
+	// Park frame ends the drive, at a distinct location so distance > 0.
+	stopFields := map[string]events.TelemetryValue{
+		string(telemetry.FieldGear):     {StringVal: ptr("P")},
+		string(telemetry.FieldSpeed):    {FloatVal: ptr(0.0)},
+		string(telemetry.FieldLocation): {LocationVal: &events.Location{Latitude: 33.3, Longitude: -96.3}},
+	}
+	if endSOC != nil {
+		stopFields[string(telemetry.FieldSOC)] = events.TelemetryValue{FloatVal: endSOC}
+	}
+	publishTelemetry(t, bus, telemetryEvent(vin, now.Add(120*time.Second), stopFields))
+
+	evt, ok := waitForEvent(endedCh)
+	if !ok {
+		t.Fatal("timed out waiting for DriveEndedEvent")
+	}
+	return evt.Payload.(events.DriveEndedEvent).Stats
+}
+
+// TestDetector_StartChargeLevelSourcing is the MYR-241 table-driven proof that
+// the state machine sources the drive-start charge correctly across every SOC
+// arrival ordering. The DriveEndedEvent it produces is the sole input to the
+// store's completion write, so a correct Stats.StartChargeLevel here is what
+// ultimately lands a non-zero startChargeLevel in the DB.
+func TestDetector_StartChargeLevelSourcing(t *testing.T) {
+	soc := func(v float64) *float64 { return &v }
+
+	tests := []struct {
+		name      string
+		idleSOC   *float64 // SOC seen while parked, before the drive
+		midSOC    *float64 // first in-drive SOC sample
+		endSOC    *float64 // SOC on the parking frame
+		wantStart int
+		wantEnd   int
+	}{
+		{
+			// (a) SOC known before drive start → seeded from last-known charge.
+			name:      "soc known before start is recorded",
+			idleSOC:   soc(80),
+			wantStart: 80,
+			wantEnd:   80, // lastSOC is seeded to the start charge when none arrives later
+		},
+		{
+			// (a + ownership) A real captured start value is never overwritten
+			// by a later in-drive sample (first-write-wins).
+			name:      "known start charge not overwritten mid-drive",
+			idleSOC:   soc(80),
+			midSOC:    soc(70),
+			endSOC:    soc(65),
+			wantStart: 80,
+			wantEnd:   65,
+		},
+		{
+			// (b) SOC first arrives mid-drive → start patched exactly once from
+			// the first in-drive sample, not the later ones.
+			name:      "soc first arrives mid-drive patches start once",
+			midSOC:    soc(70),
+			endSOC:    soc(65),
+			wantStart: 70,
+			wantEnd:   65,
+		},
+		{
+			// (c) SOC never observed anywhere → start stays 0 and end is
+			// unchanged (also 0). The mapper must not invent a value.
+			name:      "soc never observed stays zero",
+			wantStart: 0,
+			wantEnd:   0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			stats := runStartChargeScenario(t, tt.idleSOC, tt.midSOC, tt.endSOC)
+
+			if stats.StartChargeLevel != tt.wantStart {
+				t.Errorf("StartChargeLevel = %d, want %d", stats.StartChargeLevel, tt.wantStart)
+			}
+			// (d) endChargeLevel behaviour is unchanged by the start-sourcing
+			// logic across every ordering.
+			if stats.EndChargeLevel != tt.wantEnd {
+				t.Errorf("EndChargeLevel = %d, want %d", stats.EndChargeLevel, tt.wantEnd)
+			}
+		})
+	}
+}

--- a/internal/store/drive_mapper.go
+++ b/internal/store/drive_mapper.go
@@ -42,18 +42,19 @@ func mapDriveStarted(evt events.DriveStartedEvent, vehicleID string) DriveRecord
 // does in mapDriveStarted — see that comment.
 func mapDriveCompletion(evt events.DriveEndedEvent) DriveCompletion {
 	return DriveCompletion{
-		EndTime:         evt.EndedAt.Format(time.RFC3339),
-		EndLocation:     "",
-		EndAddress:      "",
-		DistanceMiles:   evt.Stats.Distance,
-		DurationMinutes: int(evt.Stats.Duration.Minutes()),
-		AvgSpeedMph:     evt.Stats.AvgSpeed,
-		MaxSpeedMph:     evt.Stats.MaxSpeed,
-		EnergyUsedKwh:   evt.Stats.EnergyDelta,
-		EndChargeLevel:  evt.Stats.EndChargeLevel,
-		FsdMiles:        evt.Stats.FSDMiles,
-		FsdPercentage:   evt.Stats.FSDPercentage,
-		Interventions:   0,
+		EndTime:          evt.EndedAt.Format(time.RFC3339),
+		EndLocation:      "",
+		EndAddress:       "",
+		DistanceMiles:    evt.Stats.Distance,
+		DurationMinutes:  int(evt.Stats.Duration.Minutes()),
+		AvgSpeedMph:      evt.Stats.AvgSpeed,
+		MaxSpeedMph:      evt.Stats.MaxSpeed,
+		EnergyUsedKwh:    evt.Stats.EnergyDelta,
+		StartChargeLevel: evt.Stats.StartChargeLevel,
+		EndChargeLevel:   evt.Stats.EndChargeLevel,
+		FsdMiles:         evt.Stats.FSDMiles,
+		FsdPercentage:    evt.Stats.FSDPercentage,
+		Interventions:    0,
 	}
 }
 

--- a/internal/store/drive_mapper_test.go
+++ b/internal/store/drive_mapper_test.go
@@ -106,6 +106,81 @@ func TestMapDriveCompletion(t *testing.T) {
 	}
 }
 
+// TestMapDriveCompletion_StartChargeLevel is the MYR-241 regression: the
+// completion mapper must forward evt.Stats.StartChargeLevel so the drive
+// detector's computed drive-start SOC is persisted on the completion UPDATE.
+// Before the fix the field did not exist on DriveCompletion, so the value the
+// detector already produced (MYR-207) was dropped and every Drive row kept the
+// insert-time default of 0 while endChargeLevel captured correctly.
+func TestMapDriveCompletion_StartChargeLevel(t *testing.T) {
+	endedAt := time.Date(2026, 3, 17, 15, 15, 0, 0, time.UTC)
+
+	tests := []struct {
+		name           string
+		startCharge    int // Stats.StartChargeLevel from the detector
+		endCharge      int // Stats.EndChargeLevel from the detector
+		wantStartLevel int
+		wantEndLevel   int
+	}{
+		{
+			// (a) SOC known before drive start → detector seeds it → persisted.
+			name:           "soc known before start",
+			startCharge:    80,
+			endCharge:      74,
+			wantStartLevel: 80,
+			wantEndLevel:   74,
+		},
+		{
+			// (b) SOC first arrived mid-drive → detector patched start once.
+			name:           "soc patched mid-drive",
+			startCharge:    70,
+			endCharge:      65,
+			wantStartLevel: 70,
+			wantEndLevel:   65,
+		},
+		{
+			// (c) SOC never observed → detector leaves both 0; mapper must not
+			// invent a value. End behaviour unchanged (also 0).
+			name:           "soc never observed",
+			startCharge:    0,
+			endCharge:      0,
+			wantStartLevel: 0,
+			wantEndLevel:   0,
+		},
+		{
+			// (d) no regression: a distinct start/end pair round-trips intact.
+			name:           "distinct start and end",
+			startCharge:    100,
+			endCharge:      42,
+			wantStartLevel: 100,
+			wantEndLevel:   42,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			evt := events.DriveEndedEvent{
+				VIN:     "5YJ3E1EA1NF000001",
+				DriveID: "drive_charge",
+				EndedAt: endedAt,
+				Stats: events.DriveStats{
+					StartChargeLevel: tt.startCharge,
+					EndChargeLevel:   tt.endCharge,
+				},
+			}
+
+			completion := mapDriveCompletion(evt)
+
+			if completion.StartChargeLevel != tt.wantStartLevel {
+				t.Errorf("StartChargeLevel = %d, want %d", completion.StartChargeLevel, tt.wantStartLevel)
+			}
+			if completion.EndChargeLevel != tt.wantEndLevel {
+				t.Errorf("EndChargeLevel = %d, want %d", completion.EndChargeLevel, tt.wantEndLevel)
+			}
+		})
+	}
+}
+
 func TestMapSingleRoutePoint(t *testing.T) {
 	ts := time.Date(2026, 3, 17, 14, 31, 0, 0, time.UTC)
 	pt := events.RoutePoint{

--- a/internal/store/drive_repo.go
+++ b/internal/store/drive_repo.go
@@ -221,7 +221,7 @@ func (r *DriveRepo) Complete(ctx context.Context, driveID string, stats DriveCom
 		stats.DistanceMiles, stats.DurationMinutes,
 		stats.AvgSpeedMph, stats.MaxSpeedMph, stats.EnergyUsedKwh,
 		stats.EndChargeLevel, stats.FsdMiles, stats.FsdPercentage,
-		stats.Interventions,
+		stats.Interventions, stats.StartChargeLevel,
 	)
 	r.metrics.ObserveQueryDuration("drive.complete", time.Since(start).Seconds())
 	if err != nil {

--- a/internal/store/drive_repo_test.go
+++ b/internal/store/drive_repo_test.go
@@ -254,18 +254,19 @@ func TestDriveRepo_Complete(t *testing.T) {
 			name:    "complete drive",
 			driveID: "drv_030",
 			stats: store.DriveCompletion{
-				EndTime:         "2026-03-17T10:45:00Z",
-				EndLocation:     "33.1500,-96.8800",
-				EndAddress:      "456 Oak Ave, Dallas, TX",
-				DistanceMiles:   12.5,
-				DurationMinutes: 45,
-				AvgSpeedMph:     35.2,
-				MaxSpeedMph:     72.0,
-				EnergyUsedKwh:   4.2,
-				EndChargeLevel:  78,
-				FsdMiles:        10.0,
-				FsdPercentage:   80.0,
-				Interventions:   1,
+				EndTime:          "2026-03-17T10:45:00Z",
+				EndLocation:      "33.1500,-96.8800",
+				EndAddress:       "456 Oak Ave, Dallas, TX",
+				DistanceMiles:    12.5,
+				DurationMinutes:  45,
+				AvgSpeedMph:      35.2,
+				MaxSpeedMph:      72.0,
+				EnergyUsedKwh:    4.2,
+				StartChargeLevel: 90,
+				EndChargeLevel:   78,
+				FsdMiles:         10.0,
+				FsdPercentage:    80.0,
+				Interventions:    1,
 			},
 		},
 		{
@@ -309,6 +310,14 @@ func TestDriveRepo_Complete(t *testing.T) {
 	}
 	if d.EndChargeLevel != 78 {
 		t.Errorf("EndChargeLevel = %d, want 78", d.EndChargeLevel)
+	}
+	// MYR-241: the completion write must (re)persist startChargeLevel. The row
+	// was seeded at insert with 85; Complete overwrites it with the detector's
+	// true drive-start SOC (90 here). In production the insert defaults to 0
+	// because drive.started carries no charge, so this write is the ONLY thing
+	// that lands a non-zero startChargeLevel in the DB.
+	if d.StartChargeLevel != 90 {
+		t.Errorf("StartChargeLevel = %d, want 90 (completion must persist it)", d.StartChargeLevel)
 	}
 	if d.Interventions != 1 {
 		t.Errorf("Interventions = %d, want 1", d.Interventions)

--- a/internal/store/queries.go
+++ b/internal/store/queries.go
@@ -114,12 +114,17 @@ const queryDriveSetRoutePointsEnc = `UPDATE "Drive"
 SET "routePointsEnc" = $2
 WHERE "id" = $1`
 
+// queryDriveComplete writes the final drive stats on drive.ended. It also
+// (re)writes "startChargeLevel": the row was inserted on drive.started with
+// startChargeLevel defaulting to 0 (that event carries no charge), and the
+// true drive-start SOC is only known once the detector ends the drive
+// (MYR-241). $14 lands that value so start/end charge are both persisted.
 const queryDriveComplete = `UPDATE "Drive"
 SET "endTime" = $2, "endLocation" = $3, "endAddress" = $4,
 	"distanceMiles" = $5, "durationMinutes" = $6,
 	"avgSpeedMph" = $7, "maxSpeedMph" = $8, "energyUsedKwh" = $9,
 	"endChargeLevel" = $10, "fsdMiles" = $11, "fsdPercentage" = $12,
-	"interventions" = $13
+	"interventions" = $13, "startChargeLevel" = $14
 WHERE "id" = $1`
 
 // queryDriveDelete removes a Drive row outright. Used when the drive

--- a/internal/store/types.go
+++ b/internal/store/types.go
@@ -123,19 +123,28 @@ type DriveRecord struct {
 }
 
 // DriveCompletion holds the final values written when a drive ends.
+//
+// StartChargeLevel is (re)written here as well as at insert time because the
+// Drive row is created on drive.started — a DriveStartedEvent that carries no
+// charge — so the insert always defaults startChargeLevel to 0. The drive
+// detector only knows the true drive-start SOC by the time the drive ends
+// (it seeds from the last-known charge, or lazily from the first in-drive SOC
+// sample; see internal/drives). Persisting evt.Stats.StartChargeLevel on the
+// completion UPDATE is what actually lands that value in the DB (MYR-241).
 type DriveCompletion struct {
-	EndTime         string
-	EndLocation     string
-	EndAddress      string
-	DistanceMiles   float64
-	DurationMinutes int
-	AvgSpeedMph     float64
-	MaxSpeedMph     float64
-	EnergyUsedKwh   float64
-	EndChargeLevel  int
-	FsdMiles        float64
-	FsdPercentage   float64
-	Interventions   int
+	EndTime          string
+	EndLocation      string
+	EndAddress       string
+	DistanceMiles    float64
+	DurationMinutes  int
+	AvgSpeedMph      float64
+	MaxSpeedMph      float64
+	EnergyUsedKwh    float64
+	StartChargeLevel int
+	EndChargeLevel   int
+	FsdMiles         float64
+	FsdPercentage    float64
+	Interventions    int
 }
 
 // RoutePointRecord is a single GPS point stored inside the Drive.routePoints


### PR DESCRIPTION
## Summary

Every production Drive row persists `startChargeLevel = 0` while `endChargeLevel` is correct. This fixes the persistence gap so the drive-start charge lands in the DB.

## Root cause (proven, not the original hypothesis)

The hypothesis was that the drive-detection state machine snapshots battery before any Soc datum arrives. That is **not** where the bug lives — the detector already handles this correctly (MYR-207, #285):

- `internal/drives/detector.go:314-317` caches the last-known Soc while idle.
- `internal/drives/transitions.go:159-164` seeds `startCharge` from that cache when a drive opens.
- `internal/drives/transitions.go:116-126` lazily patches the start charge from the first in-drive Soc sample (first-write-wins).
- `internal/drives/stats.go:120` emits the correct value in `DriveStats.StartChargeLevel`.

So the `DriveEndedEvent` already carries the right drive-start charge. The value was dropped **at the DB boundary**:

1. The Drive row is inserted on `drive.started` (`internal/store/drive_mapper.go:23` `mapDriveStarted`). `DriveStartedEvent` (`internal/events/drive_events.go:7`) carries **no charge**, so `startChargeLevel` is inserted as the Go zero value `0`.
2. On completion, `DriveCompletion` (`internal/store/types.go:126`) had **no `StartChargeLevel` field**, `mapDriveCompletion` (`internal/store/drive_mapper.go:43`) never set it, and `queryDriveComplete` (`internal/store/queries.go:117`) updated only `endChargeLevel`.

Net: `startChargeLevel` was written `0` at insert and **never updated**, so every row kept `0` regardless of the detector's correct computation. `endChargeLevel` was fine because it *was* in the completion path. MYR-207 fixed the in-memory stat but never plumbed it through the store — this closes that gap.

## Fix

- Add `StartChargeLevel` to `DriveCompletion` and forward `evt.Stats.StartChargeLevel` in `mapDriveCompletion`.
- Add `"startChargeLevel" = $14` to `queryDriveComplete` and pass `stats.StartChargeLevel` in `DriveRepo.Complete`.
- No schema/migration change — the column already exists; this only populates it on the completion UPDATE.
- Update `docs/contracts/data-lifecycle.md` to document the corrected write-point (completion, not create).

## Tests

- `internal/drives/start_charge_sourcing_test.go` — table-driven `TestDetector_StartChargeLevelSourcing`: (a) Soc known before start (recorded, not overwritten mid-drive), (b) Soc first arrives mid-drive (patched once), (c) Soc never observed (stays 0, end unchanged), (d) no regression to `endChargeLevel`.
- `internal/store/drive_mapper_test.go` — `TestMapDriveCompletion_StartChargeLevel` proves the mapper forwards the value across the same four cases.
- `internal/store/drive_repo_test.go` — `TestDriveRepo_Complete` now asserts the completion write overwrites the insert-time seed with the detector's drive-start SOC.

## Checks

- `go vet ./...` clean
- `golangci-lint run ./...` — 0 issues
- `go build ./cmd/...` and `go build ./...` green
- `go test ./internal/drives/...` green. Store integration tests require Docker/testcontainers (unavailable in this worktree; run in CI).

## Notes for review

Touches `internal/store/` and a `docs/contracts/` field-table row, so this needs `sdk-architect` review + `contract-guard`. No new persisted field, atomic group, or classification change — an existing P0 column's write-point is corrected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
