### PR TITLE
MYR-276: stream InsideTemp at 10s for live cabin temperature

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,6 @@ docker-compose.override.yml
 .claude/agent-memory/
 .claude/worktrees/
 .claude/scheduled_tasks.lock
+
+# local ops helper binary (never commit)
+/ops

--- a/internal/telemetry/fleet_api_fields.go
+++ b/internal/telemetry/fleet_api_fields.go
@@ -155,8 +155,11 @@ func DefaultFieldConfig() map[string]FieldConfig {
 		FleetFieldTimeToFullCharge:                  {IntervalSeconds: 30}, // proto 43, hours (decimal double) — v1 charge atomic group member
 		FleetFieldEstimatedHoursToChargeTermination: {IntervalSeconds: 30}, // MYR-25 observation: proto 190, MYR-28 flip-condition guard
 
-		// Climate — medium/low frequency
-		FleetFieldInsideTemp:           {IntervalSeconds: 60, ResendIntervalSeconds: intPtr(120)},
+		// Climate. InsideTemp at 10s so the owner sees the cabin temperature
+		// change as climate runs (MYR-276: client saw it lag ~a minute at 60s —
+		// interior temp moves visibly while cooling/heating). OutsideTemp stays
+		// low-frequency (ambient changes slowly).
+		FleetFieldInsideTemp:           {IntervalSeconds: 10, ResendIntervalSeconds: intPtr(120)},
 		FleetFieldOutsideTemp:          {IntervalSeconds: 60, ResendIntervalSeconds: intPtr(120)},
 		FleetFieldHvacPower:            {IntervalSeconds: 10},
 		FleetFieldHvacFanSpeed:         {IntervalSeconds: 30},


### PR DESCRIPTION
Client: enabled climate but the interior temp lagged ~a minute. `InsideTemp` was `IntervalSeconds:60`; lowered to `10` so the cabin temperature updates visibly as climate runs. OutsideTemp stays 60s. Requires a fleet-config re-push per vehicle (I'll re-push Lunar on deploy). No schema change; build/vet/lint/fleet-config tests green.