### PR TITLE
MYR-522 The owner's cancel: party-aware /cancel, initiator stamp, rider push

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,3 +54,4 @@ docker-compose.override.yml
 
 # local ops helper binary (never commit)
 /ops
+.worktrees/

--- a/cmd/telemetry-server/ride_request_adapters.go
+++ b/cmd/telemetry-server/ride_request_adapters.go
@@ -78,6 +78,17 @@ func (a *rideRequestStoreAdapter) UpdateStatusFrom(ctx context.Context, id strin
 	return a.guardedUpdate(ctx, a.repo.UpdateStatusFrom, id, from, to)
 }
 
+// UpdateStatusFromCancelled delegates to the repo's INITIATOR-STAMPING cancel
+// variant (MYR-522) — the same guarded single statement, whose SET also writes
+// `cancelled_by` first-writer-wins. The target status is fixed to `cancelled`
+// by the repo, so the writer shape differs from guardedUpdate's; the sentinel
+// translation is shared by delegating to the same classifier.
+func (a *rideRequestStoreAdapter) UpdateStatusFromCancelled(ctx context.Context, id string, from []string, by string) (telemetry.RideRequestData, error) {
+	return a.guardedUpdate(ctx, func(ctx context.Context, id string, from []store.RideRequestStatus, _ store.RideRequestStatus) (store.RideRequestRecord, error) {
+		return a.repo.UpdateStatusFromCancelled(ctx, id, from, by)
+	}, id, from, string(store.RideRequestStatusCancelled))
+}
+
 // UpdateStatusFromDispatched delegates to the repo's DORMANCY-guarded variant
 // (MYR-376) — the same single statement plus `AND (scheduled_for IS NULL OR
 // dispatch_status = 'sent' OR scheduled_for <= NOW())` — and additionally
@@ -279,6 +290,7 @@ func fromStoreRideRequest(rec store.RideRequestRecord) telemetry.RideRequestData
 		DispatchStatus:        dispatchStatus,
 		DispatchedAt:          rec.DispatchedAt,
 		DispatchError:         rec.DispatchError,
+		CancelledBy:           rec.CancelledBy,
 	}
 }
 

