### PR TITLE
MYR-433 Seal Account tokens for every provider, not just Tesla

### DIFF
--- a/cmd/backfill-account-tokens/main.go
+++ b/cmd/backfill-account-tokens/main.go
@@ -1,7 +1,16 @@
 // Binary backfill-account-tokens encrypts pre-existing plaintext OAuth
-// tokens in the Account table into their *_enc ciphertext columns
-// (MYR-62 dual-write rollout). Idempotent: re-running over a fully
-// migrated table is a no-op.
+// tokens in the Account table into their *_enc ciphertext columns.
+// Idempotent: re-running over a fully migrated table is a no-op.
+//
+// Covers EVERY provider — Tesla, Apple, and anything NextAuth links in
+// future. It was Tesla-only until the first production purge (MYR-433)
+// found 7 unsealed Apple Sign-in rows; see the package comment on
+// internal/store/accountbackfill for why sealing them is correct and
+// what was checked first.
+//
+// Run this BEFORE cmd/purge-plaintext-columns. The purge will not scrub a
+// plaintext value that has no ciphertext copy, so anything this misses is
+// a row that stays readable.
 //
 // Configuration is env-driven, matching the running telemetry-server:
 //

--- a/docs/contracts/data-classification.md
+++ b/docs/contracts/data-classification.md
@@ -69,6 +69,12 @@ Every column in every persisted table is listed below. The **Tier** column is th
 > `OwnerProvisioner` additionally NULLs the plaintext columns on its conflict-update, so re-linking a Tesla account scrubs pre-MYR-433 residue rather than preserving it.
 >
 > Migration tooling: `cmd/backfill-account-tokens/` seals legacy rows into the `_enc` columns; `cmd/purge-plaintext-columns/` then removes the plaintext values (verify-before-destroy — see §3.3). **The plaintext columns still EXIST on the table**; dropping them is a react-frontend Prisma migration, because Go migrations may not touch Prisma-owned tables (CG-DL-9).
+>
+> **Every provider, not just Tesla (MYR-433 follow-up).** The backfill originally scanned `WHERE "provider" = 'tesla'`, matching MYR-62's scope — the tokens *this server* reads. The first production purge run exposed the gap that left: **7 Apple Sign-in rows** holding a plaintext `access_token` and identity `id_token`, which the purge correctly refused to scrub because nothing had sealed them. The `Account` classification above is provider-agnostic and always was: an Apple `id_token` is an identity JWT, tiered P1 for exactly the reason the table states ("contains user identity claims"). "The telemetry server does not read it" was never the criterion. The scan and the `account_token_plaintext_remaining_total` gauge are now provider-agnostic; a gauge reading zero while unsealed rows exist is worse than no gauge, since it is the signal used to call the rollout finished.
+>
+> Nothing reads these columns for non-Tesla rows, verified in both repos before the change: every Go `Account` query is `provider = 'tesla'`-scoped, and in the Next.js app the sole token consumer (`src/lib/tesla.ts`) is Tesla-scoped while the Prisma adapter's `getUserByAccount` hydrates the row and returns only `account.user`, discarding the tokens.
+>
+> **If Sign in with Apple revocation is ever implemented**, it MUST read `id_token_enc` / `refresh_token_enc` through the decrypting path, never the plaintext columns. Apple requires token revocation on account deletion and neither repo implements it today — the Go deletion sequence revokes its own `go_refresh_tokens` and cascades the `Account` row away.
 
 ### 1.3 Vehicle table
 

--- a/internal/store/accountbackfill/backfill.go
+++ b/internal/store/accountbackfill/backfill.go
@@ -1,8 +1,31 @@
 // Package accountbackfill encrypts pre-existing Account.<col> plaintext
