### PR TITLE
MYR-254 Sanitize geocode errors — stop leaking GPS coords and the Mapbox token into logs

### DIFF
--- a/cmd/ops/geocode.go
+++ b/cmd/ops/geocode.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"log/slog"
 	"os"
-	"strings"
 	"time"
 
 	"github.com/myrobotaxi/telemetry/internal/cryptox"
@@ -274,39 +273,20 @@ func geocodeSide(ctx context.Context, geocoder geocode.Geocoder, driveID, side s
 		)
 		return nil, nil
 	default:
-		// geocode.ReverseGeocode's own error strings embed the raw
-		// lat/lng queried (fmt %.4f) and, on a non-200 response, up to
-		// 256B of the Mapbox response body — GPS coordinates are P1,
-		// "never in logs" per data-classification.md §2.2. Log only a
-		// coarse, sanitized error class, never err.Error(). The geocode
-		// package's error text itself is intentionally left unchanged —
-		// other callers (internal/store/writer_drives.go) rely on it
-		// for their own (already-compliant) handling.
+		// MYR-254: geocode.ReverseGeocode's errors are sanitized at the
+		// source (internal/geocode/geocode.go) — none of them ever embed
+		// the queried coordinates, the request URL/access_token, or the
+		// Mapbox response body, so err.Error() itself is safe to log.
+		// Still prefer geocode.ClassifyError's coarse tag over the raw
+		// string: it's a stable, greppable value across Mapbox error
+		// message changes, and it's a defense-in-depth backstop against a
+		// future geocode.go change accidentally reintroducing sensitive
+		// detail into an error string.
 		logger.Warn("geocode backfill: reverse geocode failed",
 			slog.String("drive_id", driveID), slog.String("side", side),
-			slog.String("error_class", errorClass(err)),
+			slog.String("error_class", geocode.ClassifyError(err)),
 		)
 		return nil, nil
-	}
-}
-
-// errorClass reduces a geocode.ReverseGeocode error to a coarse,
-// log-safe classification. Only called from geocodeSide's default
-// branch, where err is guaranteed non-nil and not geocode.ErrNoResult
-// (that case is already handled above it) — so those two states aren't
-// re-checked here. Never returns or logs err.Error() itself — see the
-// data-classification note at geocodeSide's default branch.
-func errorClass(err error) string {
-	switch {
-	case errors.Is(err, geocode.ErrInvalidCoordinate):
-		return "invalid_coordinate"
-	case strings.Contains(err.Error(), "HTTP "):
-		// geocode.ReverseGeocode formats non-200 responses as
-		// "...: HTTP <code>: <body>" — matching on that literal is an
-		// in-process classification check only, never logged.
-		return "http_status"
-	default:
-		return "transport"
 	}
 }
 

--- a/cmd/ops/geocode_test.go
+++ b/cmd/ops/geocode_test.go
@@ -303,25 +303,6 @@ func TestBackfillRow_ApplyPath(t *testing.T) {
 	}
 }
 