--- a/docs/contracts/rest-api.md
+++ b/docs/contracts/rest-api.md
@@ -288,7 +288,7 @@ Per-site audit (REST surface in `internal/telemetry/`, WS surface in `internal/w
 | [`ride_request_handler.go`](../../internal/telemetry/ride_request_handler.go) — second open instant ride on create (pre-check) | 409 | `ErrCodeRideActive` | Rider already holds an OPEN instant ride; body carries `activeRideRequest` (MYR-230, §7.8) |
 | [`ride_request_handler.go`](../../internal/telemetry/ride_request_handler.go) — second open instant ride on create (unique-index race backstop) | 409 | `ErrCodeRideActive` | Concurrent instant create rejected by `uq_go_ride_requests_active_instant_rider` (23505); winner re-read into `activeRideRequest` (MYR-230, §7.8) |
 | [`ride_request_handler.go`](../../internal/telemetry/ride_request_handler.go) — unknown / non-party ride | 404 | `ErrCodeNotFound` | `GetByID` miss, or caller is neither rider nor owner (no existence leak) |
-| [`ride_request_handler.go`](../../internal/telemetry/ride_request_handler.go) — owner attempts cancel (rider-only) | 403 | `ErrCodePermissionDenied` | A party, but wrong role for the action |
+| [`ride_request_handler.go`](../../internal/telemetry/ride_request_handler.go) — owner cancel outside its window (MYR-522; this row was a blanket 403 while cancel was rider-only) | 409 | `ErrCodeConflict` | The owner's cancel is legal from `accepted`/`arrived` only; the refusal for `requested` names decline, and for `enroute` names dropped-off |
 | [`ride_request_handler.go`](../../internal/telemetry/ride_request_handler.go) — illegal lifecycle transition | 409 | `ErrCodeConflict` | Cancel from a non-`{requested,accepted}` state (§7.8) |
 | [`ride_request_handler.go`](../../internal/telemetry/ride_request_handler.go) — store failure | 500 | `ErrCodeInternalError` | DB error on create / status update / list |
 | [`ride_share_gate.go`](../../internal/telemetry/ride_share_gate.go) — ride-request create OR owner accept against a vehicle whose owner has PAUSED ride sharing (MYR-342) | 409 | `ErrCodeVehicleUnavailable` | `Ride sharing is paused for this vehicle`. A CAPABILITY refusal, sharing the code with the MYR-266 busy guard and the MYR-277 in-service/offline gate — the request is well-formed and the caller authorised, the car simply cannot serve it. **Applies to SCHEDULED rides too**, unlike the MYR-313 exemption (§7.8): a service visit ends, an owner's pause does not |
@@ -630,7 +630,7 @@ No contract changes are required for the new role's wire shape (the REST respons
 | `GET` | `/api/ride-requests` | Rider's own ride-request history (paginated) | Bearer (self as rider) | FR-9.1, FR-9.3 |
 | `GET` | `/api/ride-requests/incoming` | Owner's feed of open (`requested`) ride requests across their vehicles (paginated). Two mutually exclusive params select different slices of the same feed: `?upcomingForVehicle={vehicleId}` — the owner's **accepted, still-future reservations** for one car, soonest first (MYR-360); `?activeForVehicle={vehicleId}` — the ride that car is **serving right now** (MYR-400) | Bearer (self as owner) | FR-9.1, FR-9.3 |
 | `GET` | `/api/ride-requests/{id}` | Single ride-request detail | Bearer + party (rider or owner) | FR-9.3 |
-| `POST` | `/api/ride-requests/{id}/cancel` | Rider cancels a requested/accepted ride | Bearer (rider) | FR-9.3 |
+| `POST` | `/api/ride-requests/{id}/cancel` | Party-aware cancel (MYR-522): the RIDER from `requested`/`accepted`, the OWNER from `accepted`/`arrived` | Bearer + party (rider or owner) | FR-9.3 |
 | `POST` | `/api/ride-requests/{id}/picked-up` | Owner confirms pickup — rider is aboard (accepted→arrived) | Bearer (owner) | FR-9.3 |
 | `POST` | `/api/ride-requests/{id}/start` | Rider starts the ride (arrived→enroute; triggers the leg-2 dropoff nav push) | Bearer (rider) | FR-9.3 |
 | `POST` | `/api/ride-requests/{id}/dropped-off` | Owner confirms dropoff — ride complete (enroute→completed) | Bearer (owner) | FR-9.3 |
@@ -1910,7 +1910,7 @@ The field is **OMITTED** (never an empty string) in exactly one case: the rider 
 
 - **Create** derives `ownerId` from the target vehicle's owner and enforces a vehicle-access check: the caller must be the vehicle's **owner**, OR hold an accepted share at the **`rides`** tier (§7.5). A rider ≠ owner request is therefore normal as of **MYR-184**, and `ownerId` is still the VEHICLE's owner — that asymmetry is what routes the accept/decline to the right person. **CORRECTION (MYR-184, 2026-07-29):** this bullet previously said shared-viewer requests would "light up automatically" when `GetUserVehicles` gained the viewer merge, with "no change to this handler required". **That was wrong.** The create-time check is a SEPARATE code path from the read-side access set (`internal/telemetry/ride_request_handler.go`, an owner-equality test on the `GetByID` row): widening the access set put shared cars in a viewer's list and let them read the snapshot, but this check still refused every one of their ride requests. Granting `rides` required changing it, and MYR-184 did. The identical claim in `internal/telemetry/ride_request_handler.go`'s type doc has been corrected in lockstep. **AMENDED BY [MYR-369](https://linear.app/myrobotaxi/issue/MYR-369):** the gate no longer reads a tier. It reads the grant's **`allow_rides` flag**, which the owner can switch off in place through §7.5.7 without revoking the grant, and which a **suspended** grant never satisfies. The check is therefore live state rather than something fixed at invite time — and it is now backed by two more layers, the owner-accept backstop and the reservation-dispatch probe (§7.5.7). Unknown vehicle → `404 not_found`; visible-but-not-accessible, and any viewer whose grant lacks the ride capability → `403 vehicle_not_owned`. A rider may hold only **one OPEN instant ride** (MYR-230): a second **instant** create while one is open is `409 ride_active` and returns the existing ride for the client to adopt; **scheduled** creates are exempt (see the `POST` section below).
 - **Detail (`GET {id}`)** is **party-only**: rider OR vehicle owner. A caller who is neither gets `404 not_found` (not `403`) so the server never confirms the existence of a ride the caller has no relation to.
-- **Cancel** is **rider-only**. The owner is a party but cannot cancel → `403 permission_denied`. A non-party → `404`.
+- **Cancel** is **party-aware** (MYR-522; rider-only before it). The RIDER may cancel from `requested`/`accepted` — unchanged. The OWNER may cancel from `accepted`/`arrived`; a `requested` ride keeps DECLINE as the owner's one exit (409 naming it), and once the rider is aboard (`enroute`) there is no owner cancel — ending early is what dropped-off already is (409 naming it). A non-party → `404`. A self-ride caller (owner == rider) takes the rider path. Both paths stamp `cancelledBy` ("rider" | "owner") in the same guarded write.
 - **Accept / decline** are **owner-only**. The rider is a party but cannot decide → `403 permission_denied`. A non-party → `404`. (MYR-175)
 - **Owner-driven handshake (MYR-270).** **picked-up** (`accepted → arrived`) and **dropped-off** (`enroute → completed`) are **owner-only** (the rider is a party but cannot confirm → `403`); **start** (`arrived → enroute`) is **rider-only** (the owner is a party but cannot start → `403`). A non-party → `404` on all three.
 - **Incoming feed** is scoped to the authenticated owner (`owner_id == JWT sub`) — no cross-owner reads are expressible. (MYR-175)
@@ -2006,7 +2006,18 @@ Party-only (rider or vehicle owner). Returns the bare `RideRequest`. Errors: `40
 
 #### `POST /api/ride-requests/{id}/cancel`
 
-Rider-only. Legal only from `requested` or `accepted` → `cancelled`; any other current status is `409 conflict`. Responds `200 OK` with the updated `RideRequest` and unicasts `ride_status_changed`. Errors: `401 auth_failed`, `403 permission_denied` (owner/non-rider party), `404 not_found` (unknown id / non-party), `409 conflict` (illegal transition), `500 internal_error`.
+**Party-aware** (MYR-522 — client decision 2026-08-12; rider-only before it). Which party is calling decides the legality window, and both windows are enforced by the same guarded single-statement UPDATE:
+
+| Caller | Legal from | Refusals |
+|--------|-----------|----------|
+| Rider (including a self-ride owner) | `requested`, `accepted` | any other status → `409 conflict` |
+| Owner | `accepted`, `arrived` | `requested` → `409 conflict` naming **decline** (that moment's owner verb); `enroute` → `409 conflict` naming **dropped-off** (the rider is aboard); any other status → `409 conflict` |
+
+The winning write also stamps **`cancelledBy`** (`"rider"` \| `"owner"`) into the same UPDATE, first writer wins — so who cancelled is arbitrated by exactly the race discipline that decides whether the cancel wins. The stamp is surfaced on the party-only `RideRequest` payload as optional `cancelledBy`, and consumers MUST treat absence (any row cancelled before the field existed) as "initiator unknown", never guess. Responds `200 OK` with the updated `RideRequest` and unicasts `ride_status_changed` through the same delivery every other transition uses (nav stand-down and Live Activity teardown ride the same event).
+
+**Push (MYR-522):** an OWNER's cancel notifies the RIDER — `{vehicle nickname} had to cancel your ride` (scheduled variant: `… your scheduled ride`, naming no time per the standing rule), body `Try booking another car.` — under the `ride_lifecycle` category. The rider's own cancel, and any event with no `cancelledBy`, stays silent, which keeps every pre-MYR-522 publisher behaving exactly as before. The owner's name never travels on a lock-screen surface (payload policy).
+
+Errors: `401 auth_failed`, `404 not_found` (unknown id / non-party), `409 conflict` (illegal transition / wrong door, see table), `500 internal_error`. The pre-MYR-522 `403 permission_denied` for an owner cancel is RETIRED.
 
 #### Owner-driven dispatch handshake (MYR-270)
 
@@ -2037,7 +2048,7 @@ A **SCHEDULED** ride's pickup is refused **`409 conflict`** — the SAME code, m
 >
 > Equivalently, the pickup requires `scheduledFor` **absent** OR `dispatchStatus == "sent"` OR `scheduledFor <= now()`.
 
-**The defect this closes.** MYR-179 moved a reservation's pickup nav push from accept time to `scheduledFor`, which left a reservation sitting in `accepted` — indistinguishable, to the lifecycle, from an instant ride whose car is already rolling. In production an owner accepted a ride due the **next day** and immediately tapped "Picked up". The ride reached `arrived` with `dispatchStatus` still absent, the car never dispatched and in service; from `arrived` the rider's `start` would have pushed a real **dropoff** nav to that vehicle, and the ride had no legal exit (cancel is illegal from `arrived`, per the matrix below). The gate makes "picked up" mean what it says: the car was actually sent.
+**The defect this closes.** MYR-179 moved a reservation's pickup nav push from accept time to `scheduledFor`, which left a reservation sitting in `accepted` — indistinguishable, to the lifecycle, from an instant ride whose car is already rolling. In production an owner accepted a ride due the **next day** and immediately tapped "Picked up". The ride reached `arrived` with `dispatchStatus` still absent, the car never dispatched and in service; from `arrived` the rider's `start` would have pushed a real **dropoff** nav to that vehicle, and the ride had no legal exit (the rider's cancel is illegal from `arrived`, per the matrix below; the owner's `arrived` cancel arrived later, with MYR-522). The gate makes "picked up" mean what it says: the car was actually sent.
 
 **Why dormancy ends at the DUE INSTANT and not at a successful dispatch.** Requiring `dispatchStatus == "sent"` would contradict the reservation-expiry contract stated in the transition-matrix notes below and under "Reservation-time dispatch": a reservation the sweeper failed (`failed` / `reservation_expired`), skipped (kill-switch), or never reached stays `accepted`, and its parties "may still **cancel or proceed manually**". Under a `sent`-only gate every such ride would have **cancel as its only exit** — the same stranding the defect produced, arrived at from the other direction. Past `scheduledFor`, the owner is at the car and the ride is owed: a manual pickup **is** the documented recovery path, dispatch or no dispatch. What is refused is strictly the **pre-due** pickup, which is the defect and nothing more.
 
@@ -2322,15 +2333,15 @@ A cell naming an endpoint means the transition is **legal from that status**; it
 | From \ To | `accepted` | `declined` | `arrived` | `enroute` | `completed` | `cancelled` |
 |-----------|-----------|-----------|-----------|-----------|-------------|-------------|
 | `requested` | `accept` (owner, MYR-175) | `decline` (owner, MYR-175) | `409` | `409` | `409` | `cancel` (rider, MYR-174) |
-| `accepted` | — | `decline` (owner, MYR-360 — **SCHEDULED rides only**; instant stays `409`) | `picked-up` (owner, MYR-270 — **`409` for a SCHEDULED ride that is neither dispatched nor yet due**, MYR-376) | `409` | `409` | `cancel` (rider, MYR-174) |
-| `arrived` | `409` | `409` | — | `start` (rider, MYR-270) | `409` | `409` |
+| `accepted` | — | `decline` (owner, MYR-360 — **SCHEDULED rides only**; instant stays `409`) | `picked-up` (owner, MYR-270 — **`409` for a SCHEDULED ride that is neither dispatched nor yet due**, MYR-376) | `409` | `409` | `cancel` (rider, MYR-174; **owner, MYR-522**) |
+| `arrived` | `409` | `409` | — | `start` (rider, MYR-270) | `409` | `cancel` (**owner only**, MYR-522 — the rider's cancel stays `409` here) |
 | `enroute` | `409` | `409` | `409` | — | `dropped-off` (owner, MYR-270) | `409` |
 | `declined` (terminal) | `409` | `409` | `409` | `409` | `409` | `409` |
 | `completed` (terminal) | `409` | `409` | `409` | `409` | `409` | `409` |
 | `cancelled` (terminal) | `409` | `409` | `409` | `409` | `409` | `409` |
 
 - **Atomicity / race semantics (MYR-174/175):** every transition executes as a single guarded UPDATE (`WHERE id = … AND status = ANY(<legal-from>)` — `store.RideRequestRepo.UpdateStatusFrom`), so concurrent conflicting mutations serialize in the database: **exactly one wins; every loser receives `409 conflict`** even if its pre-check read saw a legal state (e.g. rider-cancel racing owner-decline, or an owner double-tapping accept from two devices). The WS `ride_status_changed` frame and the `ride.accepted` dispatch event are published only by the winning write — the dispatch seam is exactly-once per accept by construction.
-- **MYR-174 (this story)** implements only the two `→ cancelled` transitions. Cancel from `enroute`/`arrived` (ride in progress) and from any terminal state is `409` — cancel is legal only from `{requested, accepted}`.
+- **MYR-174 (this story)** implements only the two `→ cancelled` transitions. For the RIDER, cancel from `enroute`/`arrived` (ride in progress) and from any terminal state is `409` — the rider's cancel is legal only from `{requested, accepted}`. **MYR-522 adds the OWNER's cancel** from `{accepted, arrived}` (never `requested` — decline is that moment's owner verb — and never `enroute`: the rider is aboard, and ending early is dropped-off). Both stamp `cancelledBy` in the same guarded write.
 - **MYR-175** implements `requested → accepted` / `requested → declined` (owner-only endpoints above). Accepting or declining a ride already past `requested` — including one the rider cancelled while the owner sheet was open — is the race the `409` protects.
 - **Reschedule confirm/decline (owner)** is NOT part of MYR-175: the rider-side propose endpoint (`ProposeReschedule`) has no HTTP surface yet, so an owner resolve endpoint would be unreachable dead code. The whole reschedule negotiation (propose + resolve, `rescheduleStatus` sub-state) ships together in **MYR-192**; the store layer (`ResolveReschedule`) is already in place.
 - **MYR-176** performs the leg-1 (pickup) nav push on accept but records it as an orthogonal `dispatchStatus`/`dispatchedAt` annotation (see "Dispatch outcome" above) — it does **not** advance the main lifecycle.
@@ -3412,9 +3423,13 @@ the behavior a client can rely on.
 | `ride.status.changed` → `declined` | **rider** | `«Vehicle» can't take this ride` (`Your car can't take this ride`) | `Try booking another car.` |
 | `ride.status.changed` → `arrived` | **rider** | `Your car is here — your turn to start` | `Open MyRoboTaxi to start the ride.` |
 | `ride.due` | **rider** | `«Vehicle» is heading your way` (`Your car is heading your way`) | `Your scheduled ride is starting now.` |
+| `ride.status.changed` → `cancelled` **by the OWNER** (MYR-522, `cancelledBy == "owner"`) | **rider** | `«Vehicle» had to cancel your ride` (scheduled: `«Vehicle» had to cancel your scheduled ride`; fallback `Your car …`) | `Try booking another car.` |
 
-Every other transition (`requested`, `enroute`, `completed`, `cancelled`) sends
-nothing — each is either the recipient's own action or invisible to them.
+Every other transition (`requested`, `enroute`, `completed`, and a `cancelled`
+whose event carries no `cancelledBy` or the rider's own) sends nothing — each is
+either the recipient's own action or invisible to them. An un-upgraded publisher
+omits `cancelledBy` entirely, which reads as the silent arm — exactly the
+pre-MYR-522 behaviour.
 
 **Payload policy — first names and vehicle nicknames ONLY.** A notification
 renders on a **locked screen**, to whoever is holding the phone. Pickup and

--- a/internal/events/ride_events.go
+++ b/internal/events/ride_events.go
@@ -75,7 +75,13 @@ type RideStatusChangedEvent struct {
 	// tell a RESERVATION from an instant request (MYR-360). It is NOT projected
 	// onto the `ride_status_changed` WS frame, which stays summary-only.
 	ScheduledFor *time.Time
-	UpdatedAt    time.Time
+	// CancelledBy names the party that initiated a cancellation — "rider" |
+	// "owner" (MYR-522), read off the updated row so it is nil on every other
+	// transition. Carried so the rider's push copy can tell an OWNER's cancel
+	// (worth waking a phone for) from the rider's own (noise). Not projected
+	// onto the WS frame, which stays summary-only — the detail read carries it.
+	CancelledBy *string
+	UpdatedAt   time.Time
 }
 
 // EventTopic returns TopicRideStatusChanged.

--- a/internal/push/copy.go
+++ b/internal/push/copy.go
@@ -34,18 +34,27 @@ const (
 const maxNameRunes = 32
 
 // Ride statuses that are worth waking a phone for. Every other transition
-// (`requested`, `completed`, `cancelled`) is either the recipient's own action
-// or invisible to them, so it sends nothing.
+// (`requested`, `completed`) is either the recipient's own action or invisible
+// to them, so it sends nothing. `cancelled` forks on WHO cancelled (MYR-522):
+// the rider's own cancel is their own action and stays silent, an OWNER's
+// cancel is exactly the news a rider is waiting on a locked phone for.
 //
 // `enroute` is the one status that speaks to the OWNER and not the rider: the
 // rider pressed Start ride themselves, so telling them is noise, but it is the
 // owner's only signal that their car has left the kerb with somebody in it.
 // See ownerStatusAlert (MYR-462).
 const (
-	statusAccepted = "accepted"
-	statusDeclined = "declined"
-	statusArrived  = "arrived"
+	statusAccepted  = "accepted"
+	statusDeclined  = "declined"
+	statusArrived   = "arrived"
+	statusCancelled = "cancelled"
 )
+
+// cancelledByOwner is the `cancelled_by` stamp that makes a cancellation the
+// OWNER's (MYR-522), matching the handler's rideCancelledByOwner. Absence —
+// the rider's own cancel, or a row cancelled before the stamp existed — sends
+// nothing, which is also the safe reading of an un-upgraded event.
+const cancelledByOwner = "owner"
 
 // alert is the title/body pair for one notification.
 type alert struct {
@@ -95,7 +104,13 @@ func createdAlert(ev events.RideRequestCreatedEvent) alert {
 // zone, so an absolute rendering would be either wrong ("5:30 PM" in the wrong
 // zone) or unreadable ("Aug 1, 5:30 PM UTC"). Correct local rendering belongs
 // to the client, which refetches the ride anyway.
-func statusAlert(status, vehicleName string, scheduled bool) (alert, bool) {
+// ownerCancelled reports whether this event is an OWNER's cancellation — the
+// one `cancelled` transition worth waking the rider for (MYR-522).
+func ownerCancelled(status string, cancelledBy *string) bool {
+	return status == statusCancelled && cancelledBy != nil && *cancelledBy == cancelledByOwner
+}
+
+func statusAlert(status, vehicleName string, scheduled, byOwnerCancel bool) (alert, bool) {
 	switch status {
 	case statusAccepted:
 		return alert{title: "Your ride is confirmed", body: bodySeeDetails}, true
@@ -114,6 +129,25 @@ func statusAlert(status, vehicleName string, scheduled bool) (alert, bool) {
 		return alert{
 			title: "Your car is here — your turn to start",
 			body:  "Open MyRoboTaxi to start the ride.",
+		}, true
+	case statusCancelled:
+		// MYR-522: only an OWNER's cancel speaks — the rider's own cancel is
+		// their own action. The grammar is declined's, because it is the same
+		// news one status later: the car is not coming, try another one. The
+		// vehicle nickname is the only interpolation, per the payload policy —
+		// the owner's NAME never travels on a lock-screen surface.
+		if !byOwnerCancel {
+			return alert{}, false
+		}
+		if scheduled {
+			return alert{
+				title: vehicleLabel(vehicleName) + " had to cancel your scheduled ride",
+				body:  "Try booking another car.",
+			}, true
+		}
+		return alert{
+			title: vehicleLabel(vehicleName) + " had to cancel your ride",
+			body:  "Try booking another car.",
 		}, true
 	default:
 		return alert{}, false

--- a/internal/push/copy_test.go
+++ b/internal/push/copy_test.go
@@ -33,11 +33,11 @@ func TestVehicleLabel(t *testing.T) {
 // produces nonsense on exactly the notifications that matter most.
 func TestVehicleLabelFallbackReadsNaturally(t *testing.T) {
 	label := vehicleLabel("")
-	declined, ok := statusAlert(statusDeclined, "", false)
+	declined, ok := statusAlert(statusDeclined, "", false, false)
 	if !ok {
 		t.Fatal("declined produced no alert")
 	}
-	scheduledDeclined, ok := statusAlert(statusDeclined, "", true)
+	scheduledDeclined, ok := statusAlert(statusDeclined, "", true, false)
 	if !ok {
 		t.Fatal("scheduled declined produced no alert")
 	}
@@ -93,7 +93,7 @@ func TestStatusAlertSelectsOnlyNotifiableTransitions(t *testing.T) {
 	for _, status := range all {
 		for _, scheduled := range []bool{false, true} {
 			t.Run(fmt.Sprintf("%s/scheduled=%v", status, scheduled), func(t *testing.T) {
-				a, ok := statusAlert(status, "Blue Whale", scheduled)
+				a, ok := statusAlert(status, "Blue Whale", scheduled, false)
 				if ok != notifiable[status] {
 					t.Fatalf("statusAlert(%q) notifies = %v, want %v", status, ok, notifiable[status])
 				}
@@ -177,11 +177,11 @@ func TestOwnerStatusAlertNamesOnlyTheFirstName(t *testing.T) {
 // time zone, so an absolute rendering here would be either wrong or unreadable
 // — the same standing rule createdAlert follows.
 func TestStatusAlertDeclinedNamesTheReservation(t *testing.T) {
-	instant, ok := statusAlert(statusDeclined, "Blue Whale", false)
+	instant, ok := statusAlert(statusDeclined, "Blue Whale", false, false)
 	if !ok {
 		t.Fatal("instant declined produced no alert")
 	}
-	scheduled, ok := statusAlert(statusDeclined, "Blue Whale", true)
+	scheduled, ok := statusAlert(statusDeclined, "Blue Whale", true, false)
 	if !ok {
 		t.Fatal("scheduled declined produced no alert")
 	}
@@ -204,8 +204,8 @@ func TestStatusAlertDeclinedNamesTheReservation(t *testing.T) {
 	// Only `declined` forks on scheduling — accepted/arrived read identically
 	// either way, so the fork stays as narrow as the defect it fixes.
 	for _, status := range []string{statusAccepted, statusArrived} {
-		a, _ := statusAlert(status, "Blue Whale", false)
-		b, _ := statusAlert(status, "Blue Whale", true)
+		a, _ := statusAlert(status, "Blue Whale", false, false)
+		b, _ := statusAlert(status, "Blue Whale", true, false)
 		if a != b {
 			t.Errorf("statusAlert(%q) must not fork on scheduling: %+v vs %+v", status, a, b)
 		}

--- a/internal/push/notifier.go
+++ b/internal/push/notifier.go
@@ -276,7 +276,8 @@ func (n *Notifier) handleStatusChanged(evt events.Event) {
 	// for both parties. Which transitions speak does not depend on scheduling
 	// or on either name, so the probes can pass empty values.
 	scheduled := ev.ScheduledFor != nil
-	_, notifyRider := statusAlert(ev.Status, "", scheduled)
+	byOwnerCancel := ownerCancelled(ev.Status, ev.CancelledBy)
+	_, notifyRider := statusAlert(ev.Status, "", scheduled, byOwnerCancel)
 	_, notifyOwner := ownerStatusAlert(ev.Status, nil)
 
 	// An owner riding their own car is both parties, and this platform makes
@@ -295,7 +296,7 @@ func (n *Notifier) handleStatusChanged(evt events.Event) {
 
 	n.async(func(ctx context.Context) {
 		if notifyRider {
-			a, _ := statusAlert(ev.Status, n.vehicleName(ctx, ev.VehicleID), scheduled)
+			a, _ := statusAlert(ev.Status, n.vehicleName(ctx, ev.VehicleID), scheduled, byOwnerCancel)
 			n.fanOut(ctx, delivery{
 				userID:   ev.RiderID,
 				rideID:   ev.RideRequestID,

--- a/internal/push/notifier_owner_cancel_test.go
+++ b/internal/push/notifier_owner_cancel_test.go
@@ -1,0 +1,95 @@
+package push
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/myrobotaxi/telemetry/internal/events"
+)
+
+// MYR-522 — an OWNER's cancel is the one `cancelled` transition that speaks,
+// and it speaks to the RIDER. The rider's own cancel (and a legacy event with
+// no initiator at all) stays silent, which is also what keeps every event from
+// an un-upgraded publisher behaving exactly as before this issue.
+
+// cancelledStatusEvent is statusEvent for a cancellation carrying its
+// initiator stamp; by="" models a legacy event with no stamp.
+func cancelledStatusEvent(by string, scheduledFor *time.Time) events.Event {
+	ev := events.RideStatusChangedEvent{
+		RideRequestID: testRideID,
+		VehicleID:     testVehicleID,
+		RiderID:       testRiderID,
+		OwnerID:       testOwnerID,
+		Status:        "cancelled",
+		ScheduledFor:  scheduledFor,
+	}
+	if by != "" {
+		ev.CancelledBy = &by
+	}
+	return events.NewEvent(ev)
+}
+
+func TestNotifierOwnerCancelReachesTheRider(t *testing.T) {
+	sender := NewFakeSender()
+	n := newTestNotifier(t, sender, &fakeVehicleNamer{name: "Blue Whale"})
+
+	n.handleStatusChanged(cancelledStatusEvent("owner", nil))
+	n.Wait()
+
+	sent := sender.Sent()
+	if len(sent) != 1 {
+		t.Fatalf("sent %d notifications, want exactly 1", len(sent))
+	}
+	if sent[0].DeviceToken != riderDevice {
+		t.Errorf("device = %q, want the rider's %q", sent[0].DeviceToken, riderDevice)
+	}
+	if sent[0].Title != "Blue Whale had to cancel your ride" {
+		t.Errorf("title = %q", sent[0].Title)
+	}
+	if sent[0].Body != "Try booking another car." {
+		t.Errorf("body = %q", sent[0].Body)
+	}
+}
+
+// A cancelled RESERVATION names the scheduled ride, MYR-360's declined rule:
+// days may have passed since the booking was confirmed, and "your ride" on a
+// lock screen gives the rider no way to tell it is about that booking.
+func TestNotifierOwnerCancelOfAReservationNamesTheScheduledRide(t *testing.T) {
+	sender := NewFakeSender()
+	n := newTestNotifier(t, sender, &fakeVehicleNamer{name: "Blue Whale"})
+
+	at := time.Date(2026, 8, 15, 17, 30, 0, 0, time.UTC)
+	n.handleStatusChanged(cancelledStatusEvent("owner", &at))
+	n.Wait()
+
+	sent := sender.Sent()
+	if len(sent) != 1 {
+		t.Fatalf("sent %d notifications, want exactly 1", len(sent))
+	}
+	if sent[0].Title != "Blue Whale had to cancel your scheduled ride" {
+		t.Errorf("title = %q", sent[0].Title)
+	}
+	// The standing rule: a scheduled push never renders the time.
+	copyText := sent[0].Title + " " + sent[0].Body
+	for _, forbidden := range []string{"17:30", "5:30", "UTC", "Aug", "15", "2026"} {
+		if strings.Contains(copyText, forbidden) {
+			t.Errorf("copy %q contains %q — scheduled pushes must not render a time", copyText, forbidden)
+		}
+	}
+}
+
+// The rider's own cancel, and a legacy event with no stamp, wake nobody.
+func TestNotifierRiderAndUnstampedCancelsStaySilent(t *testing.T) {
+	for _, by := range []string{"rider", ""} {
+		sender := NewFakeSender()
+		n := newTestNotifier(t, sender, &fakeVehicleNamer{name: "Blue Whale"})
+
+		n.handleStatusChanged(cancelledStatusEvent(by, nil))
+		n.Wait()
+
+		if sent := sender.Sent(); len(sent) != 0 {
+			t.Errorf("cancelledBy=%q sent %d notifications, want silence", by, len(sent))
+		}
+	}
+}

--- a/internal/store/migrations/0037_ride_request_cancelled_by.down.sql
+++ b/internal/store/migrations/0037_ride_request_cancelled_by.down.sql
@@ -1,1 +1,1 @@
-ALTER TABLE go_ride_requests DROP COLUMN cancelled_by;
+ALTER TABLE go_ride_requests DROP COLUMN IF EXISTS cancelled_by;

--- a/internal/store/migrations/0037_ride_request_cancelled_by.down.sql
+++ b/internal/store/migrations/0037_ride_request_cancelled_by.down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE go_ride_requests DROP COLUMN cancelled_by;

--- a/internal/store/migrations/0037_ride_request_cancelled_by.up.sql
+++ b/internal/store/migrations/0037_ride_request_cancelled_by.up.sql
@@ -1,0 +1,7 @@
+-- MYR-522: an owner may cancel an accepted/arrived ride. `cancelled_by`
+-- records WHICH PARTY initiated a cancellation ('rider' | 'owner') so the
+-- rider's client can render the honest "had to cancel" copy from a refetch
+-- rather than inferring it from "not my own tap". NULL on every row that is
+-- not cancelled, and on rows cancelled before this migration (consumers MUST
+-- treat absence as "initiator unknown", never guess).
+ALTER TABLE go_ride_requests ADD COLUMN cancelled_by text;

--- a/internal/store/migrations/0037_ride_request_cancelled_by.up.sql
+++ b/internal/store/migrations/0037_ride_request_cancelled_by.up.sql
@@ -4,4 +4,4 @@
 -- rather than inferring it from "not my own tap". NULL on every row that is
 -- not cancelled, and on rows cancelled before this migration (consumers MUST
 -- treat absence as "initiator unknown", never guess).
-ALTER TABLE go_ride_requests ADD COLUMN cancelled_by text;
+ALTER TABLE go_ride_requests ADD COLUMN IF NOT EXISTS cancelled_by text;

--- a/internal/store/ride_request_queries.go
+++ b/internal/store/ride_request_queries.go
@@ -54,7 +54,7 @@ const rideRequestColumns = `id, rider_id, owner_id, vehicle_id,
 	status, passenger_name, passenger_phone,
 	scheduled_for, reschedule_proposed_for, reschedule_status,
 	accepted_at, completed_at, created_at, updated_at,
-	dispatch_status, dispatched_at, dispatch_error` + requesterIdentitySelect
+	dispatch_status, dispatched_at, dispatch_error, cancelled_by` + requesterIdentitySelect
 
 const queryRideRequestInsert = `INSERT INTO go_ride_requests (
 	id, rider_id, owner_id, vehicle_id,

--- a/internal/store/ride_request_repo_guard_test.go
+++ b/internal/store/ride_request_repo_guard_test.go
@@ -737,3 +737,111 @@ func TestRideRequestRepo_UpdateStatusFrom_CancelVsDecline(t *testing.T) {
 		t.Errorf("final status %q does not match the winning transition %q", final.Status, wantStatus)
 	}
 }
+
+// MYR-522 — the INITIATOR-STAMPING cancel: the same guarded UPDATE also writes
+// cancelled_by, first writer wins, arbitrated by exactly the WHERE that decides
+// whether the cancel wins at all.
+func TestRideRequestRepo_UpdateStatusFromCancelled(t *testing.T) {
+	repo, _ := setupRideRequestRepo(t)
+	ctx := context.Background()
+
+	t.Run("owner cancel stamps cancelled_by=owner", func(t *testing.T) {
+		created, err := repo.Create(ctx, scheduledRideRequest())
+		if err != nil {
+			t.Fatalf("Create: %v", err)
+		}
+		if _, err := repo.UpdateStatusFrom(ctx, created.ID,
+			[]store.RideRequestStatus{store.RideRequestStatusRequested},
+			store.RideRequestStatusAccepted); err != nil {
+			t.Fatalf("accept: %v", err)
+		}
+		got, err := repo.UpdateStatusFromCancelled(ctx, created.ID,
+			[]store.RideRequestStatus{store.RideRequestStatusAccepted, store.RideRequestStatusArrived},
+			"owner")
+		if err != nil {
+			t.Fatalf("UpdateStatusFromCancelled: %v", err)
+		}
+		if got.Status != store.RideRequestStatusCancelled {
+			t.Errorf("status: %q", got.Status)
+		}
+		if got.CancelledBy == nil || *got.CancelledBy != "owner" {
+			t.Errorf("cancelled_by: %v", got.CancelledBy)
+		}
+		// The stamp survives a read, so a client refetch can say who.
+		read, err := repo.GetByID(ctx, created.ID)
+		if err != nil {
+			t.Fatalf("GetByID: %v", err)
+		}
+		if read.CancelledBy == nil || *read.CancelledBy != "owner" {
+			t.Errorf("cancelled_by after read: %v", read.CancelledBy)
+		}
+	})
+
+	t.Run("rider cancel stamps cancelled_by=rider", func(t *testing.T) {
+		created, err := repo.Create(ctx, scheduledRideRequest())
+		if err != nil {
+			t.Fatalf("Create: %v", err)
+		}
+		got, err := repo.UpdateStatusFromCancelled(ctx, created.ID,
+			[]store.RideRequestStatus{store.RideRequestStatusRequested, store.RideRequestStatusAccepted},
+			"rider")
+		if err != nil {
+			t.Fatalf("UpdateStatusFromCancelled: %v", err)
+		}
+		if got.CancelledBy == nil || *got.CancelledBy != "rider" {
+			t.Errorf("cancelled_by: %v", got.CancelledBy)
+		}
+	})
+
+	t.Run("guard refuses outside the allowed-from set and stamps nothing", func(t *testing.T) {
+		created, err := repo.Create(ctx, scheduledRideRequest())
+		if err != nil {
+			t.Fatalf("Create: %v", err)
+		}
+		// Owner's window excludes `requested` — the guarded write must refuse.
+		_, err = repo.UpdateStatusFromCancelled(ctx, created.ID,
+			[]store.RideRequestStatus{store.RideRequestStatusAccepted, store.RideRequestStatusArrived},
+			"owner")
+		if !errors.Is(err, store.ErrRideRequestConflict) {
+			t.Fatalf("expected ErrRideRequestConflict, got %v", err)
+		}
+		read, err := repo.GetByID(ctx, created.ID)
+		if err != nil {
+			t.Fatalf("GetByID: %v", err)
+		}
+		if read.CancelledBy != nil {
+			t.Errorf("a refused cancel must stamp nothing, got %v", read.CancelledBy)
+		}
+		if read.Status != store.RideRequestStatusRequested {
+			t.Errorf("status moved on a refusal: %q", read.Status)
+		}
+	})
+
+	t.Run("first writer wins the stamp", func(t *testing.T) {
+		created, err := repo.Create(ctx, scheduledRideRequest())
+		if err != nil {
+			t.Fatalf("Create: %v", err)
+		}
+		if _, err := repo.UpdateStatusFromCancelled(ctx, created.ID,
+			[]store.RideRequestStatus{store.RideRequestStatusRequested, store.RideRequestStatusAccepted},
+			"rider"); err != nil {
+			t.Fatalf("first cancel: %v", err)
+		}
+		// A second cancel loses on the status guard, so the stamp cannot move;
+		// the CASE arm is belt-and-braces for any future from-set that could
+		// re-enter the write.
+		_, err = repo.UpdateStatusFromCancelled(ctx, created.ID,
+			[]store.RideRequestStatus{store.RideRequestStatusAccepted, store.RideRequestStatusArrived},
+			"owner")
+		if !errors.Is(err, store.ErrRideRequestConflict) {
+			t.Fatalf("expected ErrRideRequestConflict, got %v", err)
+		}
+		read, err := repo.GetByID(ctx, created.ID)
+		if err != nil {
+			t.Fatalf("GetByID: %v", err)
+		}
+		if read.CancelledBy == nil || *read.CancelledBy != "rider" {
+			t.Errorf("stamp must stay the first writer's: %v", read.CancelledBy)
+		}
+	})
+}

--- a/internal/store/ride_request_scan.go
+++ b/internal/store/ride_request_scan.go
@@ -70,6 +70,7 @@ func (r *RideRequestRepo) scanRideRequest(row pgx.Row) (RideRequestRecord, error
 		&rec.ScheduledFor, &rec.RescheduleProposedFor, &reschedStatus,
 		&rec.AcceptedAt, &rec.CompletedAt, &rec.CreatedAt, &rec.UpdatedAt,
 		&dispatchStatus, &rec.DispatchedAt, &rec.DispatchError,
+		&rec.CancelledBy,
 		&requesterName, &requesterEmail, &requesterExists,
 	)
 	if err != nil {

--- a/internal/store/ride_request_status_queries.go
+++ b/internal/store/ride_request_status_queries.go
@@ -74,6 +74,20 @@ const queryRideRequestUpdateStatusFrom = rideRequestStatusStamp + `
 WHERE id = $1 AND status = ANY($3)
 RETURNING ` + rideRequestColumns
 
+// queryRideRequestUpdateStatusFromCancelled is the guarded transition PLUS the
+// MYR-522 initiator stamp: the SAME single-statement guard, with `cancelled_by`
+// written in the identical first-entry-only style the timestamp stamps use, so
+// a replayed or racing cancel can never overwrite who cancelled first. $4 is
+// the initiating party ('rider' | 'owner'); it backs BOTH cancel paths, which
+// is what keeps the two from drifting in how they stamp the row.
+const queryRideRequestUpdateStatusFromCancelled = rideRequestStatusStamp + `,
+	cancelled_by = CASE
+		WHEN cancelled_by IS NULL THEN $4
+		ELSE cancelled_by
+	END
+WHERE id = $1 AND status = ANY($3)
+RETURNING ` + rideRequestColumns
+
 // queryRideRequestUpdateStatusFromDispatched is the guarded transition PLUS the
 // MYR-376 reservation-dormancy predicate. It backs the owner pickup transition
 // (accepted → arrived) and nothing else.

--- a/internal/store/ride_request_status_update.go
+++ b/internal/store/ride_request_status_update.go
@@ -35,6 +35,23 @@ func (r *RideRequestRepo) UpdateStatusFrom(ctx context.Context, id string, from 
 	}, id, from, to)
 }
 
+// UpdateStatusFromCancelled is UpdateStatusFrom pointed at exactly one target
+// status — `cancelled` — plus the MYR-522 initiator stamp: the same guarded
+// single-statement UPDATE also writes `cancelled_by` (first writer wins, the
+// timestamp stamps' own style), so who cancelled is decided by the same
+// database arbitration that decides whether the cancel wins at all. `by` is
+// the initiating party ('rider' | 'owner'); the caller's allowed-from set is
+// what makes the two parties' different legality windows honest under
+// concurrency.
+func (r *RideRequestRepo) UpdateStatusFromCancelled(ctx context.Context, id string, from []RideRequestStatus, by string) (RideRequestRecord, error) {
+	return r.updateStatusGuarded(ctx, r.pool, statusGuard{
+		name:        "UpdateStatusFromCancelled",
+		op:          "ride_request.update_status_from_cancelled",
+		query:       queryRideRequestUpdateStatusFromCancelled,
+		cancelledBy: by,
+	}, id, from, RideRequestStatusCancelled)
+}
+
 // UpdateStatusFromDispatched is UpdateStatusFrom plus the MYR-376 RESERVATION
 // DORMANCY predicate, and it backs exactly one caller: the owner pickup
 // transition (accepted → arrived).
@@ -176,6 +193,10 @@ type statusGuard struct {
 	// reservation-dormancy predicate. It changes NOTHING about the write — only
 	// how a zero-row miss is explained to the caller.
 	dormancyGuarded bool
+	// cancelledBy, when non-empty, is bound as $4 for the MYR-522 cancel
+	// variant, whose SET also stamps the initiating party. Empty for every
+	// other guard, whose statements have no fourth placeholder.
+	cancelledBy string
 }
 
 // updateStatusGuarded runs one guarded transition statement on q and
@@ -191,8 +212,12 @@ func (r *RideRequestRepo) updateStatusGuarded(
 		fromStrs = append(fromStrs, string(s))
 	}
 
+	args := []any{id, string(to), fromStrs}
+	if g.cancelledBy != "" {
+		args = append(args, g.cancelledBy)
+	}
 	start := time.Now()
-	row := q.QueryRow(ctx, g.query, id, string(to), fromStrs)
+	row := q.QueryRow(ctx, g.query, args...)
 	rec, err := r.scanRideRequest(row)
 	r.metrics.ObserveQueryDuration(g.op, time.Since(start).Seconds())
 	if err == nil {

--- a/internal/store/ride_request_types.go
+++ b/internal/store/ride_request_types.go
@@ -117,4 +117,10 @@ type RideRequestRecord struct {
 	DispatchStatus *DispatchStatus
 	DispatchedAt   *time.Time
 	DispatchError  *string
+
+	// CancelledBy records which PARTY initiated a cancellation — 'rider' or
+	// 'owner' (MYR-522). Nil on every non-cancelled row, and on rows
+	// cancelled before migration 0037: absence means "initiator unknown",
+	// and consumers must not guess.
+	CancelledBy *string
 }

--- a/internal/telemetry/ride_request_handler.go
+++ b/internal/telemetry/ride_request_handler.go
@@ -94,9 +94,22 @@ func NewRideRequestHandler(
 	return h
 }
 
-// ServeCancel handles POST /api/ride-requests/{id}/cancel. Rider-only;
-// legal only from requested/accepted (→ cancelled). Every other current
-// status is a 409 conflict.
+// ServeCancel handles POST /api/ride-requests/{id}/cancel. PARTY-AWARE from
+// MYR-522 (client decision, 2026-08-12: "add ability for owner to cancel ride
+// from their end as well"):
+//
+//   - The RIDER may cancel from requested/accepted — unchanged since MYR-174.
+//   - The OWNER may cancel from accepted/arrived. A `requested` ride keeps the
+//     existing DECLINE as the owner's one exit (two owner verbs for one moment
+//     would be two copies of one decision), and once the rider is aboard
+//     (`enroute`) there is no owner cancel at all — ending early is what
+//     "Dropped off" already is.
+//
+// Both paths stamp WHO cancelled into the same guarded UPDATE that decides
+// whether the cancel wins (`cancelled_by`, first writer wins), and both
+// publish through the one shared transition path — so the WS frame, the
+// rider's push and the nav stand-down ride the same delivery every other
+// transition uses. Every other current status is a 409 conflict.
 func (h *RideRequestHandler) ServeCancel(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	userID, ok := h.authUser(w, r)
@@ -108,10 +121,13 @@ func (h *RideRequestHandler) ServeCancel(w http.ResponseWriter, r *http.Request)
 	if !ok {
 		return
 	}
+
+	// A self-ride caller (owner riding their own car) is BOTH parties and takes
+	// the rider path — their cancel is their own, exactly as before MYR-522.
 	if userID != rec.RiderID {
-		// The owner is a party but cancel is rider-only; non-parties were
-		// already 404'd by loadForParty.
-		h.writeError(w, http.StatusForbidden, wserrors.ErrCodePermissionDenied, "only the rider may cancel this request")
+		// The owner's cancel (MYR-522). Non-parties were already 404'd by
+		// loadForParty, so this caller is the owner.
+		h.serveOwnerCancel(ctx, w, rec)
 		return
 	}
 
@@ -122,16 +138,55 @@ func (h *RideRequestHandler) ServeCancel(w http.ResponseWriter, r *http.Request)
 		return
 	}
 
-	updated, ok := h.mutateStatus(ctx, w, rec, rideCancellableFrom, rideStatusCancelled)
+	updated, ok := h.mutateStatusCancelled(ctx, w, rec, rideCancellableFrom, rideCancelledByRider)
 	if !ok {
 		return
 	}
 	h.writeJSON(w, http.StatusOK, toRideRequestWire(updated))
 }
 
+// serveOwnerCancel is the owner's arm of ServeCancel (MYR-522). The two
+// refusals that are NOT plain status conflicts get sentences that name the
+// door the owner should use instead — a refusal the server can explain must
+// be explained (MYR-329's rule): a `requested` ride's exit is DECLINE, and a
+// ride with the rider aboard ends only through "Dropped off".
+func (h *RideRequestHandler) serveOwnerCancel(ctx context.Context, w http.ResponseWriter, rec RideRequestData) {
+	switch rec.Status {
+	case rideStatusRequested:
+		h.writeError(w, http.StatusConflict, wserrors.ErrCodeConflict, "decline a requested ride instead of cancelling it")
+		return
+	case rideStatusEnroute:
+		h.writeError(w, http.StatusConflict, wserrors.ErrCodeConflict, "the rider is aboard — end the ride with dropped-off")
+		return
+	}
+	if !ownerCancellableFrom(rec.Status) {
+		h.writeError(w, http.StatusConflict, wserrors.ErrCodeConflict, "ride request cannot be cancelled from status "+rec.Status)
+		return
+	}
+
+	updated, ok := h.mutateStatusCancelled(ctx, w, rec, rideOwnerCancellableFrom, rideCancelledByOwner)
+	if !ok {
+		return
+	}
+	h.writeJSON(w, http.StatusOK, toRideRequestWire(updated))
+}
+
+// The two cancelled_by stamps. Written once here and consumed by the push
+// notifier's copy fork; the wire projection carries them verbatim.
+const (
+	rideCancelledByRider = "rider"
+	rideCancelledByOwner = "owner"
+)
+
 // rideCancellableFrom is the allowed-from set for a rider cancel; must stay
 // in lockstep with cancellableFrom and the rest-api.md §7.8 matrix.
 var rideCancellableFrom = []string{rideStatusRequested, rideStatusAccepted}
+
+// rideOwnerCancellableFrom is the allowed-from set for an OWNER cancel
+// (MYR-522); must stay in lockstep with ownerCancellableFrom and the
+// rest-api.md §7.8 matrix. `requested` is deliberately absent (decline is
+// that moment's owner verb) and so is `enroute` (the rider is aboard).
+var rideOwnerCancellableFrom = []string{rideStatusAccepted, rideStatusArrived}
 
 // The guarded-transition helpers (mutateStatus and its dormancy-guarded
 // sibling) live in ride_request_status_mutation.go.
@@ -141,6 +196,13 @@ var rideCancellableFrom = []string{rideStatusRequested, rideStatusAccepted}
 // progress) and the terminal states (declined/completed/cancelled) are not.
 func cancellableFrom(status string) bool {
 	return status == rideStatusRequested || status == rideStatusAccepted
+}
+
+// ownerCancellableFrom reports whether an OWNER cancel is legal from the
+// given status (MYR-522). Legal only from accepted/arrived — before the rider
+// is aboard, after the request stopped being declinable.
+func ownerCancellableFrom(status string) bool {
+	return status == rideStatusAccepted || status == rideStatusArrived
 }
 
 // loadForParty fetches the ride by {id} and enforces party membership: a

--- a/internal/telemetry/ride_request_handler_test.go
+++ b/internal/telemetry/ride_request_handler_test.go
@@ -47,6 +47,7 @@ type fakeRideStore struct {
 	updatedState string
 	updatedFrom  []string
 	updateCalls  int
+	cancelledBy  string
 	// dispatchGuardedCalls counts the writes that went through the MYR-376
 	// DORMANCY-guarded variant, so a test can pin that the pickup path uses it
 	// (and that nothing else does).
@@ -199,6 +200,21 @@ func (f *fakeRideStore) UpdateStatusFrom(_ context.Context, id string, from []st
 		rec = f.getRec
 	}
 	rec.Status = to
+	return rec, nil
+}
+
+// UpdateStatusFromCancelled mimics the MYR-522 initiator-stamping cancel
+// write: the same guarded transition with to fixed to "cancelled", recording
+// the party stamp the way the single UPDATE writes cancelled_by. The returned
+// record carries the stamp so handler tests can assert the wire projection.
+func (f *fakeRideStore) UpdateStatusFromCancelled(ctx context.Context, id string, from []string, by string) (RideRequestData, error) {
+	f.cancelledBy = by
+	rec, err := f.UpdateStatusFrom(ctx, id, from, "cancelled")
+	if err != nil {
+		return RideRequestData{}, err
+	}
+	stamp := by
+	rec.CancelledBy = &stamp
 	return rec, nil
 }
 
@@ -668,7 +684,9 @@ func TestRideRequestHandler_Cancel(t *testing.T) {
 		{name: "conflict from completed", caller: rideUserID, rec: fixtureRideData(rideUserID, rideStatusCompleted), wantStatus: http.StatusConflict, wantErrCode: wserrors.ErrCodeConflict},
 		{name: "conflict from cancelled", caller: rideUserID, rec: fixtureRideData(rideUserID, rideStatusCancelled), wantStatus: http.StatusConflict, wantErrCode: wserrors.ErrCodeConflict},
 		{name: "conflict from enroute", caller: rideUserID, rec: fixtureRideData(rideUserID, rideStatusEnroute), wantStatus: http.StatusConflict, wantErrCode: wserrors.ErrCodeConflict},
-		{name: "owner cannot cancel (rider-only)", caller: rideOwnerID + "X", rec: fixtureRideData(rideOwnerID+"X", rideStatusRequested), wantStatus: http.StatusForbidden, wantErrCode: wserrors.ErrCodePermissionDenied},
+		// MYR-522: the owner's cancel exists now, but a REQUESTED ride keeps
+		// decline as the owner's one exit — a 409 naming that door, not a 403.
+		{name: "owner cancel of a requested ride points at decline", caller: rideOwnerID + "X", rec: fixtureRideData(rideOwnerID+"X", rideStatusRequested), wantStatus: http.StatusConflict, wantErrCode: wserrors.ErrCodeConflict},
 		{name: "non-party gets 404", caller: rideOtherUsr, rec: fixtureRideData(rideUserID, rideStatusRequested), wantStatus: http.StatusNotFound, wantErrCode: wserrors.ErrCodeNotFound},
 		{name: "unknown id 404", caller: rideUserID, getErr: fmtNotFound(), wantStatus: http.StatusNotFound, wantErrCode: wserrors.ErrCodeNotFound},
 	}

--- a/internal/telemetry/ride_request_owner_cancel_test.go
+++ b/internal/telemetry/ride_request_owner_cancel_test.go
@@ -1,0 +1,186 @@
+package telemetry
+
+import (
+	"encoding/json"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/myrobotaxi/telemetry/internal/events"
+	"github.com/myrobotaxi/telemetry/internal/wserrors"
+)
+
+// MYR-522 — the OWNER's cancel (client decision, 2026-08-12: "add ability for
+// owner to cancel ride from their end as well").
+//
+// The semantics under test, verbatim from the decision: an owner may cancel
+// any time BEFORE `enroute` — requested rides keep the existing DECLINE,
+// accepted/arrived gain cancel — and once the rider is aboard there is no
+// owner cancel at all, because ending early is what "Dropped off" already is.
+// Both cancel paths stamp WHO cancelled into the same guarded write, so the
+// push notifier (and, via the wire, the rider's client) can tell an owner's
+// cancel from the rider's own.
+
+// ownerCancelFixture returns a ride whose OWNER is a distinct account from the
+// rider, in the given status, with the handler authenticated as that owner.
+func ownerCancelFixture(status string) (RideRequestData, string) {
+	owner := rideOwnerID + "X"
+	return fixtureRideData(owner, status), owner
+}
+
+func TestRideRequestHandler_OwnerCancel(t *testing.T) {
+	tests := []struct {
+		name        string
+		status      string
+		wantStatus  int
+		wantMessage string // substring of the refusal, "" for success
+	}{
+		{name: "accepted cancels", status: rideStatusAccepted, wantStatus: http.StatusOK},
+		{name: "arrived cancels", status: rideStatusArrived, wantStatus: http.StatusOK},
+		// A requested ride's owner exit is DECLINE — the refusal names the door.
+		{name: "requested points at decline", status: rideStatusRequested, wantStatus: http.StatusConflict, wantMessage: "decline"},
+		// A rider aboard ends only through dropped-off — the refusal names it.
+		{name: "enroute points at dropped-off", status: rideStatusEnroute, wantStatus: http.StatusConflict, wantMessage: "dropped-off"},
+		{name: "completed conflicts", status: rideStatusCompleted, wantStatus: http.StatusConflict},
+		{name: "cancelled conflicts", status: rideStatusCancelled, wantStatus: http.StatusConflict},
+		{name: "declined conflicts", status: rideStatusDeclined, wantStatus: http.StatusConflict},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rec, owner := ownerCancelFixture(tt.status)
+			store := &fakeRideStore{getRec: rec}
+			pub := &fakeRidePublisher{}
+			h := newRideHandler(store, &stubVehicleSnapshotReader{row: availableSnapshotRow()}, pub, owner)
+
+			resp := doRequest(t, rideMux(h), http.MethodPost, "/api/ride-requests/"+rideID+"/cancel", "", rideAuthOK)
+
+			if resp.Code != tt.wantStatus {
+				t.Fatalf("status: got %d want %d. body=%s", resp.Code, tt.wantStatus, resp.Body.String())
+			}
+			if tt.wantStatus != http.StatusOK {
+				// assertErrEnvelope decodes (and drains) the body — read it first.
+				body := resp.Body.String()
+				assertErrEnvelope(t, resp, tt.wantStatus, wserrors.ErrCodeConflict)
+				if tt.wantMessage != "" && !strings.Contains(body, tt.wantMessage) {
+					t.Errorf("refusal should name %q, body=%s", tt.wantMessage, body)
+				}
+				if store.updateCalls != 0 {
+					t.Errorf("a pre-check refusal must not attempt the write, got %d calls", store.updateCalls)
+				}
+				if len(pub.events) != 0 {
+					t.Errorf("a refusal must publish nothing, got %d events", len(pub.events))
+				}
+				return
+			}
+
+			// The guarded write carries the OWNER's allowed-from set and stamp.
+			if store.cancelledBy != rideCancelledByOwner {
+				t.Errorf("cancelled_by stamp: got %q want %q", store.cancelledBy, rideCancelledByOwner)
+			}
+			if len(store.updatedFrom) != 2 || store.updatedFrom[0] != rideStatusAccepted || store.updatedFrom[1] != rideStatusArrived {
+				t.Errorf("owner allowed-from set: %v", store.updatedFrom)
+			}
+
+			// The wire carries the stamp so the rider's client can say who.
+			var got map[string]any
+			_ = json.Unmarshal(resp.Body.Bytes(), &got)
+			if got["status"] != rideStatusCancelled {
+				t.Errorf("body status: %v", got["status"])
+			}
+			if got["cancelledBy"] != rideCancelledByOwner {
+				t.Errorf("body cancelledBy: %v", got["cancelledBy"])
+			}
+
+			// One ride_status_changed through the shared delivery, carrying the
+			// initiator for the push notifier's copy fork.
+			if len(pub.events) != 1 {
+				t.Fatalf("expected 1 event, got %d", len(pub.events))
+			}
+			ev, ok := pub.events[0].Payload.(events.RideStatusChangedEvent)
+			if !ok {
+				t.Fatalf("expected RideStatusChangedEvent, got %T", pub.events[0].Payload)
+			}
+			if ev.CancelledBy == nil || *ev.CancelledBy != rideCancelledByOwner {
+				t.Errorf("event CancelledBy: %v", ev.CancelledBy)
+			}
+		})
+	}
+}
+
+// The RIDER's cancel is byte-for-byte what it was, plus the stamp: the write
+// carries "rider", the wire says so, and the event lets the notifier stay
+// silent about the rider's own action.
+func TestRideRequestHandler_RiderCancelStampsRider(t *testing.T) {
+	store := &fakeRideStore{getRec: fixtureRideData(rideOwnerID+"X", rideStatusAccepted)}
+	pub := &fakeRidePublisher{}
+	h := newRideHandler(store, &stubVehicleSnapshotReader{row: availableSnapshotRow()}, pub, rideUserID)
+
+	resp := doRequest(t, rideMux(h), http.MethodPost, "/api/ride-requests/"+rideID+"/cancel", "", rideAuthOK)
+
+	if resp.Code != http.StatusOK {
+		t.Fatalf("status: got %d. body=%s", resp.Code, resp.Body.String())
+	}
+	if store.cancelledBy != rideCancelledByRider {
+		t.Errorf("cancelled_by stamp: got %q want %q", store.cancelledBy, rideCancelledByRider)
+	}
+	if len(store.updatedFrom) != 2 || store.updatedFrom[0] != rideStatusRequested || store.updatedFrom[1] != rideStatusAccepted {
+		t.Errorf("rider allowed-from set unchanged: %v", store.updatedFrom)
+	}
+	var got map[string]any
+	_ = json.Unmarshal(resp.Body.Bytes(), &got)
+	if got["cancelledBy"] != rideCancelledByRider {
+		t.Errorf("body cancelledBy: %v", got["cancelledBy"])
+	}
+	ev := pub.events[0].Payload.(events.RideStatusChangedEvent)
+	if ev.CancelledBy == nil || *ev.CancelledBy != rideCancelledByRider {
+		t.Errorf("event CancelledBy: %v", ev.CancelledBy)
+	}
+}
+
+// A SELF-RIDE caller (owner riding their own car — this platform's common
+// case, MYR-325) is both parties and takes the RIDER path: their cancel is
+// their own, stamps "rider", and therefore wakes nobody's phone.
+func TestRideRequestHandler_SelfRideCancelTakesTheRiderPath(t *testing.T) {
+	// fixtureRideData's rider is rideUserID; rideOwnerID == rideUserID (the
+	// v1 self-ride constants), so this record is one account in both roles.
+	store := &fakeRideStore{getRec: fixtureRideData(rideOwnerID, rideStatusAccepted)}
+	pub := &fakeRidePublisher{}
+	h := newRideHandler(store, &stubVehicleSnapshotReader{row: availableSnapshotRow()}, pub, rideUserID)
+
+	resp := doRequest(t, rideMux(h), http.MethodPost, "/api/ride-requests/"+rideID+"/cancel", "", rideAuthOK)
+
+	if resp.Code != http.StatusOK {
+		t.Fatalf("status: got %d. body=%s", resp.Code, resp.Body.String())
+	}
+	if store.cancelledBy != rideCancelledByRider {
+		t.Errorf("self-ride must stamp rider, got %q", store.cancelledBy)
+	}
+	// The rider path also means the RIDER's legality window: a self-rider may
+	// still cancel a requested ride, exactly as before MYR-522.
+	if len(store.updatedFrom) != 2 || store.updatedFrom[0] != rideStatusRequested {
+		t.Errorf("self-ride allowed-from set: %v", store.updatedFrom)
+	}
+}
+
+// The owner's guarded write is what decides under concurrency: a pre-check
+// that read `accepted` loses to a rider boarding (`enroute`) at write time,
+// and the loser publishes nothing — the same race discipline every other
+// transition has (MYR-174/175).
+func TestRideRequestHandler_OwnerCancel_GuardWinsRace(t *testing.T) {
+	readRec, owner := ownerCancelFixture(rideStatusAccepted) // pre-check passes
+	writeRec, _ := ownerCancelFixture(rideStatusEnroute)     // guard sees the boarding
+	store := &fakeRideStore{getRec: readRec, updated: writeRec}
+	pub := &fakeRidePublisher{}
+	h := newRideHandler(store, &stubVehicleSnapshotReader{row: availableSnapshotRow()}, pub, owner)
+
+	resp := doRequest(t, rideMux(h), http.MethodPost, "/api/ride-requests/"+rideID+"/cancel", "", rideAuthOK)
+
+	assertErrEnvelope(t, resp, http.StatusConflict, wserrors.ErrCodeConflict)
+	if store.updateCalls != 1 {
+		t.Errorf("expected exactly one guarded write attempt, got %d", store.updateCalls)
+	}
+	if len(pub.events) != 0 {
+		t.Errorf("losing transition must publish no events, got %d", len(pub.events))
+	}
+}

--- a/internal/telemetry/ride_request_owner_decline_test.go
+++ b/internal/telemetry/ride_request_owner_decline_test.go
@@ -271,6 +271,19 @@ func newRacingDeclineStore(rec RideRequestData) *racingDeclineStore {
 	return &racingDeclineStore{rec: rec}
 }
 
+// UpdateStatusFromCancelled reuses the same compare-and-set arbitration with
+// the target fixed to "cancelled" (MYR-522); the stamp is carried onto the
+// winning row exactly as the single UPDATE writes cancelled_by.
+func (s *racingDeclineStore) UpdateStatusFromCancelled(ctx context.Context, id string, from []string, by string) (RideRequestData, error) {
+	rec, err := s.UpdateStatusFrom(ctx, id, from, "cancelled")
+	if err != nil {
+		return RideRequestData{}, err
+	}
+	stamp := by
+	rec.CancelledBy = &stamp
+	return rec, nil
+}
+
 func (s *racingDeclineStore) GetByID(context.Context, string) (RideRequestData, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()

--- a/internal/telemetry/ride_request_status_mutation.go
+++ b/internal/telemetry/ride_request_status_mutation.go
@@ -38,6 +38,19 @@ func (h *RideRequestHandler) mutateStatus(ctx context.Context, w http.ResponseWr
 	return h.mutateStatusWith(ctx, w, rec, from, to, h.store.UpdateStatusFrom)
 }
 
+// mutateStatusCancelled is mutateStatus over the store's INITIATOR-STAMPING
+// cancel write (MYR-522): the same guarded UPDATE, with `cancelled_by` written
+// first-writer-wins in the same statement. It backs BOTH cancel paths — the
+// rider's and the owner's — which differ only in their allowed-from set and in
+// the party they stamp, so neither can drift in how a cancel is persisted or
+// published.
+func (h *RideRequestHandler) mutateStatusCancelled(ctx context.Context, w http.ResponseWriter, rec RideRequestData, from []string, by string) (RideRequestData, bool) {
+	return h.mutateStatusWith(ctx, w, rec, from, rideStatusCancelled,
+		func(ctx context.Context, id string, from []string, _ string) (RideRequestData, error) {
+			return h.store.UpdateStatusFromCancelled(ctx, id, from, by)
+		})
+}
+
 // mutateStatusDispatched is mutateStatus over the store's DORMANCY-GUARDED
 // write (MYR-376), and it backs exactly one caller: the owner pickup
 // transition (accepted → arrived).
@@ -100,7 +113,11 @@ func (h *RideRequestHandler) mutateStatusWith(
 		// Carried so the rider's push copy can tell a reservation from an
 		// instant request (MYR-360); not projected onto the WS frame.
 		ScheduledFor: updated.ScheduledFor,
-		UpdatedAt:    updated.UpdatedAt,
+		// Nil on every transition but a cancel — read off the UPDATED row, so
+		// the initiator the push notifier sees is the one the guarded write
+		// stamped (MYR-522).
+		CancelledBy: updated.CancelledBy,
+		UpdatedAt:   updated.UpdatedAt,
 	})
 
 	return updated, true

--- a/internal/telemetry/ride_request_types.go
+++ b/internal/telemetry/ride_request_types.go
@@ -80,6 +80,14 @@ type RideRequestData struct {
 	// sweeper leaves the ride's own status at `accepted`, so nothing else on
 	// this record distinguishes an expired reservation from a live one.
 	DispatchError *string
+
+	// CancelledBy names the PARTY that initiated a cancellation — "rider" or
+	// "owner" (MYR-522). Nil on every non-cancelled ride, and on rides
+	// cancelled before the field existed: absence means "initiator unknown"
+	// and a consumer must not guess. Surfaced on the party-only detail
+	// payload so the rider's client can render the honest "had to cancel"
+	// copy from a refetch rather than inferring it from "not my own tap".
+	CancelledBy *string
 }
 
 // BookedWindowData is one interval in which a vehicle cannot take a new
@@ -219,6 +227,13 @@ type RideRequestStore interface {
 	// ErrRideStatusConflict (row exists, status outside `from`) or an
 	// sdk.ErrNotFound-wrapping error (row gone).
 	UpdateStatusFrom(ctx context.Context, id string, from []string, to string) (RideRequestData, error)
+	// UpdateStatusFromCancelled is UpdateStatusFrom pointed at exactly one
+	// target status — `cancelled` — whose guarded UPDATE also stamps the
+	// initiating party (`by`: "rider" | "owner") into cancelled_by, first
+	// writer wins (MYR-522). It backs BOTH cancel paths; the caller's
+	// allowed-from set is what expresses each party's different legality
+	// window. Miss outcomes are UpdateStatusFrom's.
+	UpdateStatusFromCancelled(ctx context.Context, id string, from []string, by string) (RideRequestData, error)
 	// UpdateStatusFromDispatched is UpdateStatusFrom plus the MYR-376
 	// RESERVATION DORMANCY precondition, carried in the SAME guarded UPDATE:
 	// the row must also satisfy `scheduled_for IS NULL OR dispatch_status =

--- a/internal/telemetry/ride_request_wire.go
+++ b/internal/telemetry/ride_request_wire.go
@@ -33,6 +33,7 @@ func toRideRequestWire(d RideRequestData) rideRequestWire {
 		UpdatedAt:             d.UpdatedAt.UTC().Format(time.RFC3339),
 		DispatchStatus:        d.DispatchStatus,
 		DispatchedAt:          formatRideTimePtr(d.DispatchedAt),
+		CancelledBy:           d.CancelledBy,
 	}
 }
 

--- a/internal/telemetry/ride_request_wire_types.go
+++ b/internal/telemetry/ride_request_wire_types.go
@@ -43,6 +43,11 @@ type rideRequestWire struct {
 	// nav-dispatch push resolves (ride-request.schema.json $defs.RideRequest).
 	DispatchStatus *string `json:"dispatchStatus,omitempty"`
 	DispatchedAt   *string `json:"dispatchedAt,omitempty"`
+	// CancelledBy names the party that initiated a cancellation — "rider" |
+	// "owner" (MYR-522). Optional, additive; omitted on every non-cancelled
+	// ride and on rides cancelled before the field existed (absence =
+	// initiator unknown, consumers must not guess).
+	CancelledBy *string `json:"cancelledBy,omitempty"`
 }
 
 // rideActiveErrorResponse is the 409 `ride_active` body (MYR-230). It carries


### PR DESCRIPTION
## Client decision (2026-08-12)

*"add ability for owner to cancel ride from their end as well"* — approved with these semantics: an owner may cancel any time **before `enroute`** (`requested` keeps DECLINE as the owner's verb; `accepted`/`arrived` gain cancel); once the rider is aboard there is no owner cancel — ending early is what "Dropped off" already is. The rider whose ride is cancelled gets a push, and their surfaces converge through the existing cancellation-erasure fold.

## What this does

- **Party-aware `POST /api/ride-requests/{id}/cancel`.** Rider path byte-identical (requested/accepted). Owner path: accepted/arrived → cancelled; `requested` → 409 naming **decline**; `enroute` → 409 naming **dropped-off** (a refusal the server can explain must be explained — MYR-329's rule). Self-ride callers take the rider path. The pre-MYR-522 blanket 403 is retired.
- **`cancelled_by` is stamped inside the same guarded UPDATE that decides the race** (migration 0037; `UpdateStatusFromCancelled`, first writer wins in the timestamp stamps' own CASE style). Who cancelled is arbitrated by exactly the WHERE that decides whether the cancel wins.
- **The wire carries it** — optional `cancelledBy` (`"rider" | "owner"`) on the party-only `RideRequest` payload (contracts **v0.32.0**, myrobotaxi/contracts#39), so the rider's client can render the honest "had to cancel" copy from a refetch. Absence on a cancelled row = initiator unknown (pre-0.32.0 write) — consumers must not guess. **Not** projected onto the WS frame (summary-only, the MYR-360 precedent).
- **The rider push**: `{vehicle nickname} had to cancel your ride` / scheduled: `… your scheduled ride` (no time rendered — the standing rule), body `Try booking another car.` — declined's grammar, because it is the same news one status later. The rider's own cancel and any unstamped legacy event stay **silent**, so every pre-MYR-522 publisher behaves exactly as before. Payload policy holds: the owner's *name* never travels on a lock-screen surface; the vehicle nickname is the only interpolation.
- **Everything else rides the shared transition path** — one `ride_status_changed` through `mutateStatusWith`, so the WS unicast, the poller-lifecycle nav stand-down and the Live Activity terminal handling are the same delivery every other transition uses. No new event topic.
- **Docs**: rest-api.md §7.8 endpoint table, authorization model, transition matrix (`accepted`/`arrived` rows), error map, and the push-copy table.

## Tests

- Handler: owner matrix (both named refusals assert the door **and** that a pre-check refusal writes nothing and publishes nothing), owner allowed-from set + stamp + wire `cancelledBy` + event `CancelledBy`, rider stamp with the unchanged rider window, self-ride takes the rider path, and the owner guarded-write race (pre-check reads `accepted`, write sees `enroute`) losing cleanly with zero events.
- Store (docker suite, runs in CI): stamp for both parties, stamp survives a re-read, a refused cancel stamps nothing and moves nothing, first-writer-wins.
- Push: owner-cancel fans out to the **rider** device with the exact copy; scheduled variant + forbidden-time sweep; rider/unstamped cancels stay silent.
- Existing cancel tables updated where MYR-522 changes the answer (the owner-cancel-403 row is now the 409-naming-decline row).

`golangci-lint run`: 0 issues. `go test ./...` green except the docker-backed suites (no local daemon; CI runs them).

## Sequencing

contracts#39 (v0.32.0) should merge + tag first; this PR's wire field is additive either way. iOS half (Cancel affordance on the owner dispatch card + confirm dialog + the rider's in-app copy) follows once both land.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CQfByoasgKg3NzugNvy9WX