-// rows into the matching Account.<col>_enc ciphertext column during the
-// MYR-62 cross-repo encryption rollout. It is the dual-write companion
-// to AccountRepo.UpdateTeslaToken: the repo handles new writes; this
-// package handles the legacy backlog.
+// rows into the matching Account.<col>_enc ciphertext column. It is the
+// companion to AccountRepo.UpdateTeslaToken: the repo handles new writes;
+// this package handles the legacy backlog, and its output is the
+// precondition for cmd/purge-plaintext-columns (which refuses to scrub a
+// plaintext value that has no ciphertext copy).
+//
+// # Every provider, not just Tesla
+//
+// This originally scanned `WHERE "provider" = 'tesla'`, because MYR-62
+// was scoped to the Tesla OAuth tokens the telemetry server itself reads.
+// The first production purge run (MYR-433) found what that missed: 7
+// Apple Sign-in rows holding plaintext `access_token` and `id_token` that
+// the purge correctly refused to touch, because nothing had sealed them.
+//
+// An Apple `id_token` is an identity JWT and an `access_token` is a
+// credential; they meet the same bar as the Tesla pair — "a database leak
+// yields ciphertext" — and the fact that this server does not happen to
+// read them is not a reason to leave them legible. So the scan is now
+// provider-agnostic: every Account row, every token column.
+//
+// Nothing reads these columns for non-Tesla rows. Verified across both
+// repos before the change (MYR-433 follow-up): in Go every Account query
+// is `provider = 'tesla'`-scoped; in the Next.js app the only token
+// consumer is `src/lib/tesla.ts`, also Tesla-scoped, and the Prisma
+// adapter's `getUserByAccount` hydrates the row but returns only
+// `account.user` — the tokens are discarded. See the PR for the full
+// read map.
 //
 // Idempotent. Re-running over a fully migrated table touches zero rows.
 // Mixed-state rows (some columns encrypted, others not) are recoverable:
@@ -150,12 +173,9 @@ func (b *Backfiller) collectBatch(ctx context.Context, res *Result) ([]pending, 
             "refresh_token", "refresh_token_enc",
             "id_token",      "id_token_enc"
         FROM "Account"
-        WHERE "provider" = 'tesla'
-          AND (
-              ("access_token"  IS NOT NULL AND "access_token_enc"  IS NULL)
+        WHERE ("access_token"  IS NOT NULL AND "access_token_enc"  IS NULL)
            OR ("refresh_token" IS NOT NULL AND "refresh_token_enc" IS NULL)
-           OR ("id_token"      IS NOT NULL AND "id_token_enc"      IS NULL)
-          )`
+           OR ("id_token"      IS NOT NULL AND "id_token_enc"      IS NULL)`
 	rows, err := b.pool.Query(ctx, selectSQL)
 	if err != nil {
 		return nil, fmt.Errorf("accountbackfill: select rows: %w", err)
@@ -264,10 +284,17 @@ WHERE "id" = $1`
 	return firstErr
 }
 
-// CountPlaintextRemaining reports, per token column, the number of Tesla
-// Account rows where `<col>` is non-NULL and `<col>_enc` is NULL — i.e.
-// rows that still hold plaintext without ciphertext. Used by the CLI's
-// post-run report and by the running server's periodic gauge update.
+// CountPlaintextRemaining reports, per token column, the number of
+// Account rows — across EVERY provider — where `<col>` is non-NULL and
+// `<col>_enc` is NULL, i.e. rows that still hold plaintext without
+// ciphertext. Used by the CLI's post-run report and by the running
+// server's periodic gauge update.
+//
+// The provider filter was removed alongside the scan's. It had to be:
+// a gauge that reads zero while 7 Apple rows sit unsealed is worse than
+// no gauge, because it is the signal an operator uses to decide the
+// rollout is finished. That is exactly how the MYR-433 residual survived
+// the first production pass.
 //
 // Exported because the gauge wiring in cmd/telemetry-server/ needs to
 // call this without owning the rest of the Backfiller.
@@ -276,8 +303,7 @@ func CountPlaintextRemaining(ctx context.Context, p pool) (map[string]int, error
 	for _, col := range TokenColumns {
 		// Column names are constants, not user input: safe to interpolate.
 		sql := fmt.Sprintf(
-			`SELECT COUNT(*) FROM "Account"
-             WHERE "provider" = 'tesla' AND %q IS NOT NULL AND %q IS NULL`,
+			`SELECT COUNT(*) FROM "Account" WHERE %q IS NOT NULL AND %q IS NULL`,
 			col, col+"_enc",
 		)
 		var n int

--- a/internal/store/accountbackfill/backfill_test.go
+++ b/internal/store/accountbackfill/backfill_test.go
@@ -306,6 +306,127 @@ func TestBackfill_NoRowsToProcess(t *testing.T) {
 	}
 }
 
+// seedProvider is seed() with an explicit OAuth provider, so a test can
+// plant the non-Tesla rows this backfill used to skip.
+func seedProvider(t *testing.T, id, userID, provider string, accessPT, refreshPT, idPT *string) {
+	t.Helper()
+	_, err := testPool.Exec(context.Background(),
+		`INSERT INTO "Account" ("id","userId","type","provider","providerAccountId",
+            "access_token","refresh_token","id_token") VALUES ($1,$2,'oauth',$3,$4,$5,$6,$7)`,
+		id, userID, provider, id+"-acct", accessPT, refreshPT, idPT,
+	)
+	if err != nil {
+		t.Fatalf("seed %s: %v", provider, err)
+	}
+}
+
+// TestBackfill_SealsEveryProvider is the regression test for the residual
+// the first production purge surfaced (MYR-433).
+//
+// The scan was `WHERE "provider" = 'tesla'`, which was right for MYR-62's
+// scope and wrong for the acceptance bar: 7 Apple Sign-in rows sat in
+// production holding a plaintext access_token and identity id_token that
+// nothing had sealed, so the purge correctly refused to scrub them and
+// they stayed readable to anyone with a database connection.
+//
+// An Apple id_token is an identity JWT. It meets the same bar as the
+// Tesla pair, and "this server does not read it" is not a reason to leave
+// it legible.
+func TestBackfill_SealsEveryProvider(t *testing.T) {
+	requirePool(t)
+	if !dockerAvailable {
+		t.Skip("Docker not available")
+	}
+	cleanAccount(t)
+
+	enc := newEncryptor(t)
+
+	// The shapes production actually holds: a Tesla row with the full
+	// triple, and an Apple row with access + id and no refresh.
+	seedProvider(t, "p_tesla", "u_tesla", "tesla", ptr("tesla-access"), ptr("tesla-refresh"), nil)
+	seedProvider(t, "p_apple", "u_apple", "apple", ptr("apple-access"), nil, ptr("apple-id-jwt"))
+	seedProvider(t, "p_google", "u_google", "google", nil, nil, ptr("google-id-jwt"))
+
+	res, err := accountbackfill.New(testPool, enc, silentLogger()).Run(context.Background())
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if res.RowsScanned != 3 {
+		t.Errorf("RowsScanned = %d, want 3 — a provider filter is still excluding rows", res.RowsScanned)
+	}
+
+	// Every planted plaintext value must now have a ciphertext sibling
+	// that decrypts back to it.
+	for _, tc := range []struct {
+		id, col, want string
+	}{
+		{"p_tesla", "access_token", "tesla-access"},
+		{"p_tesla", "refresh_token", "tesla-refresh"},
+		{"p_apple", "access_token", "apple-access"},
+		{"p_apple", "id_token", "apple-id-jwt"},
+		{"p_google", "id_token", "google-id-jwt"},
+	} {
+		t.Run(tc.id+"/"+tc.col, func(t *testing.T) {
+			var ct *string
+			//nolint:gosec // column name is a test constant, not user input
+			q := `SELECT "` + tc.col + `_enc" FROM "Account" WHERE "id" = $1`
+			if err := testPool.QueryRow(context.Background(), q, tc.id).Scan(&ct); err != nil {
+				t.Fatalf("read ciphertext: %v", err)
+			}
+			if ct == nil {
+				t.Fatalf("%s.%s_enc is NULL — the row was never sealed, so the purge "+
+					"will refuse it and the plaintext stays readable", tc.id, tc.col)
+			}
+			got, err := enc.DecryptString(*ct)
+			if err != nil {
+				t.Fatalf("decrypt %s.%s_enc: %v", tc.id, tc.col, err)
+			}
+			if got != tc.want {
+				t.Errorf("%s.%s_enc decrypts to %q, want %q", tc.id, tc.col, got, tc.want)
+			}
+		})
+	}
+
+	// And the gauge must agree that nothing is left, across all providers.
+	// A gauge that reads zero while Apple rows sit unsealed is worse than
+	// no gauge — it is the signal an operator uses to call the rollout
+	// done, and it is how this residual survived the first pass.
+	for _, col := range accountbackfill.TokenColumns {
+		if got := res.PlaintextRemaining[col]; got != 0 {
+			t.Errorf("PlaintextRemaining[%s] = %d, want 0", col, got)
+		}
+	}
+}
+
+// TestCountPlaintextRemaining_CountsEveryProvider pins the gauge half
+// independently of the scan half: both had the provider filter, and
+// fixing only one would leave the other lying.
+func TestCountPlaintextRemaining_CountsEveryProvider(t *testing.T) {
+	requirePool(t)
+	if !dockerAvailable {
+		t.Skip("Docker not available")
+	}
+	cleanAccount(t)
+
+	seedProvider(t, "c_apple", "u_capple", "apple", ptr("apple-access"), nil, ptr("apple-id"))
+
+	counts, err := accountbackfill.CountPlaintextRemaining(context.Background(), testPool)
+	if err != nil {
+		t.Fatalf("CountPlaintextRemaining: %v", err)
+	}
+	if counts["access_token"] != 1 {
+		t.Errorf("access_token remaining = %d, want 1 — an unsealed Apple row must be counted",
+			counts["access_token"])
+	}
+	if counts["id_token"] != 1 {
+		t.Errorf("id_token remaining = %d, want 1 — an unsealed Apple row must be counted",
+			counts["id_token"])
+	}
+	if counts["refresh_token"] != 0 {
+		t.Errorf("refresh_token remaining = %d, want 0", counts["refresh_token"])
+	}
+}
+
 func TestPlaintextGauge_RegistersAndCounts(t *testing.T) {
 	requirePool(t)
 	if !dockerAvailable {


### PR DESCRIPTION
Follow-up to #374. Closes the one residual the first production purge surfaced.

The seal-and-purge run removed 326 plaintext values with zero errors and the operator-view bar verifies against prod — drives 0 readable, Tesla tokens 0, vehicle GPS at the zero sentinel with ciphertext beside it. What it left behind: **7 Apple Sign-in `Account` rows** holding a plaintext `access_token` and `id_token`.

The purge behaved correctly. It refuses to scrub a plaintext value that has no ciphertext copy, and nothing had ever sealed these — `backfill-account-tokens` scanned `WHERE "provider" = 'tesla'`.

## Decision: seal them

That filter matched MYR-62's scope — the tokens *this server* reads — but not the bar. The `Account` classification table in `data-classification.md` is provider-agnostic and always was: `id_token` is tiered **P1** with the rationale "contains user identity claims (JWT)". An Apple `id_token` is exactly that. "The telemetry server does not happen to read it" was never the criterion for whether a credential may sit legible in the database.

Both the scan **and** `CountPlaintextRemaining` are now provider-agnostic. The gauge mattered as much as the scan: `account_token_plaintext_remaining_total` reading zero while 7 rows sat unsealed is worse than no gauge, because it is the signal an operator uses to decide the rollout is finished — which is precisely how this survived the first pass.

## Read map for non-Tesla token columns

Checked before touching anything, since sealing a column the web auth layer reads would break sign-in.

**Verdict: SAFE TO SEAL.** Nothing reads a plaintext Apple token, in either repo.

### telemetry (this repo)

Every `Account` query is Tesla-scoped, without exception:

| Site | Query |
|---|---|
| `internal/store/queries.go:426` `queryTeslaToken` | `WHERE "userId" = $1 AND "provider" = 'tesla'` |
| `internal/store/queries.go:441` `queryUpdateTeslaToken` | same |
| `internal/store/owner_provision.go:130` | `WHERE "provider" = 'tesla' AND "providerAccountId" = $1` — selects `userId` only |
| `internal/store/owner_provision.go:160` | INSERT … `'tesla'` |
| `internal/store/owner_teardown.go:124` | `DELETE … AND "provider" = 'tesla'` |

`internal/store/plaintextpurge` is already provider-agnostic, so once sealed a re-run purges them with no change needed there.

### react-frontend (read-only; audited, not modified)

| Site | Scope | Reads |
|---|---|---|
| `src/lib/tesla.ts:73-83` | **`provider: 'tesla'` only** (line 74) | the only real token consumer in the app; enc-first via `readAccountToken`; never touches `id_token` |
| `src/lib/account-encryption.ts:80-98` | helper | enc-first with plaintext fallback — called only from `lib/tesla.ts` |
| `src/app/api/users/me/export/route.ts:90-101` | all providers | explicit `select` allowlist: `id, type, provider, providerAccountId, scope, expires_at`. Tokens deliberately excluded |
| `src/features/settings/api/actions.ts:62`, `:131`, `src/auth.ts:65` | tesla only | `select: {id}` / `deleteMany` / `updateMany` — no tokens |

**The crux, stated precisely because it looks alarming and isn't.** The Prisma adapter's `getUserByAccount` (`node_modules/@auth/prisma-adapter/index.js:8-14`) issues a `findUnique` on `Account` with no `select`, so Prisma hydrates every scalar and the plaintext tokens *are* physically present in the JS result object on every Apple sign-in. But line 13 is `return account?.user ?? null` — the account row, tokens and all, is dropped and only the joined `User` escapes. Columns being *returned* is not the same as their values being *consumed*, and no consumer exists:

- `linkAccount` is create-only; `unlinkAccount` deletes by unique key.
- `getAccount` — the one adapter method that hands a caller raw plaintext — is invoked solely from `@auth/core/lib/utils/webauthn-utils.js:168`, and there is no WebAuthn provider configured (zero hits for `webauthn|Authenticator` in `src/`).
- Session strategy is **`jwt`** (`src/auth.ts:99`), so the `Account` row is never re-read after the sign-in round-trip at all.

Two things that scan as reads are false positives, both worth naming:
- `src/auth.ts:36-40` reads `account.access_token`/`id_token`/`refresh_token` inside `withEncryptedAccountAdapter` — but that object is built by `@auth/core` from the **live token-endpoint response** (`utils/providers.js:93-96` → `handle-login.js:133`), never from the database. It is the write path that *populates* the encrypted shadows.
- The GDPR export uses a column allowlist that omits tokens entirely.

### The SIWA-revocation premise doesn't hold today

Worth correcting explicitly, because it was the stated reason the access/refresh pair might need to stay readable: **neither repo implements Apple token revocation.**

- Go's `POST /api/auth/revoke` (`cmd/telemetry-server/wiring_identity.go:71`) is this server's **own** refresh-token endpoint, operating on the Go-owned `go_refresh_tokens` table.
- `internal/identity/applekeys.go` fetches Apple's JWKS to **verify** identity tokens at sign-in; it never reads a stored token.
- The account-deletion sequence's step 8 is `RevokeRefreshTokens` — again `go_refresh_tokens`, not `Account`.
- react-frontend's deletion route (`src/app/api/users/me/route.ts:79`) cascades the `Account` row away and reads no token column.

So these Apple tokens are currently used by nothing at all. That strengthens the case for sealing rather than weakening it: sealing meets the bar today and keeps the value recoverable if revocation is implemented later — which Apple does require on account deletion. Recorded in `data-classification.md`: **if SIWA revocation is added, it must read `id_token_enc`/`refresh_token_enc`, never the plaintext columns.**

## Change

`internal/store/accountbackfill/backfill.go` — dropped `WHERE "provider" = 'tesla'` from the scan and from `CountPlaintextRemaining`. The per-row `UPDATE` was already keyed by `"id"`, so it needed no change. Package and CLI doc comments record why, and the CLI now states it must run before the purge.

## Tests

Two new tests, both **mutation-proven** — restoring the provider filter fails them:

- `TestBackfill_SealsEveryProvider` — plants the shapes production actually holds (Tesla with the full triple, Apple with access+id and no refresh, Google with id only), then asserts every planted value has a ciphertext sibling that decrypts back to it, and that the gauge reports zero remaining. Under the old filter: `RowsScanned` wrong and the Apple/Google `*_enc` columns NULL.
- `TestCountPlaintextRemaining_CountsEveryProvider` — pins the gauge half independently, because both halves carried the filter and fixing only one would leave the other lying. Under the old filter: `access_token remaining = 0, want 1`.

## Next step

Re-run seal + purge on Fly. Expected: the backfill seals 14 values across the 7 rows (7 × `access_token`, 7 × `id_token`), then the purge scrubs them and `Account.access_token` / `Account.id_token` reach `remaining = 0`. Nothing else should move — everything else is already at zero.

## Gate

| Check | Result |
|---|---|
| `gofmt -l .` | clean |
| `go vet ./...` | clean |
| `golangci-lint run ./...` | **0 issues** |
| `go test -count=1 ./...` | **30 packages ok, 0 failures** |
| `-race` on `./internal/store/accountbackfill/...` | ok |

Scoped to `internal/store/accountbackfill/`, `cmd/backfill-account-tokens/`, `docs/`. No schema changes, no migrations, no react-frontend changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CQfByoasgKg3NzugNvy9WX