-func TestErrorClass(t *testing.T) {
-	tests := []struct {
-		name string
-		err  error
-		want string
-	}{
-		{name: "invalid coordinate", err: fmt.Errorf("geocode.ReverseGeocode(999.0000,999.0000): %w", geocode.ErrInvalidCoordinate), want: "invalid_coordinate"},
-		{name: "http status error", err: errors.New("geocode.ReverseGeocode(33.0000,-96.0000): HTTP 500: internal error"), want: "http_status"},
-		{name: "generic transport error", err: errors.New("dial tcp: connection reset by peer"), want: "transport"},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			if got := errorClass(tt.err); got != tt.want {
-				t.Errorf("errorClass(%v) = %q, want %q", tt.err, got, tt.want)
-			}
-		})
-	}
-}
-
 func TestLogSafePresence(t *testing.T) {
 	set := "4220 Tributary Way, Frisco, TX"
 	empty := ""

--- a/internal/geocode/errors_test.go
+++ b/internal/geocode/errors_test.go
@@ -1,0 +1,214 @@
+package geocode
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+// MYR-254 regression tests: geocode.ReverseGeocode used to build error
+// strings that embedded the full-precision queried coordinates, the full
+// request URL (including the access_token query param), and up to 256B of
+// the raw Mapbox response body. Those errors were logged verbatim at five
+// call sites in internal/store (see writer_drives.go, etc.), leaking a P1
+// secret and P1 GPS data into production logs. These tests pin that every
+// error ReverseGeocode returns is free of all three, across every failure
+// mode the method can hit.
+
+// secretToken is shaped like a real Mapbox public token so a regression
+// that leaks it into an error string is impossible to miss in a failing
+// test's diff.
+const secretToken = "pk.super-secret-mapbox-token-do-not-leak" //nolint:gosec // test fixture, not a real credential
+
+// coordinatePairPattern matches a "lat,lng"-shaped digit run with at
+// least three decimal places on each side — the shape the pre-MYR-254
+// code interpolated into error strings via fmt's %.4f/%f verbs (e.g.
+// "30.2672,-97.7431" or "33.086000,-96.852200"). A sanitized error must
+// never contain this pattern.
+var coordinatePairPattern = regexp.MustCompile(`-?\d{1,3}\.\d{3,}\s*,\s*-?\d{1,3}\.\d{3,}`)
+
+// assertErrorSanitized fails the test if err's message contains anything
+// MYR-254 identified as a leak: a coordinate-pair-shaped digit run, the
+// "access_token" query key (or the raw secret value), or an http(s) URL
+// scheme (i.e. the request URL itself).
+func assertErrorSanitized(t *testing.T, err error) {
+	t.Helper()
+	if err == nil {
+		t.Fatal("assertErrorSanitized: err is nil")
+	}
+	msg := err.Error()
+
+	if coordinatePairPattern.MatchString(msg) {
+		t.Errorf("error string contains a coordinate-pair-shaped digit run: %q", msg)
+	}
+	if strings.Contains(strings.ToLower(msg), "access_token") {
+		t.Errorf("error string contains %q: %q", "access_token", msg)
+	}
+	if strings.Contains(msg, secretToken) {
+		t.Errorf("error string contains the raw secret token: %q", msg)
+	}
+	if strings.Contains(msg, "http://") || strings.Contains(msg, "https://") {
+		t.Errorf("error string contains a URL scheme: %q", msg)
+	}
+}
+
+func TestReverseGeocode_InvalidCoordinateSanitized(t *testing.T) {
+	g := &MapboxGeocoder{token: secretToken, client: http.DefaultClient}
+	_, err := g.ReverseGeocode(context.Background(), 999.0, 999.0)
+	if !errors.Is(err, ErrInvalidCoordinate) {
+		t.Fatalf("expected ErrInvalidCoordinate, got: %v", err)
+	}
+	assertErrorSanitized(t, err)
+}
+
+// TestReverseGeocode_TransportErrorSanitized simulates the exact failure
+// mode named in MYR-254: (*http.Client).Do returning a *url.Error, whose
+// Error() embeds the full request URL. The handler hijacks and closes the
+// connection without writing a response, forcing a genuine transport
+// error rather than a clean non-200 status.
+func TestReverseGeocode_TransportErrorSanitized(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		hj, ok := w.(http.Hijacker)
+		if !ok {
+			return
+		}
+		conn, _, err := hj.Hijack()
+		if err != nil {
+			return
+		}
+		_ = conn.Close()
+	}))
+	defer srv.Close()
+
+	g := &MapboxGeocoder{token: secretToken, client: srv.Client()}
+	g.client.Transport = &rewriteTransport{base: srv.Client().Transport, baseURL: srv.URL}
+
+	_, err := g.ReverseGeocode(context.Background(), queryLat, queryLng)
+	if err == nil {
+		t.Fatal("expected a transport error, got nil")
+	}
+	if !errors.Is(err, ErrTransport) {
+		t.Errorf("expected ErrTransport, got: %v", err)
+	}
+	assertErrorSanitized(t, err)
+}
+
+// TestReverseGeocode_ConnectionRefusedSanitized exercises a different
+// *url.Error shape (a dial failure against a closed listener, rather than
+// a hijacked-and-dropped connection) through the same sanitization path.
+func TestReverseGeocode_ConnectionRefusedSanitized(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
+	addr := srv.URL
+	srv.Close()
+
+	g := &MapboxGeocoder{token: secretToken, client: http.DefaultClient}
+	g.client.Transport = &rewriteTransport{base: http.DefaultTransport, baseURL: addr}
+
+	_, err := g.ReverseGeocode(context.Background(), queryLat, queryLng)
+	if err == nil {
+		t.Fatal("expected a transport error, got nil")
+	}
+	if !errors.Is(err, ErrTransport) {
+		t.Errorf("expected ErrTransport, got: %v", err)
+	}
+	assertErrorSanitized(t, err)
+}
+
+// TestReverseGeocode_UpstreamStatusSanitized covers a non-200 response
+// whose body deliberately echoes back a coordinate pair and the
+// access_token — mirroring how a real upstream error page can reflect
+// query parameters — to confirm the sanitization holds even when the
+// upstream itself hands back sensitive data.
+func TestReverseGeocode_UpstreamStatusSanitized(t *testing.T) {
+	leakyBody := `{"message":"invalid request","query":"33.086000,-96.852200","access_token":"` + secretToken + `"}`
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write([]byte(leakyBody))
+	}))
+	defer srv.Close()
+
+	g := &MapboxGeocoder{token: secretToken, client: srv.Client()}
+	g.client.Transport = &rewriteTransport{base: srv.Client().Transport, baseURL: srv.URL}
+
+	_, err := g.ReverseGeocode(context.Background(), queryLat, queryLng)
+	if !errors.Is(err, ErrUpstreamStatus) {
+		t.Fatalf("expected ErrUpstreamStatus, got: %v", err)
+	}
+	assertErrorSanitized(t, err)
+	if !strings.Contains(err.Error(), "400") {
+		t.Errorf("expected the numeric status code in the error, got: %v", err)
+	}
+}
+
+// TestReverseGeocode_LargeBodySanitized uses a body well over the 256B
+// the old code truncated to (and still stuffed with a coordinate pair and
+// the token) to confirm no prefix of the body leaks into the error
+// either.
+func TestReverseGeocode_LargeBodySanitized(t *testing.T) {
+	big := strings.Repeat("x", 400)
+	leakyBody := `{"message":"` + big + `","query":"33.086000,-96.852200","access_token":"` + secretToken + `"}`
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte(leakyBody))
+	}))
+	defer srv.Close()
+
+	g := &MapboxGeocoder{token: secretToken, client: srv.Client()}
+	g.client.Transport = &rewriteTransport{base: srv.Client().Transport, baseURL: srv.URL}
+
+	_, err := g.ReverseGeocode(context.Background(), queryLat, queryLng)
+	if !errors.Is(err, ErrUpstreamStatus) {
+		t.Fatalf("expected ErrUpstreamStatus, got: %v", err)
+	}
+	assertErrorSanitized(t, err)
+	if strings.Contains(err.Error(), big) {
+		t.Error("error string contains (a prefix of) the raw response body")
+	}
+}
+
+func TestReverseGeocode_RateLimitedSanitized(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusTooManyRequests)
+		_, _ = w.Write([]byte(`{"message":"rate limited","access_token":"` + secretToken + `"}`))
+	}))
+	defer srv.Close()
+
+	g := &MapboxGeocoder{token: secretToken, client: srv.Client()}
+	g.client.Transport = &rewriteTransport{base: srv.Client().Transport, baseURL: srv.URL}
+
+	_, err := g.ReverseGeocode(context.Background(), queryLat, queryLng)
+	if !errors.Is(err, ErrRateLimited) {
+		t.Fatalf("expected ErrRateLimited, got: %v", err)
+	}
+	assertErrorSanitized(t, err)
+}
+
+func TestClassifyError(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want string
+	}{
+		{name: "nil", err: nil, want: ""},
+		{name: "invalid coordinate", err: fmt.Errorf("geocode.ReverseGeocode: %w", ErrInvalidCoordinate), want: "invalid_coordinate"},
+		{name: "no result", err: ErrNoResult, want: "no_result"},
+		{name: "rate limited", err: fmt.Errorf("geocode.ReverseGeocode: %w", ErrRateLimited), want: "rate_limited"},
+		{name: "upstream status", err: fmt.Errorf("geocode.ReverseGeocode: status 500: %w", ErrUpstreamStatus), want: "upstream_status"},
+		{name: "transport", err: fmt.Errorf("geocode.ReverseGeocode: %w", ErrTransport), want: "transport"},
+		{name: "unrecognized error", err: errors.New("some other failure"), want: "unknown"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := ClassifyError(tt.err); got != tt.want {
+				t.Errorf("ClassifyError(%v) = %q, want %q", tt.err, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/geocode/geocode.go
+++ b/internal/geocode/geocode.go
@@ -27,6 +27,27 @@ var ErrNoResult = errors.New("geocode: no result for coordinates")
 // the given input — retrying with the same coordinates will not help.
 var ErrInvalidCoordinate = errors.New("geocode: invalid coordinate")
 
+// ErrRateLimited is returned when the Mapbox API responds with HTTP 429
+// (Too Many Requests). Callers should back off before retrying rather
+// than treating this the same as ErrUpstreamStatus.
+var ErrRateLimited = errors.New("geocode: rate limited by upstream")
+
+// ErrUpstreamStatus is returned when the Mapbox API responds with a
+// non-200, non-429 status code. The numeric status code is safe to
+// include in the wrapping error text (see ReverseGeocode) — it carries
+// no coordinates, tokens, or response body.
+var ErrUpstreamStatus = errors.New("geocode: upstream returned an error status")
+
+// ErrTransport is returned for network-level failures reaching the
+// Mapbox API: request construction, DNS, connection, TLS, timeout, or
+// response-decode failures. Deliberately opaque (MYR-254): the
+// underlying errors here — in particular the *url.Error returned by
+// (*http.Client).Do — embed the full request URL, which carries the
+// full-precision queried coordinates AND the access_token secret as
+// query parameters. Never unwrap or format the underlying error into
+// this one; classify only.
+var ErrTransport = errors.New("geocode: transport error calling upstream")
+
 // defaultRateLimit is the steady-state requests-per-second cap applied
 // when NewMapboxGeocoder is used without an explicit limiter. Mapbox's
 // free tier permits 600 requests/minute (10 req/s); paid tiers go
@@ -134,12 +155,21 @@ func NewMapboxGeocoderWithLimiter(token string, timeout time.Duration, limiter *
 // ReverseGeocode calls the Mapbox Geocoding API to convert lat/lng into
 // a place name and address. Returns ErrInvalidCoordinate when the input
 // is outside the WGS-84 range. Returns ErrNoResult when the API returns
-// no matching features. Returns other errors on network or API failures.
+// no matching features. Returns ErrRateLimited, ErrUpstreamStatus, or
+// ErrTransport on network/API failures — see those sentinels' docs.
 // Honors the configured rate limiter — a request that exceeds the
 // budget blocks until a token is available or ctx is cancelled.
+//
+// MYR-254: every error this method returns is guaranteed free of the
+// queried coordinates, the request URL, the access_token secret, and
+// the upstream response body — all of which are P1 data
+// (docs/contracts/data-classification.md §2.2) that callers routinely
+// log verbatim via err.Error(). Do not reintroduce any of the four into
+// an error string here without updating that guarantee (and the tests
+// that pin it) at the same time.
 func (g *MapboxGeocoder) ReverseGeocode(ctx context.Context, lat, lng float64) (*Result, error) {
 	if !validCoordinate(lat, lng) {
-		return nil, fmt.Errorf("geocode.ReverseGeocode(%.4f,%.4f): %w", lat, lng, ErrInvalidCoordinate)
+		return nil, fmt.Errorf("geocode.ReverseGeocode: %w", ErrInvalidCoordinate)
 	}
 
 	if g.limiter != nil {
@@ -185,23 +215,38 @@ func (g *MapboxGeocoder) ReverseGeocode(ctx context.Context, lat, lng float64) (
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, http.NoBody)
 	if err != nil {
-		return nil, fmt.Errorf("geocode.ReverseGeocode: build request: %w", err)
+		// MYR-254: never wrap err here. http.NewRequestWithContext's error
+		// embeds the URL it failed to parse — which carries the
+		// full-precision coordinates and the access_token secret.
+		// Classify only.
+		return nil, fmt.Errorf("geocode.ReverseGeocode: build request: %w", ErrTransport)
 	}
 
 	resp, err := g.client.Do(req)
 	if err != nil {
-		return nil, fmt.Errorf("geocode.ReverseGeocode(%.4f,%.4f): %w", lat, lng, err)
+		// MYR-254: client.Do's error is a *url.Error whose Error() embeds
+		// the full request URL — access_token and full-precision
+		// coordinates included. Never wrap it; classify only.
+		return nil, fmt.Errorf("geocode.ReverseGeocode: %w", ErrTransport)
 	}
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		body, _ := io.ReadAll(io.LimitReader(resp.Body, 256))
-		return nil, fmt.Errorf("geocode.ReverseGeocode(%.4f,%.4f): HTTP %d: %s", lat, lng, resp.StatusCode, body)
+		// MYR-254: drain (don't parse) up to 256B so the connection can be
+		// reused, but the body is never placed in the returned error —
+		// Mapbox error bodies can echo back query parameters, including
+		// the access_token.
+		_, _ = io.Copy(io.Discard, io.LimitReader(resp.Body, 256))
+		if resp.StatusCode == http.StatusTooManyRequests {
+			return nil, fmt.Errorf("geocode.ReverseGeocode: %w", ErrRateLimited)
+		}
+		// The numeric status code alone is safe to log/return.
+		return nil, fmt.Errorf("geocode.ReverseGeocode: status %d: %w", resp.StatusCode, ErrUpstreamStatus)
 	}
 
 	var data mapboxResponse
 	if err := json.NewDecoder(resp.Body).Decode(&data); err != nil {
-		return nil, fmt.Errorf("geocode.ReverseGeocode: decode: %w", err)
+		return nil, fmt.Errorf("geocode.ReverseGeocode: decode response: %w", ErrTransport)
 	}
 
 	if len(data.Features) == 0 {
@@ -209,6 +254,32 @@ func (g *MapboxGeocoder) ReverseGeocode(ctx context.Context, lat, lng float64) (
 	}
 
 	return buildResult(lat, lng, data.Features), nil
+}
+
+// ClassifyError reduces any error returned by ReverseGeocode to a coarse,
+// log-safe classification string. MYR-254: every error ReverseGeocode
+// returns is already free of coordinates, the request URL/access_token,
+// and the upstream response body, so err.Error() itself is safe to log —
+// ClassifyError exists for callers that want a single structured log
+// field (e.g. slog.String("error_class", ...)) instead of duplicating
+// errors.Is checks against every sentinel at each call site.
+func ClassifyError(err error) string {
+	switch {
+	case err == nil:
+		return ""
+	case errors.Is(err, ErrInvalidCoordinate):
+		return "invalid_coordinate"
+	case errors.Is(err, ErrNoResult):
+		return "no_result"
+	case errors.Is(err, ErrRateLimited):
+		return "rate_limited"
+	case errors.Is(err, ErrUpstreamStatus):
+		return "upstream_status"
+	case errors.Is(err, ErrTransport):
+		return "transport"
+	default:
+		return "unknown"
+	}
 }
 
 // NoopGeocoder always returns ErrNoResult, effectively disabling

--- a/internal/geocode/geocode_test.go
+++ b/internal/geocode/geocode_test.go
@@ -392,19 +392,19 @@ func TestMapboxGeocoder_ReverseGeocode(t *testing.T) {
 			name:       "server error",
 			statusCode: http.StatusInternalServerError,
 			body:       `{"message": "internal error"}`,
-			wantErr:    errors.New("HTTP 500"),
+			wantErr:    ErrUpstreamStatus,
 		},
 		{
 			name:       "unauthorized",
 			statusCode: http.StatusUnauthorized,
 			body:       `{"message": "Not Authorized"}`,
-			wantErr:    errors.New("HTTP 401"),
+			wantErr:    ErrUpstreamStatus,
 		},
 		{
 			name:       "rate limited (server-side 429)",
 			statusCode: http.StatusTooManyRequests,
 			body:       `{"message": "Rate limit exceeded"}`,
-			wantErr:    errors.New("HTTP 429"),
+			wantErr:    ErrRateLimited,
 		},
 	}
 
@@ -432,8 +432,8 @@ func TestMapboxGeocoder_ReverseGeocode(t *testing.T) {
 				if err == nil {
 					t.Fatalf("expected error, got nil")
 				}
-				if errors.Is(tt.wantErr, ErrNoResult) && !errors.Is(err, ErrNoResult) {
-					t.Errorf("expected ErrNoResult, got: %v", err)
+				if !errors.Is(err, tt.wantErr) {
+					t.Errorf("expected error matching %v, got: %v", tt.wantErr, err)
 				}
 				return
 			}


### PR DESCRIPTION
Confirmed by the pre-external-tester multi-tenant security review (the one surviving finding; all cross-user isolation probes were refuted).

Geocode error paths embedded P1 GPS coordinates and — on transport errors — the full request URL including the Mapbox access_token secret, then the store writers logged them verbatim. Errors returned by the geocode package now carry only an opaque class (no coordinates, no URL, no token, no response body). Sanitizer mirrors the existing cmd/ops/geocode.go errorClass pattern; tests assert no coordinate pair / no access_token / no URL scheme survives into err.Error().

All gates green locally: go vet, golangci-lint (0 issues), go test ./... (full suite incl. testcontainers), go build ./cmd/...

Follow-up (ops): rotate the Mapbox token, since it may sit in historical logs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)