### PR TITLE
MYR-473 Clamp FSD miles to the driven distance — a drive cannot be more than 100% autonomous

### DIFF
--- a/internal/drives/detector_test.go
+++ b/internal/drives/detector_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"math"
 	"sync"
 	"testing"
 	"time"
@@ -619,10 +620,17 @@ func TestDetector_StatsAccuracy(t *testing.T) {
 		t.Errorf("EnergyDelta: got %f, want %f", stats.EnergyDelta, expectedEnergy)
 	}
 
-	// Verify FSD miles.
-	expectedFSD := 110.0 - 100.0
-	if stats.FSDMiles != expectedFSD {
-		t.Errorf("FSDMiles: got %f, want %f", stats.FSDMiles, expectedFSD)
+	// Verify FSD miles. The counter delta is 10.0 (110 − 100), but this
+	// fixture has no odometer baseline, so distance is the GPS haversine sum
+	// (~9.0 mi) — and MYR-473 clamps FSD miles to the driven distance, because
+	// a drive cannot be MORE than 100% autonomous. The pre-473 expectation
+	// (10.0 FSD mi on a ~9.0 mi drive) was exactly the inconsistent triple the
+	// field report photographed.
+	if stats.FSDMiles != stats.Distance {
+		t.Errorf("FSDMiles: got %f, want clamped to the driven distance %f", stats.FSDMiles, stats.Distance)
+	}
+	if stats.FSDPercentage != 100.0 {
+		t.Errorf("FSDPercentage: got %f, want exactly 100 with the operand clamped", stats.FSDPercentage)
 	}
 
 	// Verify route points were collected.
@@ -1719,5 +1727,89 @@ func TestCalculateStats_FSDPercentageFromOdometer(t *testing.T) {
 	}
 	if stats.FSDPercentage != 50.0 {
 		t.Errorf("FSDPercentage: got %f, want 50", stats.FSDPercentage)
+	}
+}
+
+// TestCalculateStats_FSDMilesClampedToDrivenDistance pins MYR-473: FSD miles
+// are a subset of driven miles BY DEFINITION, so the mileage is clamped to the
+// distance — not only the percentage, which is how the field frame "100% ·
+// 5.0 mi autonomous on a 4.6 mi drive" shipped: MYR-157's ratio clamp hid the
+// inconsistency in the one place it was applied while the operand printed
+// free. The two counters sample on independent cadences, so the FSD delta can
+// legitimately measure a few tenths past the odometer delta at the
+// boundaries; the honest report is the smaller number, and the triple
+// (distance, FSD miles, percentage) is then consistent by construction.
+func TestCalculateStats_FSDMilesClampedToDrivenDistance(t *testing.T) {
+	start := time.Date(2026, 8, 8, 1, 35, 0, 0, time.UTC)
+	drive := &activeDrive{
+		startedAt:           start,
+		lastTimestamp:       start.Add(15 * time.Minute),
+		odometerBaselineSet: true,
+		startOdometer:       12000.0,
+		lastOdometer:        12004.6,
+		fsdBaselineSet:      true,
+		startFSDMiles:       500.0,
+		lastFSDMiles:        505.0, // 5.0 measured — 0.4 past the odometer delta
+	}
+
+	stats := calculateStats(drive)
+
+	if math.Abs(stats.Distance-4.6) > 1e-9 {
+		t.Fatalf("Distance: got %f, want 4.6", stats.Distance)
+	}
+	if math.Abs(stats.FSDMiles-4.6) > 1e-9 {
+		t.Errorf("FSDMiles: got %f, want 4.6 (clamped to the driven distance)", stats.FSDMiles)
+	}
+	if math.Abs(stats.FSDPercentage-100.0) > 1e-9 {
+		t.Errorf("FSDPercentage: got %f, want exactly 100 with the operand clamped", stats.FSDPercentage)
+	}
+}
+
+// TestCalculateStats_FSDMilesZeroWhenNoDistanceMeasured — the same rule at
+// zero: a drive with no measured distance may claim no autonomous distance
+// either. Before MYR-473 this printed "0.0 mi total, 5.0 mi FSD".
+func TestCalculateStats_FSDMilesZeroWhenNoDistanceMeasured(t *testing.T) {
+	start := time.Date(2026, 8, 8, 1, 35, 0, 0, time.UTC)
+	drive := &activeDrive{
+		startedAt:      start,
+		lastTimestamp:  start.Add(5 * time.Minute),
+		fsdBaselineSet: true,
+		startFSDMiles:  500.0,
+		lastFSDMiles:   505.0,
+	}
+
+	stats := calculateStats(drive)
+
+	if stats.FSDMiles != 0 {
+		t.Errorf("FSDMiles: got %f, want 0 on a drive with no measured distance", stats.FSDMiles)
+	}
+	if stats.FSDPercentage != 0 {
+		t.Errorf("FSDPercentage: got %f, want 0", stats.FSDPercentage)
+	}
+}
+
+// TestCalculateStats_FSDMilesWithinDistanceUntouched — the negative that keeps
+// the clamp a clamp: an ordinary measurement inside the driven distance is
+// reported exactly as measured.
+func TestCalculateStats_FSDMilesWithinDistanceUntouched(t *testing.T) {
+	start := time.Date(2026, 8, 8, 1, 35, 0, 0, time.UTC)
+	drive := &activeDrive{
+		startedAt:           start,
+		lastTimestamp:       start.Add(15 * time.Minute),
+		odometerBaselineSet: true,
+		startOdometer:       12000.0,
+		lastOdometer:        12004.6,
+		fsdBaselineSet:      true,
+		startFSDMiles:       500.0,
+		lastFSDMiles:        503.0,
+	}
+
+	stats := calculateStats(drive)
+
+	if math.Abs(stats.FSDMiles-3.0) > 1e-9 {
+		t.Errorf("FSDMiles: got %f, want 3.0 untouched", stats.FSDMiles)
+	}
+	if math.Abs(stats.FSDPercentage-(3.0/4.6*100.0)) > 1e-9 {
+		t.Errorf("FSDPercentage: got %f, want %f", stats.FSDPercentage, 3.0/4.6*100.0)
 	}
 }

