### PR TITLE
MYR-320/303 backend: backfill publish loses fields on a spent read deadline + media free text numeric-coerced

### DIFF
--- a/internal/telemetry/converters.go
+++ b/internal/telemetry/converters.go
@@ -43,6 +43,16 @@ var fieldConverters = map[tpb.Field]func(*tpb.Value) (events.TelemetryValue, err
 	tpb.Field_HvacAutoMode:        convertHvacAutoMode,
 	tpb.Field_MediaPlaybackStatus: convertMediaStatus,
 	tpb.Field_DoorState:           convertDoorState,
+	// MYR-303 free-text now-playing fields. These MUST be listed: without an
+	// entry they fall through to convertNumericOrString, which ParseFloats a
+	// numeric-looking title and returns a FloatVal with no StringVal — and both
+	// consumers (store.mapControlMediaNowPlaying, the WS field mapping) read
+	// StringVal only, so the value is silently dropped. See convertMediaText.
+	tpb.Field_MediaNowPlayingTitle:   convertMediaText,
+	tpb.Field_MediaNowPlayingArtist:  convertMediaText,
+	tpb.Field_MediaNowPlayingAlbum:   convertMediaText,
+	tpb.Field_MediaNowPlayingStation: convertMediaText,
+	tpb.Field_MediaPlaybackSource:    convertMediaText,
 	// Temperatures (incl. driver/passenger setpoints) — Celsius→Fahrenheit.
 	tpb.Field_InsideTemp:                  convertTemperature,
 	tpb.Field_OutsideTemp:                 convertTemperature,
@@ -89,6 +99,36 @@ func convertLocation(v *tpb.Value) (events.TelemetryValue, error) {
 // coerce a rare purely-numeric-looking version (e.g. "2026") to a float that the
 // string-typed store column then drops. Forcing StringVal persists it verbatim.
 func convertVersion(v *tpb.Value) (events.TelemetryValue, error) {
+	if sv, ok := v.Value.(*tpb.Value_StringValue); ok {
+		s := sv.StringValue
+		return events.TelemetryValue{StringVal: &s}, nil
+	}
+	return convertNumericOrString(v)
+}
+
+// convertMediaText keeps the MYR-303 now-playing free-text fields as strings —
+// the same guarantee convertVersion gives softwareVersion, and for the same
+// reason.
+//
+// Media metadata is arbitrary human text that very often parses as a number:
+// track titles ("1979", "22", "7"), album names ("21", "1989"), FM station
+// labels ("94.7"). Without this converter the numeric-or-string fallback wins
+// that ParseFloat race and hands back a FloatVal with StringVal nil. Every
+// consumer of these five fields reads StringVal — the control-state persist
+// (store.mapControlMediaNowPlaying) and the WS field mapping both do — so such a
+// value is not merely mistyped, it VANISHES: nothing is persisted, nothing is
+// broadcast, and the stored column stays at whatever it held, indistinguishable
+// on read from "the car never told us".
+//
+// An EMPTY string is returned as a non-nil empty StringVal, never dropped: under
+// MYR-303 semantics that is the car reporting the track ENDED, a real
+// observation that must overwrite a stale title through the COALESCE upsert.
+//
+// Non-string Value variants fall back to convertNumericOrString rather than
+// being forced into a string. Tesla sends these as string_value; inventing a
+// rendering for a variant we have never observed would be guessing, and the
+// fallback's behaviour for them is unchanged from before this converter existed.
+func convertMediaText(v *tpb.Value) (events.TelemetryValue, error) {
 	if sv, ok := v.Value.(*tpb.Value_StringValue); ok {
 		s := sv.StringValue
 		return events.TelemetryValue{StringVal: &s}, nil

--- a/internal/telemetry/converters_media_text_test.go
+++ b/internal/telemetry/converters_media_text_test.go
@@ -1,0 +1,105 @@
+package telemetry
+
+import (
+	"testing"
+
+	tpb "github.com/myrobotaxi/telemetry/internal/telemetry/proto/tesla"
+)
+
+// stringDatum builds a Tesla Datum carrying a string_value, which is how the
+// vehicle sends every MYR-303 free-text media field.
+func stringDatum(field tpb.Field, s string) *tpb.Datum {
+	return &tpb.Datum{
+		Key:   field,
+		Value: &tpb.Value{Value: &tpb.Value_StringValue{StringValue: s}},
+	}
+}
+
+// TestConvertMediaFreeTextNeverNumericCoerced pins the MYR-303 free-text fields
+// against the numeric-coercion trap parseStringValue sets for every field
+// WITHOUT a fieldConverters entry.
+//
+// The fallback converter tries strconv.ParseFloat first and, on success, returns
+// a FloatVal with no StringVal at all. Both consumers of these five fields
+// require StringVal — store.mapControlMediaNowPlaying (control_state_media.go)
+// and the WS field mapping — so a numerically-parseable value is silently
+// DROPPED: never persisted, never broadcast, and indistinguishable on read from
+// "the car never told us". Real media metadata hits this constantly: track
+// titles ("1979", "22", "7"), album names ("21", "1989"), and FM station labels
+// ("94.7") all parse as floats.
+//
+// This is the exact defect convertVersion (MYR-279) was added to prevent for
+// softwareVersion; these five needed the same treatment and did not get it.
+func TestConvertMediaFreeTextNeverNumericCoerced(t *testing.T) {
+	t.Parallel()
+
+	fields := map[string]tpb.Field{
+		"title":   tpb.Field_MediaNowPlayingTitle,
+		"artist":  tpb.Field_MediaNowPlayingArtist,
+		"album":   tpb.Field_MediaNowPlayingAlbum,
+		"station": tpb.Field_MediaNowPlayingStation,
+		"source":  tpb.Field_MediaPlaybackSource,
+	}
+
+	// Every one of these is a real-world value that ParseFloat accepts.
+	values := []string{"1979", "22", "7", "1989", "94.7", "-1", "1e5", "0"}
+
+	for name, field := range fields {
+		for _, want := range values {
+			t.Run(name+"/"+want, func(t *testing.T) {
+				t.Parallel()
+				tv, err := extractValue(stringDatum(field, want))
+				if err != nil {
+					t.Fatalf("extractValue: %v", err)
+				}
+				if tv.StringVal == nil {
+					t.Fatalf("%s %q decoded to StringVal=nil (FloatVal=%v) — "+
+						"the store's media mapper requires StringVal, so this value is dropped",
+						name, want, tv.FloatVal)
+				}
+				if *tv.StringVal != want {
+					t.Errorf("%s = %q, want %q (verbatim)", name, *tv.StringVal, want)
+				}
+				if tv.FloatVal != nil {
+					t.Errorf("%s produced a FloatVal (%v); free text must never be numeric-coerced",
+						name, *tv.FloatVal)
+				}
+			})
+		}
+	}
+}
+
+// TestConvertMediaFreeTextKeepsEmptyString guards the MYR-303 empty-string
+// semantics through the converter: an empty title is the car reporting that the
+// track ENDED — a real observation that must reach the store as a non-nil empty
+// StringVal so it wins the COALESCE upsert and clears a stale track. Returning
+// a nil StringVal here would pin the last known title forever.
+func TestConvertMediaFreeTextKeepsEmptyString(t *testing.T) {
+	t.Parallel()
+
+	tv, err := extractValue(stringDatum(tpb.Field_MediaNowPlayingTitle, ""))
+	if err != nil {
+		t.Fatalf("extractValue: %v", err)
+	}
+	if tv.StringVal == nil {
+		t.Fatal("empty title decoded to StringVal=nil; the track-ended observation is lost")
+	}
+	if *tv.StringVal != "" {
+		t.Errorf("empty title = %q, want \"\"", *tv.StringVal)
+	}
+}
+
+// TestConvertMediaFreeTextPassesThroughOrdinaryText is the non-regression half:
+// text that never parsed as a number must behave exactly as it did before.
+func TestConvertMediaFreeTextPassesThroughOrdinaryText(t *testing.T) {
+	t.Parallel()
+
+	const want = "Bohemian Rhapsody"
+	tv, err := extractValue(stringDatum(tpb.Field_MediaNowPlayingTitle, want))
+	if err != nil {
+		t.Fatalf("extractValue: %v", err)
+	}
+	if tv.StringVal == nil || *tv.StringVal != want {
+		t.Errorf("title = %v, want %q", tv.StringVal, want)
+	}
+}

--- a/internal/telemetry/service_status_vehicle_data.go
+++ b/internal/telemetry/service_status_vehicle_data.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log/slog"
 	"strings"
+	"time"
 
 	"github.com/myrobotaxi/telemetry/internal/events"
 )
@@ -79,6 +80,11 @@ var (
 	ErrVehicleDataPublish = errors.New("vehicle_data broadcast publish failed")
 )
 
+// publishTimeout bounds the detached backfill publish (MYR-320). The bus send
+// is a buffered channel write per subscriber, so this is a deadlock guard rather
+// than a latency budget — it must never be the reason a frame is dropped.
+const publishTimeout = 5 * time.Second
+
 // RefreshFromVehicleData is the error-returning core of the vehicle_data
 // backfill: ONE Fleet API read, mapped through vehicleDataToFields, gated by
 // the MYR-300 stream-recency rule, and republished as a synthetic
@@ -148,7 +154,28 @@ func (m *ServiceStatusMonitor) RefreshFromVehicleData(ctx context.Context, vin, 
 		// counts our own output as evidence the car is streaming (MYR-300).
 		Source: events.SourceRESTBackfill,
 	}
-	if err := m.bus.Publish(ctx, events.NewEvent(evt)); err != nil {
+	// MYR-320: publish on a context DETACHED from the caller's Fleet API
+	// deadline. That deadline exists to bound Tesla; this fan-out is in-process
+	// and has already been paid for by the reads that succeeded, so letting the
+	// two share a budget means a slow car can cost us data we already hold.
+	//
+	// It was reachable in production: the connectivity-edge bundle spends ONE
+	// 30s budget on up to four sequential Fleet API GETs (vehicle, service_data,
+	// vehicle_data, release_notes), each with its own retry/backoff — and the
+	// fourth is the one MYR-320 added. ChannelBus.Publish re-checks ctx.Done()
+	// before EVERY subscriber and returns without delivering to any of them, so a
+	// budget spent during the reads silently discards the whole backfilled field
+	// set. The signature of that failure is exactly what the client saw: `color`
+	// populated (a direct column UPDATE, written earlier in this function) while
+	// its same-payload siblings `trim` / `trimLabel` / `fsdVersion` — which
+	// travel only on this frame — stayed null.
+	//
+	// The publish stays BOUNDED rather than unbounded: a wedged subscriber must
+	// not pin this goroutine, and publishTimeout is generous next to a buffered
+	// channel send.
+	pubCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), publishTimeout)
+	defer cancel()
+	if err := m.bus.Publish(pubCtx, events.NewEvent(evt)); err != nil {
 		return fmt.Errorf("%w: %w", ErrVehicleDataPublish, err)
 	}
 	m.logger.Info("service-status: populated owner controls from REST vehicle_data",

--- a/internal/telemetry/service_status_vehicle_data_publish_test.go
+++ b/internal/telemetry/service_status_vehicle_data_publish_test.go
@@ -1,0 +1,108 @@
+package telemetry
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/myrobotaxi/telemetry/internal/events"
+)
+
+// cancellingReleaseNotesReader models the live failure mode this test exists
+// for: by the time the FOURTH sequential Fleet API GET of the edge bundle runs,
+// the per-edge deadline is spent. It cancels the caller's context and then
+// fails, exactly as a real GetReleaseNotes does when the budget lapses mid-read.
+type cancellingReleaseNotesReader struct {
+	*fakeVehicleReader
+
+	cancel context.CancelFunc
+}
+
+func (f *cancellingReleaseNotesReader) GetReleaseNotes(_ context.Context, _, _ string) ([]ReleaseNote, error) {
+	f.cancel()
+	return nil, errors.New("context deadline exceeded")
+}
+
+// TestRefreshFromVehicleDataPublishesAfterReadDeadlineSpent pins the rule that
+// the READ budget must not be able to swallow the WRITE.
+//
+// The client-observed symptom this reproduces: `color` populated while its
+// same-payload siblings `trim` / `trimLabel` / `fsdVersion` stayed null. Those
+// two values travel by DIFFERENT routes out of one vehicle_config decode —
+// colour by a direct column UPDATE that happens early in the call, the rest by a
+// synthetic frame published on the event bus at the very end — so a context that
+// lapses in between lands exactly one of them. MYR-320 made that reachable by
+// adding a fourth sequential Fleet API GET (release_notes) to the same 30s
+// per-edge budget that already funded three, each with its own retry/backoff.
+//
+// ChannelBus.Publish checks ctx.Done() before EVERY subscriber and returns
+// without delivering to any of them, so a spent read deadline silently drops the
+// entire backfilled field set — no error surfaces above a Debug log, and the
+// stored values simply never change.
+func TestRefreshFromVehicleDataPublishesAfterReadDeadlineSpent(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	reader := &cancellingReleaseNotesReader{
+		fakeVehicleReader: &fakeVehicleReader{
+			data: &VehicleData{
+				VehicleConfig: &VehicleDataVehicleConfig{
+					TrimBadging:        ptr("p74d"),
+					PerformancePackage: ptr("Performance"),
+				},
+			},
+		},
+		cancel: cancel,
+	}
+
+	bus := events.NewChannelBus(events.BusConfig{BufferSize: 8}, events.NoopBusMetrics{}, discardLogger())
+	got := collectTelemetry(t, bus)
+	m := newBusMonitor(bus, reader.fakeVehicleReader, WithReleaseNotes(reader))
+
+	if err := m.RefreshFromVehicleData(ctx, svcTestVIN, "tok"); err != nil {
+		t.Fatalf("RefreshFromVehicleData must not fail when only the read budget lapsed: %v", err)
+	}
+
+	evt, ok := awaitBackfill(t, got)
+	if !ok {
+		t.Fatal("no backfill frame published: the spent READ deadline swallowed the publish, " +
+			"so trim/trimLabel never reach the control-state persist")
+	}
+	assertTelemetryString(t, evt.Fields, string(FieldTrim), "p74d")
+	assertTelemetryString(t, evt.Fields, string(FieldTrimLabel), "Performance")
+}
+
+// TestRefreshFromVehicleDataPublishSurvivesAlreadyDoneContext is the same rule
+// stated at its boundary: even a caller whose context was ALREADY finished
+// before the call must still land the values it read. The publish is our own
+// in-process fan-out, not a Tesla request, so it has no business inheriting a
+// deadline that exists to bound Tesla.
+func TestRefreshFromVehicleDataPublishSurvivesAlreadyDoneContext(t *testing.T) {
+	t.Parallel()
+
+	reader := &fakeVehicleReader{
+		data: &VehicleData{
+			VehicleConfig: &VehicleDataVehicleConfig{PerformancePackage: ptr("Performance")},
+		},
+	}
+
+	bus := events.NewChannelBus(events.BusConfig{BufferSize: 8}, events.NoopBusMetrics{}, discardLogger())
+	got := collectTelemetry(t, bus)
+	m := newBusMonitor(bus, reader)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	// The read itself is a fake, so it succeeds regardless; what is under test
+	// is strictly whether the frame reaches the bus.
+	if err := m.RefreshFromVehicleData(ctx, svcTestVIN, "tok"); err != nil {
+		t.Fatalf("RefreshFromVehicleData: %v", err)
+	}
+	evt, ok := awaitBackfill(t, got)
+	if !ok {
+		t.Fatal("no backfill frame published for a done context")
+	}
+	assertTelemetryString(t, evt.Fields, string(FieldTrimLabel), "Performance")
+}


### PR DESCRIPTION
## What this is

Investigation of two reported live data bugs on the client's vehicle
(`cmphman6p000fkz04rq3adktk` / VIN `…3795`). The investigation reached the
production database, which **disproved one of the two premises** and turned up a
different, real defect behind each bug ID. Both fixes below have failing-first
tests.

## Ground truth from prod (read at 12:56 UTC, `go_vehicle_control_state`)

| column | value |
|---|---|
| `trim` | `p74d` |
| `trim_label` | `Performance` |
| `fsd_version` | `FSD (Supervised) v14.3.5` |
| `Vehicle.color` | `Quicksilver` |
| `media_playback_status` | `Playing` |
| all 8 MYR-303 now-playing columns | **NULL** |
| `Vehicle.status` | **`in_service`** |

Two things follow, and they matter more than the code:

1. **`trimLabel`/`fsdVersion` ARE persisted.** Bug A's premise ("never persist")
   is not reproducible: every stage — `performance_package` decode, the REST
   field mapper, the COALESCE upsert, migration 0018, the snapshot LEFT JOIN
   scan order, the mask — is correct and covered by passing tests. The reported
   `null` snapshot either predates the write or read a surface that never
   carries these fields (they are deliberately absent from the vehicles-list
   row). **No fix was needed for the symptom as described.**
2. **The car is IN SERVICE and not streaming.** `mediaPlaybackStatus: "Playing"`
   is a *stale* MYR-298 value from before the visit; the fresh `lastUpdated`
   comes from the REST/service-window writes, not from a live frame. So the
   "playing car should have delivered the title in 2 minutes" reasoning does not
   apply — an in-service car emits nothing. Prod logs confirm: six periodic
   in-service passes in the last 80 minutes, **zero** `populated owner controls
   from REST vehicle_data` lines (the car answers 408 asleep, correctly and
   non-fatally).

Both fixes below are therefore latent defects found *while* tracing, each
independently provable — not speculative changes to code that was already right.

## Fix 1 — MYR-303: media free text was numeric-coerced and silently dropped

`internal/telemetry/converters.go`

The five free-text now-playing fields had **no `fieldConverters` entry**, so they
fell through to `convertNumericOrString` → `parseStringValue`, which ParseFloats
anything numeric-looking and returns a `FloatVal` with `StringVal` nil. Both
consumers read `StringVal` only (`store.mapControlMediaNowPlaying`, the WS field
mapping), so such a value did not arrive mistyped — **it vanished**: nothing
persisted, nothing broadcast, and the column left indistinguishable on read from
"the car never told us".

Real metadata hits this constantly: titles `1979` / `22` / `7`, albums `21` /
`1989`, FM station labels `94.7`.

`convertMediaText` gives these five the same guarantee `convertVersion`
(MYR-279) already gives `softwareVersion` — the identical trap, one field
family later. An **empty** string still returns a non-nil empty `StringVal` so
the MYR-303 "track ended" observation keeps winning the COALESCE upsert.

## Fix 2 — MYR-320: the backfill publish inherited the Fleet API read deadline

`internal/telemetry/service_status_vehicle_data.go`

`RefreshFromVehicleData` published its synthetic frame on the **caller's**
context — the per-edge Fleet API budget. `ChannelBus.Publish` re-checks
`ctx.Done()` before *every* subscriber and returns without delivering to any of
them, so a budget spent during the reads **silently discarded the entire
backfilled field set**. No error surfaces above a Debug log; the stored values
simply never change.

MYR-320 made this reachable by adding a **fourth** sequential Fleet API GET
(`release_notes`) to the one 30s budget already funding three, each with its own
retry/backoff (3 retries, 1s base, exponential).

The failure signature is asymmetric and is *exactly* the reported symptom:
`color` lands — a direct column UPDATE written earlier in the same function —
while `trim` / `trimLabel` / `fsdVersion`, which travel only on the frame, stay
null. That the client's car has since acquired all three does not make the race
unreal; it makes it intermittent.

The deadline exists to bound Tesla. The fan-out is in-process and already paid
for by the reads that succeeded, so the two must not share a budget. The publish
stays **bounded** (`publishTimeout`, 5s) as a deadlock guard against a wedged
subscriber — never as a reason to drop a frame.

Deliberately **not** widened: `syncVehicleColor`'s DB write keeps the caller's
context. It is a real I/O call that should be bounded, and it is not implicated.

## Tests (failing-first, verified against this branch's parent)

- `converters_media_text_test.go` — 42 subtests. Five fields × eight
  ParseFloat-accepting values assert `StringVal` survives verbatim and no
  `FloatVal` is produced; plus the empty-string ("track ended") and ordinary-text
  non-regression cases. **Failed 40/42 on main.**
- `service_status_vehicle_data_publish_test.go` — 2 tests. A release-notes reader
  that spends the budget mid-bundle, and the already-done-context boundary; both
  assert `trim`/`trimLabel` still reach the bus. **Both failed on main** with
  `publish(vehicle.telemetry): context canceled`.

## Gates

`go vet ./...` clean · `golangci-lint run` **0 issues** · `go build ./cmd/...` ok ·
`go test -race ./...` **all 27 packages ok** (store suites via colima
`DOCKER_HOST`). 300-line cap held (converters.go 240, service_status_vehicle_data.go 211).

No contract or documented-behavior change: fix 1 restores the string typing the
schema already specifies, fix 2 is internal robustness. No docs/changelog edit.

## Fleet-config re-push after deploy?

**No.** Neither fix touches `DefaultFieldConfig`. Re-verified against the
vendored proto while investigating: `MediaNowPlayingTitle` = 248,
`MediaNowPlayingArtist` = 247, both present with `IntervalSeconds: 10` and
`ResendIntervalSeconds: 120` — worker #337's numbers are correct.

Worth stating plainly: **this deploy will not make the client's media panel fill
in.** That car is in service and streaming nothing. The now-playing block will
populate on its own once the car returns to service and streams — and fix 1 is
what stops a numerically-titled track from being thrown away when it does.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