--- a/internal/drives/stats.go
+++ b/internal/drives/stats.go
@@ -123,10 +123,26 @@ func calculateStats(drive *activeDrive) events.DriveStats {
 		}
 	}
 
-	// FSD share, clamped to [0,100]. FSD miles ⊆ total odometer miles, so a
-	// correct measurement is always ≤100%; the clamp guards against residual
-	// counter/sampling skew that previously produced >100% (e.g. 176%) when
-	// FSD (odometer-accurate) was divided by the undercounting GPS distance.
+	// MYR-473 — FSD miles ⊆ driven miles BY DEFINITION, so the clamp belongs
+	// on the OPERAND, not only on the ratio. MYR-157 clamped the percentage
+	// and left the mileage free, which is exactly the frame a tester filed:
+	// "FULL SELF-DRIVING 100% · 5.0 mi · Driven autonomously" on a 4.6 mi
+	// drive — three numbers that cannot all be true, with the clamp hiding the
+	// inconsistency in the one place it was applied. The two counters sample
+	// on independent cadences (FieldFSDMiles and the odometer are separate
+	// emissions, ~15s apart at the boundary — the same skew
+	// TestDetector_FSDMilesAcrossCadenceMismatch documents), so the FSD delta
+	// can legitimately measure a few tenths past the odometer delta; the
+	// honest report is the smaller of the two. A drive with NO measured
+	// distance may claim no FSD distance either — the same reasoning at zero.
+	if fsdMiles > distance {
+		fsdMiles = distance
+	}
+
+	// FSD share, clamped to [0,100]. With the operand clamped above the ratio
+	// cannot exceed 100 any more; the clamp stays as defence in depth (it is
+	// one comparison, and the invariant it states is the display's whole
+	// contract).
 	var fsdPercentage float64
 	if distance > 0 && fsdMiles > 0 {
 		fsdPercentage = (fsdMiles / distance) * 100.0


### PR DESCRIPTION
Closes MYR-473. External beta: *"How 5 miles FSD when overall drive was 4.6 miles"* — the drive detail read **DISTANCE 4.6 mi** with **FULL SELF-DRIVING 100% ring, "5.0 mi", "Driven autonomously"**.

## Cause — the issue's own analysis, confirmed in `calculateStats`

MYR-157 clamped the FSD **percentage** to ≤100 and left the FSD **mileage** unclamped. The two operands come from different counters on independent sampling cadences (`FieldFSDMiles` vs the odometer — the same boundary skew `TestDetector_FSDMilesAcrossCadenceMismatch` documents), so the FSD delta can measure a few tenths past the odometer delta — and the ratio clamp then *hid* the inconsistency in the one place it was applied while the raw mileage printed free.

## Fix

FSD miles ⊆ driven miles **by definition**, so the clamp moves to the operand: `fsdMiles = min(fsdMiles, distance)`, including the zero arm (a drive with no measured distance claims no autonomous distance). The percentage clamp stays as defence in depth; with the operand clamped the triple (distance, FSD miles, %) is consistent by construction, and "100%" now only ever appears with FSD miles equal to the driven distance.

## Tests

- Three new pins: the client's own numbers (5.0 measured on 4.6 driven → 4.6 / 100%), the zero arm, and the negative (3.0 on 4.6 → untouched, 65.2%).
- `TestDetector_StatsAccuracy` updated deliberately: its fixture asserted 10.0 FSD mi on a ~9.0 mi GPS drive — exactly the inconsistent triple this issue outlaws — and now asserts the clamp.
- `internal/...` green (Docker-dependent store/identity suites run in CI), `golangci-lint` 0 issues. No contract change: §7.2's fields are unchanged; only their arithmetic relationship is now enforced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)